### PR TITLE
init: update config.mk references from sub systems Makefiles.

### DIFF
--- a/systems/init/api-gateway/Makefile
+++ b/systems/init/api-gateway/Makefile
@@ -1,4 +1,4 @@
-include ../../../services/config.mk
+include ../../config.mk
 
 .PHONY: build deps lint gen clean integration.test test
 

--- a/systems/init/lookup/Makefile
+++ b/systems/init/lookup/Makefile
@@ -1,4 +1,5 @@
-include ../../../services/config.mk
+include ../../config.mk
+
 
 .PHONY: integration.test test build lint deps 
 

--- a/systems/init/node-gateway/Makefile
+++ b/systems/init/node-gateway/Makefile
@@ -1,4 +1,5 @@
-include ../../../services/config.mk
+include ../../config.mk
+
 
 .PHONY: build deps lint gen clean integration.test test
 


### PR DESCRIPTION
Makefiles  within Init system are still using references from  ukama/services/config.mk. 
Maybe they should be updated to use the config inside ukama/systems/config.mk

Signed-off-by: Elvis Attro <attroelvis@gmail.com>