### PR TITLE
Fixed issue where invitation context exceeded and email was not sent

### DIFF
--- a/systems/registry/api-gateway/pkg/config.go
+++ b/systems/registry/api-gateway/pkg/config.go
@@ -50,7 +50,7 @@ func NewConfig() *Config {
 		},
 
 		Services: GrpcEndpoints{
-			Timeout:    10 * time.Second,
+			Timeout:    20 * time.Second,
 			Network:    "network:9090",
 			Member:     "member:9090",
 			Node:       "node:9090",


### PR DESCRIPTION
Fixed an issue in the invitation service where the API gateway context exceeded, leading to emails not being sent.