### PR TITLE
ukama/ukama: ignore .DS_Store files in git repository. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+.DS_Store
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
This pull request fixes #393 
Signed-off-by: Elvis Attro <attroelvis@gmail.com>