### PR TITLE
updated  metric ws.

### DIFF
--- a/systems/metrics/api-gateway/Makefile
+++ b/systems/metrics/api-gateway/Makefile
@@ -4,7 +4,7 @@ include ../../../systems/config.mk
 
 build:integration.build
 	@echo Building version: \"$(BIN_VER)\"
-	env CGO_ENABLED=0 go build  -ldflags '-X github.com/ukama/ukama/systems/metrics/api-gateway/cmd/version.Version=$(BIN_VER) -extldflags=-static' -o bin/api-gateway cmd/main.go
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build  -ldflags '-X github.com/ukama/ukama/systems/metrics/api-gateway/cmd/version.Version=$(BIN_VER) -extldflags=-static' -o bin/api-gateway cmd/main.go
 
 test:
 	go test -v ./...

--- a/systems/metrics/api-gateway/pkg/rest/router.go
+++ b/systems/metrics/api-gateway/pkg/rest/router.go
@@ -55,6 +55,9 @@ var upgrader = websocket.Upgrader{
 	},
 } // use default options
 
+//TODO: Commenting below lines because of unused variables warning
+
+/*
 var (
 	// pongWait is how long we will await a pong response from client
 	pongWait = 100 * time.Second
@@ -63,6 +66,7 @@ var (
 	// The reason why it has to be less than PingRequency is becuase otherwise it will send a new Ping before getting response
 	pingInterval = (pongWait * 9) / 10
 )
+*/
 
 func NewClientsSet(endpoints *pkg.GrpcEndpoints, metricHost string, debug bool) *Clients {
 	c := &Clients{}

--- a/systems/metrics/docker-compose.yml
+++ b/systems/metrics/docker-compose.yml
@@ -1,95 +1,94 @@
-version: "3.9"
+version: '3.9'
 services:
-  postgresd-metrics:
-    image: postgres:13.3
-    ports:
-      - "5407:5432"
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=Pass2020!
-    networks:
-      - ukama-net
-    volumes:
-      - postgress-data:/var/lib/postgresql
+ postgresd-metrics:
+  image: postgres:13.3
+  ports:
+   - '5407:5432'
+  environment:
+   - POSTGRES_USER=postgres
+   - POSTGRES_PASSWORD=Pass2020!
+  networks:
+   - ukama-net
+  volumes:
+   - postgress-data:/var/lib/postgresql
 
-  prometheus:
-    image: prom/prometheus:latest
-    ports:
-        - 9090:9090
-    volumes:
-        - ./prometheus:/etc/prometheus
-        - prometheus-data:/prometheus
-    command: --web.enable-lifecycle  --config.file=/etc/prometheus/prometheus.yml
-    networks:
-      - ukama-net
+ prometheus:
+  image: prom/prometheus:latest
+  ports:
+   - 9090:9090
+  volumes:
+   - ./prometheus:/etc/prometheus
+   - prometheus-data:/prometheus
+  command: --web.enable-lifecycle  --config.file=/etc/prometheus/prometheus.yml
+  networks:
+   - ukama-net
 
-  exporter:
-    build:
-      context: ./exporter
-      dockerfile: ./Dockerfile
-    ports:
-      - "10251:10251"
-    environment:
-      - DEBUGMODE=true
-      - DB_HOST=postgresd
-      - DB_PASSWORD=Pass2020!
-      - DB_USER=postgres
-      - QUEUE_URI=amqp://guest:guest@${LOCAL_HOST_IP}:5672
-      - MSGCLIENT_HOST=msgclient-metrics:9095
-      - EXPORTER_SERVICE_HOST=exporter
-      - EXPORTER_SERVICE_PORT=9092
-    restart: always
-    networks:
-      - ukama-net
+ exporter:
+  build:
+   context: ./exporter
+   dockerfile: ./Dockerfile
+  ports:
+   - '10251:10251'
+  environment:
+   - DEBUGMODE=true
+   - DB_HOST=postgresd
+   - DB_PASSWORD=Pass2020!
+   - DB_USER=postgres
+   - QUEUE_URI=amqp://guest:guest@${LOCAL_HOST_IP}:5672
+   - MSGCLIENT_HOST=msgclient-metrics:9095
+   - EXPORTER_SERVICE_HOST=exporter
+   - EXPORTER_SERVICE_PORT=9092
+  restart: always
+  networks:
+   - ukama-net
 
+ metricsgateway:
+  build:
+   context: ./api-gateway
+   dockerfile: ./Dockerfile
+  ports:
+   - '8077:8080'
+  environment:
+   - METRICSCONFIG_METRICSSERVER=http://prometheus:9090
+   - BYPASS_AUTH_MODE=true
+  restart: always
+  depends_on:
+   - exporter
+  networks:
+   - ukama-net
 
-  metricsgateway:
-    build: 
-      context: ./api-gateway
-      dockerfile: ./Dockerfile
-    ports:
-      - "8077:8080"
-    environment:
-      - METRICSCONFIG_METRICSSERVER=http://prometheus:9090
-      - AUTH_BYPASSAUTHMODE=true
-    restart: always
-    depends_on:
-      - exporter
-    networks:
-      - ukama-net
+ msgclient-metrics:
+  build:
+   context: ../services/msgClient
+   dockerfile: ./Dockerfile
+  ports:
+   - '9095:9095'
+  environment:
+   - DEBUGMODE=true
+   - DB_HOST=postgresd-metrics
+   - DB_PASSWORD=Pass2020!
+   - DB_USER=postgres
+   - QUEUE_URI=amqp://guest:guest@${LOCAL_HOST_IP}:5672
+   - SYSTEM=metrics
+  restart: always
+  depends_on:
+   - prometheus
+  networks:
+   - ukama-net
 
-  msgclient-metrics:
-    build: 
-      context: ../services/msgClient
-      dockerfile: ./Dockerfile
-    ports:
-      - "9095:9095"
-    environment:
-      - DEBUGMODE=true
-      - DB_HOST=postgresd-metrics
-      - DB_PASSWORD=Pass2020!
-      - DB_USER=postgres
-      - QUEUE_URI=amqp://guest:guest@${LOCAL_HOST_IP}:5672
-      - SYSTEM=metrics
-    restart: always
-    depends_on:
-      - prometheus
-    networks:
-      - ukama-net
-  
-  pushgateway:
-    image: prom/pushgateway
-    restart: unless-stopped
-    ports:
-      - "9091:9091"
-    networks:
-      - ukama-net
+ pushgateway:
+  image: prom/pushgateway
+  restart: unless-stopped
+  ports:
+   - '9091:9091'
+  networks:
+   - ukama-net
 
 volumes:
-  postgress-data:
-  prometheus-data:
+ postgress-data:
+ prometheus-data:
 
 networks:
-  ukama-net:
-    external: true
-    name: services_dev-net
+ ukama-net:
+  external: true
+  name: services_dev-net

--- a/systems/metrics/exporter/Makefile
+++ b/systems/metrics/exporter/Makefile
@@ -4,7 +4,7 @@ include ../../config.mk
 
 build: integration.build
 	@echo Building version: \"$(BIN_VER)\"
-	env CGO_ENABLED=0 go build -ldflags='-X github.com/ukama/ukama/systems/metrics/exporter/cmd/version.Version=$(BIN_VER) -extldflags=-static' -gcflags=all="-N -l" -o bin/exporter cmd/server/main.go	
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -ldflags='-X github.com/ukama/ukama/systems/metrics/exporter/cmd/version.Version=$(BIN_VER) -extldflags=-static' -gcflags=all="-N -l" -o bin/exporter cmd/server/main.go	
 	
 test:
 	go test -v ./...


### PR DESCRIPTION
Added support to get request for multiple metrics in ws.
Request:
```
ws://{{METRICS_API}}/v1/live/metrics?metric=cpu,memory&nodeid=uk-test17-hnode-a1-31df&interval=5
```

Response for each metric:
```
{
    "Name": "cpu",
    "data": {
        "result": [],
        "resultType": "vector"
    },
    "status": "success"
}
```