### PR TITLE
Cookie base Id implementation bug fixed

### DIFF
--- a/interfaces/console/package.json
+++ b/interfaces/console/package.json
@@ -25,7 +25,6 @@
     "luxon": "^2.3.0",
     "react": "^17.0.2",
     "react-apexcharts": "1.3.9",
-    "react-cookie": "^4.1.1",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.12.0",
     "react-imask": "^6.4.2",

--- a/interfaces/console/src/App.tsx
+++ b/interfaces/console/src/App.tsx
@@ -17,7 +17,6 @@ import { BrowserRouter } from "react-router-dom";
 import { ThemeProvider } from "@mui/material/styles";
 import { Alert, AlertColor, CssBaseline, Snackbar } from "@mui/material";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
-import { useCookies } from "react-cookie";
 
 const SNACKBAR_TIMEOUT = 5000;
 
@@ -25,7 +24,6 @@ const App = () => {
     const { response } = useWhoami();
     const setPage = useSetRecoilState(pageName);
     const _isDarkMod = useRecoilValue(isDarkmode);
-    const [, setCookie] = useCookies(["orgId"]);
     const [_snackbarMessage, setSnackbarMessage] =
         useRecoilState(snackbarMessage);
     const setSkeltonLoading = useSetRecoilState(isSkeltonLoading);
@@ -40,7 +38,6 @@ const App = () => {
                     handleGoToLogin();
                 }
             } else if (response?.isValid) {
-                setCookie("orgId", response?.id);
                 setPage(getTitleFromPath(window.location.pathname));
                 setSkeltonLoading(false);
             }

--- a/interfaces/console/src/layout/Header/index.tsx
+++ b/interfaces/console/src/layout/Header/index.tsx
@@ -27,7 +27,6 @@ import ExitToAppOutlined from "@mui/icons-material/ExitToAppOutlined";
 import { Settings, Notifications, AccountCircle } from "@mui/icons-material";
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from "recoil";
 import { isSkeltonLoading, user, pageName } from "../../recoil";
-import { useCookies } from "react-cookie";
 
 const popupStyle = {
     boxShadow:
@@ -54,7 +53,6 @@ const Header = ({
     const _user = useRecoilValue(user);
     const resetPageName = useResetRecoilState(pageName);
     const resetData = useResetRecoilState(user);
-    const [, , removeCookie] = useCookies(["orgId"]);
     const setSkeltonLoading = useSetRecoilState(isSkeltonLoading);
 
     const [notificationAnchorEl, setNotificationAnchorEl] =
@@ -117,7 +115,6 @@ const Header = ({
     }, [alertsInfoRes]);
 
     const handleLogout = () => {
-        removeCookie("orgId");
         handleUserClose();
         resetData();
         resetPageName();

--- a/interfaces/console/yarn.lock
+++ b/interfaces/console/yarn.lock
@@ -2390,11 +2390,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookie@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
-  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
-
 "@types/enzyme-adapter-react-16@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.6.tgz#8aca7ae2fd6c7137d869b6616e696d21bb8b0cec"
@@ -2447,14 +2442,6 @@
   version "4.7.11"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
-
-"@types/hoist-non-react-statics@^3.0.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
-  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
 
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.2"
@@ -4787,7 +4774,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.2, cookie@^0.4.0:
+cookie@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
@@ -7276,7 +7263,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -11679,15 +11666,6 @@ react-composer@^5.0.2:
   dependencies:
     prop-types "^15.6.0"
 
-react-cookie@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-4.1.1.tgz#832e134ad720e0de3e03deaceaab179c4061a19d"
-  integrity sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==
-  dependencies:
-    "@types/hoist-non-react-statics" "^3.0.1"
-    hoist-non-react-statics "^3.0.0"
-    universal-cookie "^4.0.0"
-
 react-dev-utils@^11.0.3:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-11.0.4.tgz#a7ccb60257a1ca2e0efe7a83e38e6700d17aa37a"
@@ -14039,14 +14017,6 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
-
-universal-cookie@^4.0.0:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
-  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
-  dependencies:
-    "@types/cookie" "^0.3.3"
-    cookie "^0.4.0"
 
 universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"

--- a/services/bff/src/common/index.ts
+++ b/services/bff/src/common/index.ts
@@ -33,5 +33,5 @@ export const parseCookie = (ctx: Context): ParsedCookie => {
             Cookie: `ukama_session=${cookieObj["ukama_session"]}`,
         };
     }
-    return { header: header, orgId: cookieObj["orgId"] };
+    return { header: header, orgId: cookieObj["id"] };
 };

--- a/services/bff/src/index.ts
+++ b/services/bff/src/index.ts
@@ -24,7 +24,10 @@ const initializeApp = async () => {
     });
 
     const corsOptions = {
-        origin: process.env.DASHBOARD_APP_URL,
+        origin: [
+            process.env.DASHBOARD_APP_URL || "",
+            process.env.AUTH_APP_URL || "",
+        ],
         credentials: true,
     };
     app.use(cors(corsOptions));
@@ -58,6 +61,28 @@ const initializeApp = async () => {
 
     app.get("/ping", (req, res) => {
         res.send("pong");
+    });
+
+    app.get("/getCookie", (req, res) => {
+        if (hasSession(req.headers.cookie || "")) {
+            const { expiry = "", id = "" } = req.query;
+            if (expiry && id) {
+                const date = new Date(expiry as string);
+                res.cookie("id", id, {
+                    path: "/",
+                    secure: true,
+                    expires: date,
+                    httpOnly: true,
+                    sameSite: "lax",
+                    domain:
+                        process.env.NODE_ENV === "development"
+                            ? "localhost"
+                            : ".dev.ukama.com",
+                });
+                res.send({ success: true });
+            }
+        }
+        res.send({ success: false });
     });
 
     mockServer(app);


### PR DESCRIPTION
## Fixes
**BFF**
Expose `getCookie` endpoint, which take `id` and `expiry` as params and set secure cookie in response.

**Console**
Removed old set/remove cookie implementation