### PR TITLE
Fixes related to rabbitmq.NewConsumer interface change

### DIFF
--- a/services/cloud/device-feeder/pkg/listener.go
+++ b/services/cloud/device-feeder/pkg/listener.go
@@ -43,7 +43,7 @@ type DevicesUpdateRequest struct {
 }
 
 func NewQueueListener(queueUri string, serviceId string, requestMult RequestMultiplier, requestExec RequestExecutor, conf ListenerConfig) (*QueueListener, error) {
-	consumer, err := rabbitmq.NewConsumer(queueUri, amqp.Config{},
+	consumer, err := rabbitmq.NewConsumer(queueUri, rabbitmq.Config{},
 		rabbitmq.WithConsumerOptionsLogger(log.WithField("service", "rabbitmq")))
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating queue consumer")

--- a/services/cloud/device-feeder/pkg/multipl/queue_pub.go
+++ b/services/cloud/device-feeder/pkg/multipl/queue_pub.go
@@ -3,7 +3,6 @@ package multipl
 import (
 	"encoding/json"
 
-	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/ukama/ukama/services/cloud/device-feeder/pkg"
 	"github.com/ukama/ukama/services/cloud/device-feeder/pkg/global"
 	"github.com/ukama/ukama/services/common/msgbus"
@@ -20,7 +19,7 @@ type QueuePublisher interface {
 
 func NewQueuePublisher(queueUri string) (*queuePublisher, error) {
 
-	publisher, err := rabbitmq.NewPublisher(queueUri, amqp.Config{})
+	publisher, err := rabbitmq.NewPublisher(queueUri, rabbitmq.Config{})
 	if err != nil {
 		return nil, err
 	}

--- a/services/cloud/device-feeder/test/integration/device_feeder_test.go
+++ b/services/cloud/device-feeder/test/integration/device_feeder_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/coredns/coredns/plugin/pkg/log"
-	amqp "github.com/rabbitmq/amqp091-go"
 	uuid2 "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -169,7 +168,7 @@ func PrepareRegistryData(t *testing.T) (*grpc.ClientConn, pb.RegistryServiceClie
 }
 
 func sendMessageToQueue(msg pkg.DevicesUpdateRequest) error {
-	rabbit, err := rabbitmq.NewPublisher(testConf.QueueUri, amqp.Config{})
+	rabbit, err := rabbitmq.NewPublisher(testConf.QueueUri, rabbitmq.Config{})
 	if err != nil {
 		return err
 	}

--- a/services/cloud/hss/pkg/dev_requests.go
+++ b/services/cloud/hss/pkg/dev_requests.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/rabbitmq/amqp091-go"
 	log "github.com/sirupsen/logrus"
 	pb "github.com/ukama/ukama/services/cloud/hss/pb/gen"
 	"github.com/ukama/ukama/services/common/msgbus"
@@ -26,7 +25,7 @@ type DevicesUpdateRequest struct {
 
 func NewDeviceFeederReqGenerator(amqpConnStr string) (*DeviceFeederReqGenerator, error) {
 
-	publisher, err := rabbitmq.NewPublisher(amqpConnStr, amqp091.Config{})
+	publisher, err := rabbitmq.NewPublisher(amqpConnStr, rabbitmq.Config{})
 	if err != nil {
 		return nil, err
 	}

--- a/services/cloud/net/pkg/listener/listener.go
+++ b/services/cloud/net/pkg/listener/listener.go
@@ -53,7 +53,7 @@ func NewLiseterConfig() *ListenerConfig {
 }
 
 func StartListener(config *ListenerConfig) {
-	client, err := rabbitmq.NewConsumer(config.Queue.Uri, amqp.Config{},
+	client, err := rabbitmq.NewConsumer(config.Queue.Uri, rabbitmq.Config{},
 		rabbitmq.WithConsumerOptionsLogger(logrus.WithField("service", "rabbitmq")))
 	if err != nil {
 		logrus.Fatalf("error creating queue consumer. Error: %s", err.Error())


### PR DESCRIPTION
Change in `rabbitmq.NewConsumer` interface breaks build for couple of services. 
This PR updated usage of that function