### PR TITLE
RestClient added to common pkg

### DIFF
--- a/systems/common/rest/restClient.go
+++ b/systems/common/rest/restClient.go
@@ -1,0 +1,28 @@
+package rest
+
+import (
+	"net/url"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/sirupsen/logrus"
+)
+
+type RestClient struct {
+	C   *resty.Client
+	URL *url.URL
+}
+
+func NewRestClient(path string, debug bool) (*RestClient, error) {
+	url, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+	c := resty.New()
+	c.SetDebug(debug)
+	rc := &RestClient{
+		C:   c,
+		URL: url,
+	}
+	logrus.Tracef("Client created %+v for %s ", rc, rc.URL.String())
+	return rc, nil
+}


### PR DESCRIPTION
 This PR proposes the integration of RestClient into the common package to provide an easier and more efficient method for handling REST API calls.