### PR TITLE
Regex support for key's value for matching pattern. #17

### DIFF
--- a/transport/router/src/pattern.c
+++ b/transport/router/src/pattern.c
@@ -16,6 +16,7 @@
 #include <curl/easy.h>
 #include <string.h>
 #include <strings.h>
+#include <regex.h>
 
 #include "router.h"
 #include "log.h"
@@ -27,11 +28,22 @@
 static int match_all_key_value(Pattern *pattern, char *key, char *value) {
 
   Pattern *ptr=NULL;
+  int ret;
+  regex_t re;
 
   for(ptr=pattern; ptr; ptr=ptr->next) {
-    if (strcasecmp(ptr->key, key) == 0 &&
-	strcasecmp(ptr->value, value) == 0) {
-      return TRUE;
+
+    if (strcasecmp(ptr->key, key) == 0) {
+      if ((ret=regcomp(&re, value, REG_EXTENDED | REG_NOSUB)) != 0) {
+	return FALSE;
+      }
+
+      if (regexec(&re, ptr->value, 0, NULL, 0) == 0) {
+	regfree(&re);
+	return TRUE;
+      }
+
+      regfree(&re);
     }
   }
 


### PR DESCRIPTION
#17 

Run mock_service:
`./mock_service test 127.0.0.1 4444 4446 "Hello" "{ \"key3\" : \"value.\", \"path\" : \"/service\"} "
`
Value is regex as "value.", the "." would matching with any char

**As client:**

```
kashif@chogori:~$ curl -X POST "localhost:4444/service?key3=value"
Service Unavailable
kashif@chogori:~$ curl -X POST "localhost:4444/service?key3=value22"
POST: Hello
kashif@chogori:~$ curl -X POST "localhost:4444/service?key3=value222222"
POST: Hello
kashif@chogori:~$ curl -X POST "localhost:4444/service?key3=value2"
POST: Hello
kashif@chogori:~$ curl -X POST "localhost:4444/service?key3=values"
POST: Hello

```