### PR TITLE
Rollback to golintci

### DIFF
--- a/.github/workflows/services-bootstrap-lookup.yaml
+++ b/.github/workflows/services-bootstrap-lookup.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -110,25 +110,19 @@ jobs:
     env: 
       working-directory: services/bootstrap/lookup
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
 
   release:

--- a/.github/workflows/services-cloud-api-gateway.yaml
+++ b/.github/workflows/services-cloud-api-gateway.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -110,25 +110,19 @@ jobs:
     env: 
       working-directory: services/cloud/api-gateway
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
 
   release:

--- a/.github/workflows/services-cloud-device-feeder.yaml
+++ b/.github/workflows/services-cloud-device-feeder.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -110,25 +110,19 @@ jobs:
     env: 
       working-directory: services/cloud/device-feeder
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
 
   release:

--- a/.github/workflows/services-cloud-device-gateway.yaml
+++ b/.github/workflows/services-cloud-device-gateway.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -110,25 +110,19 @@ jobs:
     env: 
       working-directory: services/cloud/device-gateway
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
 
   release:

--- a/.github/workflows/services-cloud-dummy-sim-manager.yaml
+++ b/.github/workflows/services-cloud-dummy-sim-manager.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -91,25 +91,19 @@ jobs:
     env: 
       working-directory: services/cloud/dummy-sim-manager
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
 
   release:

--- a/.github/workflows/services-cloud-hss.yaml
+++ b/.github/workflows/services-cloud-hss.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -110,25 +110,19 @@ jobs:
     env: 
       working-directory: services/cloud/hss
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
 
   release:

--- a/.github/workflows/services-cloud-net.yaml
+++ b/.github/workflows/services-cloud-net.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -122,25 +122,19 @@ jobs:
     env: 
       working-directory: services/cloud/net
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
 
   release:

--- a/.github/workflows/services-cloud-registry.yaml
+++ b/.github/workflows/services-cloud-registry.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -122,25 +122,20 @@ jobs:
     env: 
       working-directory: services/cloud/registry
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
 
   release:
       name: release

--- a/.github/workflows/services-cloud-users.yaml
+++ b/.github/workflows/services-cloud-users.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -110,25 +110,19 @@ jobs:
     env: 
       working-directory: services/cloud/users
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
 
   release:

--- a/.github/workflows/services-hub-distributor.yaml
+++ b/.github/workflows/services-hub-distributor.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -110,25 +110,20 @@ jobs:
     env: 
       working-directory: services/hub/distributor
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
 
   release:
       name: release

--- a/.github/workflows/services-hub-hub.yaml
+++ b/.github/workflows/services-hub-hub.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
     - name: Login to Amazon ECR
       run: | 
@@ -123,6 +123,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.1.0
         with:                
           working-directory: ${{ env.working-directory }}
+
 
   release:
       name: release

--- a/.github/workflows/workflow-template.yaml.templ
+++ b/.github/workflows/workflow-template.yaml.templ
@@ -107,25 +107,19 @@ jobs:
     env: 
       working-directory: {{SERVICE}}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
-    
-    - name: Granting private modules access
-      run: |
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+
+      - name: Granting private modules access
+        run: |
             git config --global url."https://none:${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}@github.com/ukama".insteadOf "https://github.com/ukama"     
 
-    - name: install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-    - name: run static check
-      run: staticcheck ./...
-      working-directory: ${{ env.working-directory }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.1.0
+        with:                
+          working-directory: ${{ env.working-directory }}
 
 
   release:


### PR DESCRIPTION
Fixes #44 

Update lint step in GH Workflows to use the recent version of [golintci](https://golangci-lint.run/)