### PR TITLE
registry/api-gateway: move state param from path to json payload. Fixes #600

### DIFF
--- a/systems/registry/api-gateway/pkg/rest/api.go
+++ b/systems/registry/api-gateway/pkg/rest/api.go
@@ -66,7 +66,7 @@ type DetachNodeRequest struct {
 
 type UpdateNodeStateRequest struct {
 	NodeId string `json:"node_id" path:"node_id" validate:"required"`
-	State  string `json:"state" path:"state" validate:"required"`
+	State  string `json:"state" validate:"required"`
 }
 
 type UpdateNodeRequest struct {

--- a/systems/registry/api-gateway/pkg/rest/router.go
+++ b/systems/registry/api-gateway/pkg/rest/router.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/ukama/ukama/systems/common/config"
 	"github.com/ukama/ukama/systems/common/rest"
+	"github.com/ukama/ukama/systems/registry/api-gateway/cmd/version"
 	"github.com/ukama/ukama/systems/registry/api-gateway/pkg"
 	"github.com/ukama/ukama/systems/registry/api-gateway/pkg/client"
-	"github.com/wI2L/fizz/openapi"
 
 	"github.com/gin-gonic/gin"
 	"github.com/loopfz/gadgeto/tonic"
-	"github.com/ukama/ukama/systems/common/config"
-	"github.com/ukama/ukama/systems/registry/api-gateway/cmd/version"
 	"github.com/wI2L/fizz"
+	"github.com/wI2L/fizz/openapi"
 
 	log "github.com/sirupsen/logrus"
 	invpb "github.com/ukama/ukama/systems/registry/invitation/pb/gen"

--- a/systems/registry/api-gateway/pkg/rest/router_test.go
+++ b/systems/registry/api-gateway/pkg/rest/router_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/ukama/ukama/systems/common/providers"
-	"github.com/ukama/ukama/systems/common/rest"
-	"github.com/ukama/ukama/systems/common/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/ukama/ukama/systems/common/providers"
+	"github.com/ukama/ukama/systems/common/rest"
+	"github.com/ukama/ukama/systems/common/uuid"
 	"github.com/ukama/ukama/systems/registry/api-gateway/pkg"
 	"github.com/ukama/ukama/systems/registry/api-gateway/pkg/client"
 


### PR DESCRIPTION
This PR fixes #600  with the following change: 

- Move state param from path to json payload for NodeStateUpdate