### PR TITLE
Rpi access node

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -76,7 +76,7 @@ XLD := $(XGCCPATH)$(XLD)
 .PHONY: all clean
 
 $(BUILDER_EXEC): $(VENDOR_PKG) $(PLATFORM) $(OBJFILES)
-	$(XCC) -o $(BUILDER_EXEC) $(OBJFILES) $(LDFLAGS) $(LIBS)
+	$(XGCC) -o $(BUILDER_EXEC) $(OBJFILES) $(LDFLAGS) $(LIBS)
 	echo "Done."
 
 ifeq ($(ALPINE_BUILD),1)

--- a/builder/docker/Dockerfile
+++ b/builder/docker/Dockerfile
@@ -71,6 +71,10 @@ RUN if echo "${TARGETPLATFORM}" | grep -q "alpine"; then \
         libmicrohttpd-dev \
         libcurl4-openssl-dev \
         libjansson-dev \
+        gcc-aarch64-linux-gnu \
+        g++-aarch64-linux-gnu \
+        uuid-dev \
+        sqlite3-dev \
         && rm -rf /var/lib/apt/lists/*; \
     else \
         echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1; \
@@ -126,11 +130,11 @@ RUN git clone https://github.com/ukama/prometheus-client.git && \
 FROM builder as final
 
 # Conditional logic for final stage
-RUN if echo "${TARGETPLATFORM}" | grep -q "ubuntu"; then \
-        apt-get update && apt-get install -y extlinux; \
-    elif echo "${TARGETPLATFORM}" | grep -q "alpine"; then \
-        echo "No additional packages for Alpine."; \
-    fi
+#RUN if echo "${TARGETPLATFORM}" | grep -q "ubuntu"; then \
+#        apt-get update && apt-get install -y extlinux; \
+#    elif echo "${TARGETPLATFORM}" | grep -q "alpine"; then \
+#        echo "No additional packages for Alpine."; \
+#    fi
 
 # Optionally set the working directory again if it was overridden
 WORKDIR /workspace

--- a/builder/docker/Dockerfile
+++ b/builder/docker/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM}
 
 # Install dependencies based on platform
-RUN if [ "${TARGETPLATFORM}" = "alpine:latest" ]; then \
+RUN if echo "${TARGETPLATFORM}" | grep -q "alpine"; then \
         apk add --no-cache \
         build-base \
         make \
@@ -32,7 +32,7 @@ RUN if [ "${TARGETPLATFORM}" = "alpine:latest" ]; then \
         linux-headers \
         bsd-compat-headers \
         musl-dev; \
-    elif [ "${TARGETPLATFORM}" = "ubuntu:latest" ]; then \
+    elif echo "${TARGETPLATFORM}" | grep -q "ubuntu"; then \
         apt-get update && apt-get install -y \
         software-properties-common \
         && add-apt-repository universe \
@@ -67,6 +67,10 @@ RUN if [ "${TARGETPLATFORM}" = "alpine:latest" ]; then \
         kpartx \
         fdisk \
         util-linux \
+        libgnutls28-dev \
+        libmicrohttpd-dev \
+        libcurl4-openssl-dev \
+        libjansson-dev \
         && rm -rf /var/lib/apt/lists/*; \
     else \
         echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1; \
@@ -122,9 +126,9 @@ RUN git clone https://github.com/ukama/prometheus-client.git && \
 FROM builder as final
 
 # Conditional logic for final stage
-RUN if [[ "$TARGETPLATFORM" == *"ubuntu"* ]]; then \
+RUN if echo "${TARGETPLATFORM}" | grep -q "ubuntu"; then \
         apt-get update && apt-get install -y extlinux; \
-    elif [[ "$TARGETPLATFORM" == *"alpine"* ]]; then \
+    elif echo "${TARGETPLATFORM}" | grep -q "alpine"; then \
         echo "No additional packages for Alpine."; \
     fi
 

--- a/builder/docker/Dockerfile
+++ b/builder/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN if echo "${TARGETPLATFORM}" | grep -q "alpine"; then \
         gcc-aarch64-linux-gnu \
         g++-aarch64-linux-gnu \
         uuid-dev \
-        sqlite3-dev \
+        libsqlite3-dev \
         && rm -rf /var/lib/apt/lists/*; \
     else \
         echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1; \

--- a/builder/docker/apps_build.sh
+++ b/builder/docker/apps_build.sh
@@ -9,11 +9,12 @@
 
 set -e
 
+NODE=$1
+APPS=$2
+
 export UKAMA_ROOT=/workspace
 export ALPINE_BUILD=1
-
-#default branch is main
-APPS=$1
+export TARGET="$NODE"
 
 cd "${UKAMA_ROOT}/builder" && make clean && make ALPINE_BUILD=1 all
 

--- a/builder/docker/apps_build.sh
+++ b/builder/docker/apps_build.sh
@@ -8,6 +8,7 @@
 # To run within specific container
 
 set -e
+set -x
 
 NODE=$1
 APPS=$2

--- a/builder/docker/apps_setup.sh
+++ b/builder/docker/apps_setup.sh
@@ -8,9 +8,10 @@
 
 set -e
 
-TARGET=$1
-UKAMA_ROOT=$2
-APPS=$3
+NODE=$1
+TARGET=$2
+UKAMA_ROOT=$3
+APPS=$4
 
 if [ "$TARGET" = "Darwin" ]; then
     TARGETPLATFORM="amd64/ubuntu:latest"
@@ -28,7 +29,7 @@ docker build --build-arg TARGETPLATFORM=${TARGETPLATFORM} \
 docker run --privileged \
        -v ${UKAMA_ROOT}:/workspace \
        apps-builder-${TARGETPLATFORM} \
-       /bin/bash -c "cd /workspace/builder/scripts/ && /workspace/builder/docker/apps_build.sh ${APPS} > /workspace/apps_build.log 2>&1"
+       /bin/bash -c "cd /workspace/builder/scripts/ && /workspace/builder/docker/apps_build.sh ${NODE} ${APPS} > /workspace/apps_build.log 2>&1"
 
 # clean up
 docker image rm --force apps-builder-${TARGETPLATFORM}

--- a/builder/docker/apps_setup.sh
+++ b/builder/docker/apps_setup.sh
@@ -12,29 +12,29 @@ NODE=$1
 TARGET=$2
 UKAMA_ROOT=$3
 APPS=$4
+DOCKER_IMG=
 
 if [ "$TARGET" = "Darwin" ]; then
     TARGETPLATFORM="amd64/ubuntu:latest"
+    DOCKER_IMG="apps-builder-amd64"
 elif [ "$TARGET" = "alpine" ]; then
     TARGETPLATFORM="alpine:latest"
+    DOCKER_IMG="apps-builder-alpine"
+elif [ "$TARGET" = "arm64" ]; then
+    TARGETPLATFORM="arm64v8/ubuntu:20.04"
+    DOCKER_IMG="apps-builder-arm64"
 else
     TARGETPLATFORM="ubuntu:latest"
+    DOCKER_IMG="apps-builder-ubuntu"
 fi
 
-# Build docker image using local Dockerfile
-if [ "$TARGET" = "arm64" ]; then
-    # rpi (access-node)
-    docker build --build-arg TARGETPLARFORM="arm64v8/ubuntu:20.04" \
-           -t apps-builder-arm64 .
-else
-    docker build --build-arg TARGETPLATFORM=${TARGETPLATFORM} \
-           -t apps-builder-${TARGETPLATFORM} .
-fi
+# Build the container
+docker build --build-arg TARGETPLATRFORM=${TARGETPLATFORM} -t ${DOCKER_IMG} .
 
 # Run the docker to build the apps 
 docker run --privileged \
        -v ${UKAMA_ROOT}:/workspace \
-       apps-builder-${TARGETPLATFORM} \
+       ${DOCKER_IMG} \
        /bin/bash -c "cd /workspace/builder/scripts/ && /workspace/builder/docker/apps_build.sh ${NODE} ${APPS} > /workspace/apps_build.log 2>&1"
 
 # clean up

--- a/builder/docker/apps_setup.sh
+++ b/builder/docker/apps_setup.sh
@@ -22,7 +22,7 @@ elif [ "$TARGET" = "alpine" ]; then
     TARGETPLATFORM="alpine:latest"
     DOCKER_IMG="apps-builder-alpine"
 elif [ "$TARGET" = "arm64" ]; then
-    TARGETPLATFORM="ubuntu:latest"
+    TARGETPLATFORM="ubuntu:22.04"
     DOCKER_IMG="apps-builder-arm64"
 else
     TARGETPLATFORM="ubuntu:latest"

--- a/builder/docker/apps_setup.sh
+++ b/builder/docker/apps_setup.sh
@@ -22,8 +22,14 @@ else
 fi
 
 # Build docker image using local Dockerfile
-docker build --build-arg TARGETPLATFORM=${TARGETPLATFORM} \
-       -t apps-builder-${TARGETPLATFORM} .
+if [ "$TARGET" = "arm64" ]; then
+    # rpi (access-node)
+    docker build --build-arg TARGETPLARFORM="arm64v8/ubuntu:20.04" \
+           -t apps-builder-arm64 .
+else
+    docker build --build-arg TARGETPLATFORM=${TARGETPLATFORM} \
+           -t apps-builder-${TARGETPLATFORM} .
+fi
 
 # Run the docker to build the apps 
 docker run --privileged \

--- a/builder/docker/apps_setup.sh
+++ b/builder/docker/apps_setup.sh
@@ -53,6 +53,6 @@ else
 fi
 
 # clean up
-docker image rm --force apps-builder-${TARGETPLATFORM}
+docker image rm --force "${DOCKER_IMG}"
 
 exit 0

--- a/builder/scripts/build-access-node.sh
+++ b/builder/scripts/build-access-node.sh
@@ -6,7 +6,6 @@
 # Copyright (c) 2024-present, Ukama Inc.
 
 set -e
-set -x
 
 # Variables
 ALPINE_VERSION="3.20.3"
@@ -99,7 +98,7 @@ function build_apps_using_container() {
     cwd=$(pwd)
 
     cd "${ukama_root}/builder/docker"
-    ./apps_setup.sh "alpine" "${ukama_root}" "${apps}"
+    ./apps_setup.sh "access" "alpine" "${ukama_root}" "${apps}"
     cd ${cwd}
 }
 
@@ -406,6 +405,7 @@ NODE_APPS=$2
 OS_TYPE="alpine"
 OS_VERSION="0.0.1"
 MANIFEST_FILE="manifest.json"
+export TARGET="access"
 
 check_sudo
 check_requirements

--- a/builder/scripts/build-access-node.sh
+++ b/builder/scripts/build-access-node.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2024-present, Ukama Inc.
+
+set -e
+
+# Variables
+ALPINE_VERSION="3.20.3"
+ALPINE_ARCH="armv7"
+IMG_SIZE="1G"
+IMG_NAME="access-node.img"
+
+ALPINE_URL_HOST="https://dl-cdn.alpinelinux.org"
+ALPINE_URL_PATH="alpine/v${ALPINE_VERSION%.*}/releases/${ALPINE_ARCH}"
+ALPINE_TAR="alpine-minirootfs-${ALPINE_VERSION}-${ALPINE_ARCH}.tar.gz"
+ALPINE_URL=${ALPINE_URL_HOST}/${ALPINE_URL_PATH}/${ALPINE_TAR}
+
+BOOT_MOUNT="/mnt/access-node/boot"
+PRIMARY_MOUNT="//mnt/access-node/primary"
+PASSIVE_MOUNT="/mnt/access-node/passive"
+UNUSED_MOUNT="/mnt/access-node/unused"
+
+TMP_DIR="/tmp/access-node/"
+TMP_ROOTFS="${TMP_DIR}/alpine-rootfs"
+TMP_LINUX="${TMP_DIR}/linux"
+
+trap cleanup EXIT
+
+function log() {
+    local type="$1"
+    local message="$2"
+    echo -e "\033[1;34m${type}:\033[0m ${message}"
+}
+
+function check_command() {
+    command -v "$1" >/dev/null 2>&1 || {
+        log "ERROR" "Command '$1' not found. Please install it."
+        exit 1
+    }
+}
+
+function check_requirements() {
+    log "INFO" "Checking required commands..."
+    for cmd in git make parted rsync wget tar dd losetup mkfs.vfat mkfs.ext4; do
+        check_command "$cmd"
+    done
+    log "SUCCESS" "All required commands are available."
+}
+
+function check_status() {
+    if [ $1 -ne 0 ]; then
+        log "ERROR" "$3"
+        exit 1
+    fi
+    log "SUCCESS" "$2"
+}
+
+function cleanup() {
+    log "INFO" "Cleaning up resources..."
+    sudo umount -R "$BOOT_MOUNT" \
+         "$PRIMARY_MOUNT" \
+         "$PASSIVE_MOUNT" \
+         "$UNUSED_MOUNT" 2>/dev/null || true
+    sudo rm -rf "$TMP_DIR"
+    sudo losetup -d "$LOOP_DEVICE" 2>/dev/null || true
+    log "INFO" "Cleanup completed."
+}
+
+function build_linux_kernel() {
+    log "INFO" "Building linux kernel..."
+    cd "$TMP_DIR"
+    git clone --depth=1 https://github.com/raspberrypi/linux || true
+    cd "$TMP_LINUX"
+    make -j6 ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- bcm2711_defconfig  || true
+    make -j6 ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image modules dtbs || true
+    cd "$TMP_DIR"
+    log "INFO" "Linux kernel build completed."
+}
+
+function download_alpine_rootfs() {
+    log "INFO" "Downloading Alpine Linux Rootfs..."
+    if [[ ! -f "$ALPINE_TAR" ]]; then
+        wget "$ALPINE_URL" -O "$ALPINE_TAR"
+    else
+        log "INFO" "Using cached Alpine image."
+    fi
+    log "SUCCESS" "Alpine Linux downloaded."
+}
+
+function copy_rootfs() {
+    log "INFO" "Extracting Alpine Linux root filesystem..."
+    cd "$TMP_DIR"
+    sudo mkdir -p "$TMP_ROOTFS"
+    sudo tar -xzf "$ALPINE_TAR" -C "$TMP_ROOTFS"
+    log "SUCCESS" "Alpine Linux extracted."
+}
+
+function copy_linux_kernel() {
+    log "INFO" "Building linux kernel..."
+    cd "$TMP_LINUX"
+    sudo mkdir -p ${BOOT_MOUNT}/overlays/
+    env PATH=$PATH make -j6 ARCH=arm64 \
+        CROSS_COMPILE=aarch64-linux-gnu- INSTALL_MOD_PATH=${PRIMARY} modules_install
+    cp arch/arm64/boot/Image               ${BOOT_MOUNT}/kernel8.img
+    cp arch/arm64/boot/dts/broadcom/*.dtb  ${BOOT_MOUNT}/
+    cp arch/arm64/boot/dts/overlays/*.dtb* ${BOOT_MOUNT}/overlays/
+    cp arch/arm64/boot/dts/overlays/README ${BOOT_MOUNT}/overlays/
+    cd "$TMP_DIR"
+    log "SUCCESS" "Linux kernel copied"
+}
+
+function create_disk_image() {
+    log "INFO" "Creating disk image..."
+    dd if=/dev/zero of="$IMG_NAME" bs=1M count=0 seek=$((1024 * ${IMG_SIZE%G}))
+    LOOP_DEVICE=$(sudo losetup -fP --show "$IMG_NAME")
+    log "SUCCESS" "Disk image created: $LOOP_DEVICE"
+}
+
+function partition_disk_image() {
+    log "INFO" "Partitioning disk image..."
+    sudo parted --script "$LOOP_DEVICE" mklabel msdos
+    sudo parted --script "$LOOP_DEVICE" mkpart primary fat32  1MiB  48MiB
+    sudo parted --script "$LOOP_DEVICE" mkpart primary ext4  49MiB 300MiB
+    sudo parted --script "$LOOP_DEVICE" mkpart primary ext4 301MiB 600MiB
+    sudo parted --script "$LOOP_DEVICE" mkpart primary ext4 601MiB   100%
+    log "SUCCESS" "Disk image partitioned."
+}
+
+function format_partitions() {
+    log "INFO" "Formatting partitions..."
+    sudo mkfs.vfat -F 16 -n boot ${LOOP_DEVICE}p1
+    sudo mkfs.ext4 -L primary    ${LOOP_DEVICE}p2
+    sudo mkfs.ext4 -L passive    ${LOOP_DEVICE}p3
+    sudo mkfs.ext4 -L unused     ${LOOP_DEVICE}p4
+    log "SUCCESS" "Partitions formatted."
+}
+
+function mount_partitions() {
+    log "INFO" "Mounting partitions..."
+    sudo mkdir -p "$BOOT_MOUNT" "$PRIMARY_MOUNT" "$PASSIVE_MOUNT" "$UNUSED_MOUNT"
+    sudo mount ${LOOP_DEVICE}p1 "$BOOT_MOUNT"
+    sudo mount ${LOOP_DEVICE}p2 "$PRIMARY_MOUNT"
+    sudo mount ${LOOP_DEVICE}p3 "$PASSIVE_MOUNT"
+    sudo mount ${LOOP_DEVICE}p4 "$UNUSED_MOUNT"
+    log "SUCCESS" "Partitions mounted."
+}
+
+function setup_rootfs() {
+    log "INFO" "Setting up root filesystem..."
+    sudo rsync -aAX "$TMP_ROOTFS/" "$PRIMARY_MOUNT/"
+    echo "127.0.0.1 localhost" | sudo tee "$PRIMARY_MOUNT/etc/hosts"
+    echo "nameserver 8.8.8.8" | sudo tee "$PRIMARY_MOUNT/etc/resolv.conf"
+    sudo chroot "$PRIMARY_MOUNT" /bin/sh <<EOF
+apk update
+apk add busybox dropbear dhcpcd openrc e2fsprogs
+rc-update add networking boot
+EOF
+    sudo rsync -aAX "$PRIMARY_MOUNT/" "$PASSIVE_MOUNT/"
+    log "SUCCESS" "Root filesystem setup complete."
+}
+
+function setup_fstab() {
+    log "INFO" "Configuring fstab..."
+    echo "/dev/mmcblk0p1  /boot  vfat defaults 0 1" | sudo tee "$PRIMARY_MOUNT/etc/fstab" > /dev/null
+    echo "/dev/mmcblk0p2  /      ext4 defaults 0 1" | sudo tee -a "$PRIMARY_MOUNT/etc/fstab" > /dev/null
+    echo "/dev/mmcblk0p1  /boot  vfat defaults 0 1" | sudo tee "$PASSIVE_MOUNT/etc/fstab" > /dev/null
+    echo "/dev/mmcblk0p3  /      ext4 defaults 0 1" | sudo tee -a "$PASSIVE_MOUNT/etc/fstab" > /dev/null
+    log "SUCCESS" "fstab configured."
+}
+
+function unmount_partitions() {
+    log "INFO" "Unmounting partitions..."
+    sudo umount -R "$BOOT_MOUNT" "$PRIMARY_MOUNT" "$PASSIVE_MOUNT" "$UNUSED_MOUNT"
+    log "SUCCESS" "Partitions unmounted."
+}
+
+# Main Script Execution
+check_requirements
+
+if [ -f "${IMG_NAME}" ]; then
+    rm "${IMG_NAME}"
+fi
+
+if [ -d "${TMP_DIR}" ]; then
+    rm -rf "${TMP_DIR}"
+fi
+mkdir -p "${TMP_DIR}"
+
+CWD=$(pwd); cd ${TMP_DIR}
+build_linux_kernel
+download_alpine_rootfs
+
+create_disk_image
+partition_disk_image
+format_partitions
+mount_partitions
+
+copy_linux_kernel
+copy_rootfs
+setup_rootfs
+setup_fstab
+unmount_partitions
+cleanup
+
+cd ${CWD}
+log "SUCCESS" "Access node image built successfully: $IMG_NAME"

--- a/builder/scripts/build-access-node.sh
+++ b/builder/scripts/build-access-node.sh
@@ -31,6 +31,13 @@ CWD=$(pwd)
 
 trap cleanup EXIT
 
+function check_sudo() {
+    if ! sudo -v; then
+        echo "You do not have sudo privileges or sudo is not configured correctly."
+        exit 1
+    fi
+}
+
 function log() {
     local type="$1"
     local message="$2"
@@ -102,10 +109,12 @@ function copy_rootfs() {
 
 function copy_linux_kernel() {
     log "INFO" "Building linux kernel..."
-    local build_dir="${CWD}/build_access_node/"
+    local build_dir="${CWD}/build_access_node"
 
     cd "$TMP_LINUX"
     sudo mkdir -p ${BOOT_MOUNT}/overlays/
+    sudo mkdir -p ${build_dir}/overlays/
+
     env PATH=$PATH make -j6 ARCH=arm64 \
         CROSS_COMPILE=aarch64-linux-gnu- INSTALL_MOD_PATH=${PRIMARY} modules_install
     cp arch/arm64/boot/Image               ${BOOT_MOUNT}/kernel8.img
@@ -209,6 +218,7 @@ function pre_cleanup_and_dir_setup() {
 }
 
 # Main Script Execution
+check_sudo
 check_requirements
 pre_cleanup_and_dir_setup "$IMG_NAME" "$TMP_DIR" "${CWD}/build_access_node"
 

--- a/builder/scripts/build-access-node.sh
+++ b/builder/scripts/build-access-node.sh
@@ -164,15 +164,15 @@ function copy_all_apps() {
 
     log "INFO" "Copying apps"
 
-    sudo mkdir -p "${PRIMARY_MOUNT}/ukama/apps/"
-    sudo mkdir -p "${PASSIVE_MOUNT}/ukama/apps/"
+    sudo mkdir -p "${PRIMARY_MOUNT}/ukama/apps/pkgs"
+    sudo mkdir -p "${PASSIVE_MOUNT}/ukama/apps/pkgs"
 
     IFS=',' read -r -a array <<< "$apps"
     for app in "${array[@]}"; do
         sudo cp "${ukama_root}/build/pkgs/${app}_latest.tar.gz" \
-             "${PRIMARY_MOUNT}/ukama/apps/"
+             "${PRIMARY_MOUNT}/ukama/apps/pkgs"
         sudo cp "${ukama_root}/build/pkgs/${app}_latest.tar.gz" \
-             "${PASSIVE_MOUNT}/ukama/apps/"
+             "${PASSIVE_MOUNT}/ukama/apps/pkgs"
     done
 
     # cleanup
@@ -185,7 +185,7 @@ function copy_misc_files() {
 
     log "INFO" "Copying various files to image"
 
-    generate_manifest_file $apps
+    create_manifest_file $apps
     sudo cp ${MANIFEST_FILE} "${PRIMARY_MOUNT}/manifest.json"
     sudo cp ${MANIFEST_FILE} "${PASSIVE_MOUNT}/manifest.json"
     rm ${MANIFEST_FILE}
@@ -429,6 +429,8 @@ setup_fstab
 build_apps_using_container "${UKAMA_ROOT}" "${NODE_APPS}"
 copy_all_apps              "${UKAMA_ROOT}" "${NODE_APPS}"
 copy_misc_files            "${UKAMA_ROOT}" "${NODE_APPS}"
+
+cp "${TMP_DIR}/${IMG_NAME}" ${CWD}
 
 unmount_partitions
 cleanup

--- a/builder/scripts/build-access-node.sh
+++ b/builder/scripts/build-access-node.sh
@@ -6,6 +6,7 @@
 # Copyright (c) 2024-present, Ukama Inc.
 
 set -e
+set -x
 
 # Variables
 ALPINE_VERSION="3.20.3"
@@ -399,7 +400,6 @@ function pre_cleanup_and_dir_setup() {
 }
 
 # Main Script Execution
-
 UKAMA_ROOT=$1
 NODE_APPS=$2
 
@@ -426,9 +426,9 @@ copy_rootfs
 setup_rootfs
 setup_fstab
 
-build_apps_using_container "${NODE_APPS}"
-copy_all_apps   "${UKAMA_ROOT}" "${NODE_APPS}"
-copy_misc_files "${UKAMA_ROOT}" "${NODE_APPS}"
+build_apps_using_container "${UKAMA_ROOT}" "${NODE_APPS}"
+copy_all_apps              "${UKAMA_ROOT}" "${NODE_APPS}"
+copy_misc_files            "${UKAMA_ROOT}" "${NODE_APPS}"
 
 unmount_partitions
 cleanup

--- a/builder/scripts/build-amplifier-node.sh
+++ b/builder/scripts/build-amplifier-node.sh
@@ -220,7 +220,7 @@ package_all_apps_via_container_build() {
     cwd=$(pwd)
 
     cd "${ukama_root}/builder/docker"
-    ./apps_setup.sh "alpine" "${ukama_root}" "${apps}"
+    ./apps_setup.sh "amplifier" "alpine" "${ukama_root}" "${apps}"
     cd ${cwd}
 }
 

--- a/builder/scripts/build-virtual-access-node.sh
+++ b/builder/scripts/build-virtual-access-node.sh
@@ -96,7 +96,7 @@ function build_apps_using_container() {
     cwd=$(pwd)
 
     cd "${ukama_root}/builder/docker"
-    ./apps_setup.sh "access" "alpine" "${ukama_root}" "${apps}"
+    ./apps_setup.sh "access" "arm64" "${ukama_root}" "${apps}"
     cd ${cwd}
 }
 

--- a/builder/scripts/build-virtual-access-node.sh
+++ b/builder/scripts/build-virtual-access-node.sh
@@ -217,7 +217,7 @@ function copy_misc_files() {
     install_starter_app "${PRIMARY_MOUNT}"
 
     log "INFO" "Copy Ukama sys lib to the image"
-    sudo mkdir -p "${PRIMARY_MOUNT}/lib/x86_64-linux-gnu/"
+    sudo mkdir -p "${PRIMARY_MOUNT}/lib/aarch64-linux-gnu/"
     sudo cp "${ukama_root}/nodes/ukamaOS/distro/platform/build/libusys.so" \
          "${PRIMARY_MOUNT}/lib/x86_64-linux-gnu/"
 

--- a/builder/scripts/build-virtual-access-node.sh
+++ b/builder/scripts/build-virtual-access-node.sh
@@ -377,9 +377,12 @@ function create_ssh_user() {
 
     local path=$1
 
-    echo "${USER_NAME}:x:1001:1001::/home/${USER_NAME}:/bin/bash" >> "${path}/etc/passwd"
-    echo "${USER_NAME}:x:1001:"                                   >> "${path}/etc/group"
-    echo "${USER_NAME}::19000:0:99999:7:::"                       >> "${path}/etc/shadow"
+    sudo echo "${USER_NAME}:x:1001:1001::/home/${USER_NAME}:/bin/bash" \
+         >> "${path}/etc/passwd"
+    sudo echo "${USER_NAME}:x:1001:" \
+         >> "${path}/etc/group"
+    sudo echo "${USER_NAME}::19000:0:99999:7:::" \
+         >> "${path}/etc/shadow"
 
     # Create home directory
     mkdir -p        "${path}/home/${USER_NAME}"

--- a/builder/scripts/build-virtual-access-node.sh
+++ b/builder/scripts/build-virtual-access-node.sh
@@ -12,10 +12,15 @@ set -x
 LOG_FILE="build_run.log"
 IMG_NAME="access-node.img"
 RPI_BASE_URL="https://downloads.raspberrypi.com"
-RPI_URL_PATH="raspios_oldstable_armhf/images/raspios_oldstable_armhf-2024-10-28"
-RPI_IMG="2024-10-22-raspios-bullseye-armhf.img"
-RPI_IMG_OFFSET="272629760"
+RPI_URL_PATH="raspios_lite_arm64/images/raspios_lite_arm64-2024-11-19"
+RPI_IMG="2024-11-19-raspios-bookworm-arm64-lite.img"
+RPI_IMG_OFFSET="541065216"
 PRIMARY_MOUNT="/mnt/access-node"
+
+# for 32-bit ARM
+#RPI_URL_PATH="raspios_oldstable_armhf/images/raspios_oldstable_armhf-2024-10-28"
+#RPI_IMG="2024-10-22-raspios-bullseye-armhf.img"
+#RPI_IMG_OFFSET="272629248"
 
 TMP_DIR="/tmp/access-node"
 TMP_ROOTFS="${TMP_DIR}/alpine-rootfs"

--- a/builder/scripts/build-virtual-access-node.sh
+++ b/builder/scripts/build-virtual-access-node.sh
@@ -131,6 +131,26 @@ function build_linux_kernel() {
     log "SUCCESS" "Linux kernel build completed."
 }
 
+function build_apps_using_target() {
+
+    # Idea is to run QEMU so we can build everything on the target
+    # rather than doing docker. This avoid lib mismatch.
+    #
+    # Steps:
+    # 1. copy repo to workspace.
+    # 2. mount the workspace.
+    # 3. update system.d to run the following script:
+    # 3. after running QEMU:
+    #    install all pkgs (look into dockerfile)
+    #    compile all pkgs (run the scripts under docker)
+    #    copy the pkgs to right location (copy_all_apps)
+    #    exit the qemu
+    # 4. remove the above script from the system.d
+    # 5. rest of stuff as before
+   
+
+}
+
 function build_apps_using_container() {
     local ukama_root="$1"
     local apps="$2"
@@ -345,8 +365,12 @@ git clone https://github.com/ukama/prometheus-client.git && \
     make install DESTDIR=/usr && \
     cd ../../.. && \
     rm -rf prometheus-client
-EOF
 
+# Copy libs to default location to avoid seeting LD_LIBRARY_PATH
+cp -rf /usr/local/lib/* /lib/aarch64-linux-gnu/
+
+EOF
+    
     # Unmount system directories
     log "INFO" "Unmounting system directories"
     sudo umount "$PRIMARY_MOUNT/dev/pts"

--- a/builder/scripts/build-virtual-access-node.sh
+++ b/builder/scripts/build-virtual-access-node.sh
@@ -424,6 +424,10 @@ function create_ssh_user() {
     chown 1001:1001 "${PRIMARY_MOUNT}/home/${USER_NAME}"
     chmod 700       "${PRIMARY_MOUNT}/home/${USER_NAME}"
 
+    # Add to sudoer
+    echo "ukama ALL=(ALL:ALL) ALL" | sudo tee "${PRIMARY_MOUNT}/etc/sudoers.d/ukama"
+    sudo chmod 0440 "${PRIMARY_MOUNT}/etc/sudoers.d/ukama"
+
     log "SUCCESS" "User $USER_NAME added with no password."
 }
 

--- a/builder/scripts/build-virtual-access-node.sh
+++ b/builder/scripts/build-virtual-access-node.sh
@@ -66,7 +66,7 @@ function build_linux_kernel() {
 
     if [ -d "${TMP_LINUX}" ]; then
         log "INFO" "Using existing linux kernel at: ${TMP_LINUX}"
-    else 
+    else
         wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.34.tar.xz
         tar xJf linux-6.1.34.tar.xz
         mv linux-6.1.34 "${TMP_LINUX}"

--- a/builder/scripts/build-virtual-access-node.sh
+++ b/builder/scripts/build-virtual-access-node.sh
@@ -1,0 +1,436 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2024-present, Ukama Inc.
+
+set -e
+set -x
+
+# Variables
+IMG_NAME="access-node.img"
+RPI_BASE_URL="https://downloads.raspberrypi.com"
+RPI_URL_PATH="raspios_oldstable_armhf/images/raspios_oldstable_armhf-2024-10-28"
+RPI_IMG="2024-10-22-raspios-bullseye-armhf.img"
+RPI_IMG_OFFSET="272629760"
+PRIMARY_MOUNT="/mnt/access-node"
+
+TMP_DIR="/tmp/access-node"
+TMP_ROOTFS="${TMP_DIR}/alpine-rootfs"
+TMP_LINUX="${TMP_DIR}/linux"
+
+CWD=$(pwd)
+
+trap cleanup EXIT
+
+function check_sudo() {
+    if ! sudo -v; then
+        echo "You do not have sudo privileges or sudo is not configured correctly."
+        exit 1
+    fi
+}
+
+function log() {
+    local type="$1"
+    local message="$2"
+    echo -e "\033[1;34m${type}:\033[0m ${message}"
+}
+
+function check_command() {
+    command -v "$1" >/dev/null 2>&1 || {
+        log "ERROR" "Command '$1' not found. Please install it."
+        exit 1
+    }
+}
+
+function check_requirements() {
+    log "INFO" "Checking required commands..."
+    for cmd in git make parted rsync wget tar dd losetup mkfs.vfat mkfs.ext4; do
+        check_command "$cmd"
+    done
+    log "SUCCESS" "All required commands are available."
+}
+
+function cleanup() {
+    log "INFO" "Cleaning up resources..."
+    sudo umount -R "${PRIMARY_MOUNT}" 2>/dev/null || true
+#    sudo rm -rf "$TMP_DIR"
+    log "INFO" "Cleanup completed."
+}
+
+function build_linux_kernel() {
+    log "INFO" "Building linux kernel..."
+
+    if [ -d "${TMP_LINUX}" ]; then
+        log "INFO" "Using existing linux kernel at: ${TMP_LINUX}"
+    else 
+        wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.34.tar.xz
+        tar xJf linux-6.1.34.tar.xz
+        mv linux-6.1.34 "${TMP_LINUX}"
+    fi
+
+    cd "${TMP_LINUX}"
+
+    if [ -f "${TMP_LINUX}/arch/arm64/boot/Image" ]; then
+        log "INFO" "Kernel image already exists, skipping"
+    else 
+        # build linux kernel suitable for qemu
+        ARCH=arm64 CROSS_COMPILE=/bin/aarch64-linux-gnu- make defconfig        || true
+        ARCH=arm64 CROSS_COMPILE=/bin/aarch64-linux-gnu- make kvm_guest.config || true
+        ARCH=arm64 CROSS_COMPILE=/bin/aarch64-linux-gnu- make -j8              || true
+    fi
+
+    cd "${TMP_DIR}"
+    log "SUCCESS" "Linux kernel build completed."
+}
+
+function build_apps_using_container() {
+
+    local ukama_root="$1"
+    local apps="$2"
+
+    log "INFO" "Packaging applications via container build ..."
+    cwd=$(pwd)
+
+    cd "${ukama_root}/builder/docker"
+    ./apps_setup.sh "access" "alpine" "${ukama_root}" "${apps}"
+    cd ${cwd}
+}
+
+function download_rpi_rootfs() {
+    log "INFO" "Checking for RPI rootfs image..."
+
+    if [ -f "${RPI_IMG}" ]; then
+        log "INFO" "Using existing extracted image: ${RPI_IMG}"
+        return
+    fi
+
+    if [ -f "${RPI_IMG}.xz" ]; then
+        log "INFO" "Using existing compressed image: ${RPI_IMG}.xz"
+    else
+        log "INFO" "Downloading RPI rootfs image..."
+        wget "${RPI_BASE_URL}/${RPI_URL_PATH}/${RPI_IMG}.xz" \
+            || { log "ERROR" "Unable to download ${RPI_IMG}.xz"; exit 1; }
+    fi
+
+    log "INFO" "Extracting ${RPI_IMG}.xz..."
+    xz -d -f "${RPI_IMG}.xz" \
+        || { log "ERROR" "Unable to extract ${RPI_IMG}.xz"; exit 1; }
+
+    log "SUCCESS" "RPI rootfs image downloaded and extracted: ${RPI_IMG}"
+}
+
+function install_starter_app() {
+
+    path=$1
+
+    log "INFO" "Installing starter.d"
+
+    sudo chroot "$path" /bin/sh <<'EOF'
+cd /ukama/apps/pkgs/
+tar zxvf starterd_latest.tar.gz starterd_latest/sbin/starter.d .
+mv starterd_latest/sbin/starter.d /sbin/
+rm -rf starterd_latest/
+EOF
+}
+
+function copy_linux_kernel() {
+    log "INFO" "Copying linux kernel..."
+    cp "${TMP_LINUX}/arch/arm64/boot/Image" "${CWD}/build_access_node/"
+    log "SUCCESS" "Linux kernel copied"
+}
+
+function copy_all_apps() {
+    local ukama_root=$1
+    local apps=$2
+
+    log "INFO" "Copying apps"
+
+    sudo mkdir -p "${PRIMARY_MOUNT}/ukama/apps/pkgs"
+    IFS=',' read -r -a array <<< "$apps"
+    for app in "${array[@]}"; do
+        sudo cp "${ukama_root}/build/pkgs/${app}_latest.tar.gz" \
+             "${PRIMARY_MOUNT}/ukama/apps/pkgs"
+    done
+
+    sudo rm -rf "${ukama_root}/build/"
+}
+
+function copy_misc_files() {
+    local ukama_root=$1
+    local apps=$2
+
+    log "INFO" "Copying various files to image"
+
+    create_manifest_file $apps
+    sudo cp ${MANIFEST_FILE} "${PRIMARY_MOUNT}/manifest.json"
+    rm ${MANIFEST_FILE}
+
+    # install the starter.d app
+    install_starter_app "${PRIMARY_MOUNT}"
+
+    log "INFO" "Copy Ukama sys lib to the image"
+    sudo mkdir -p "${PRIMARY_MOUNT}/lib/x86_64-linux-gnu/"
+    sudo cp "${ukama_root}/nodes/ukamaOS/distro/platform/build/libusys.so" \
+         "${PRIMARY_MOUNT}/lib/x86_64-linux-gnu/"
+
+    # update /etc/services to add ports
+    log "INFO" "Adding all the apps to /etc/services"
+    sudo mkdir -p "${PRIMARY_MOUNT}/etc"
+    sudo cp "${ukama_root}/nodes/ukamaOS/distro/scripts/files/services" \
+         "${PRIMARY_MOUNT}/etc/services"
+}
+
+function create_manifest_file() {
+    local apps_to_include="$1"
+    log "INFO" "Creating manifest file"
+
+    # Create an array from the comma-separated list
+    IFS=',' read -r -a apps_array <<< "$apps_to_include"
+
+   cat <<EOF > ${MANIFEST_FILE}
+{
+    "version": "0.1",
+
+    "spaces" : [
+        { "name" : "boot" },
+        { "name" : "services" },
+        { "name" : "reboot" }
+    ],
+
+    "capps": [
+        {
+            "name"   : "noded",
+            "tag"    : "latest",
+            "restart": "yes",
+            "space"  : "boot"
+        },
+        {
+            "name"   : "bootstrap",
+            "tag"    : "latest",
+            "restart": "yes",
+            "space"  : "boot",
+                "depends_on" : [
+                {
+                    "capp"  : "noded",
+                                "state" : "active"
+                        }
+                ]
+        },
+        {
+            "name"   : "meshd",
+            "tag"    : "latest",
+            "restart": "yes",
+            "space"  : "boot",
+                "depends_on" : [
+                {
+                    "capp"  : "bootstrap",
+                                "state" : "done"
+                        }
+                ]
+        }
+EOF
+
+  echo '        ,' >> ${MANIFEST_FILE}
+  echo '        {"name" : "services", "capps" : [' >> ${MANIFEST_FILE}
+
+  for app in "${apps_array[@]}"; do
+    case "$app" in
+      "wimcd"|"configd"|"metricsd"|"lookoutd"|"deviced"|"notifyd")
+        cat <<EOF >> ${MANIFEST_FILE}
+        {
+            "name"   : "$app",
+            "tag"    : "latest",
+            "restart": "yes",
+            "space"  : "services"
+        },
+EOF
+        ;;
+    esac
+  done
+
+  echo '        ,' >> ${MANIFEST_FILE}
+  echo '        {"name" : "services", "capps" : [' >> ${MANIFEST_FILE}
+
+  for app in "${apps_array[@]}"; do
+    case "$app" in
+      "wimcd"|"configd"|"metricsd"|"lookoutd"|"deviced"|"notifyd")
+        cat <<EOF >> ${MANIFEST_FILE}
+        {
+            "name"   : "$app",
+            "tag"    : "latest",
+            "restart": "yes",
+            "space"  : "services"
+        },
+EOF
+        ;;
+    esac
+  done
+
+  # Remove the last comma and close the JSON array
+  sed -i '$ s/,$//' ${MANIFEST_FILE}
+  echo '    ]}'  >> ${MANIFEST_FILE}
+  echo '}'       >> ${MANIFEST_FILE}
+}
+
+function mount_partitions() {
+    log "INFO" "Mounting partitions..."
+
+    sudo mkdir -p "$PRIMARY_MOUNT"
+    sudo mount -o loop,offset="${RPI_IMG_OFFSET}" "${RPI_IMG}" "${PRIMARY_MOUNT}" || \
+        { log "ERROR" "Unable to mount rootfs partition"; exit 1; }
+       
+    log "SUCCESS" "Partitions mounted."
+}
+
+function setup_ukama_dirs() {
+    log "INFO" "Creating Ukama directories..."
+
+    mkdir -p "${PRIMARY_MOUNT}/ukama"
+    mkdir -p "${PRIMARY_MOUNT}/ukama/configs"
+    mkdir -p "${PRIMARY_MOUNT}/ukama/apps"
+    mkdir -p "${PRIMARY_MOUNT}/ukama/apps/pkgs"
+    mkdir -p "${PRIMARY_MOUNT}/ukama/apps/rootfs"
+    mkdir -p "${PRIMARY_MOUNT}/ukama/apps/registry"
+
+    echo "${NODE_ID}" > "${PRIMARY_MOUNT}/ukama/nodeid"
+    echo "localhost"  > "${PRIMARY_MOUNT}/ukama/bootstrap"
+
+    touch "${PRIMARY_MOUNT}/ukama/apps.log"
+
+    log "SUCCESS" "Ukama directories created."
+}
+
+function configure_openrc_service() {
+    local rootfs_path=$1
+
+    log "INFO" "Setting up minimal Debian rootfs with debootstrap"
+
+    # Step 1: Install debootstrap if not already installed
+    if ! command -v debootstrap &>/dev/null; then
+        log "INFO" "Installing debootstrap"
+        sudo apt update && sudo apt install debootstrap -y
+    fi
+
+    # Step 2: Bootstrap a minimal Debian system
+    if [ ! -d "$rootfs_path" ]; then
+        log "INFO" "Bootstrapping Debian system at $rootfs_path"
+        sudo debootstrap --variant=minbase stable "$rootfs_path" http://deb.debian.org/debian/
+        log "SUCCESS" "Minimal Debian system installed at $rootfs_path"
+    else
+        log "INFO" "Rootfs path already exists at $rootfs_path, skipping debootstrap"
+    fi
+
+    # Step 3: Bind system directories for chroot
+    log "INFO" "Binding system directories for chroot"
+    sudo mount --bind /dev "$rootfs_path/dev"
+    sudo mount --bind /proc "$rootfs_path/proc"
+    sudo mount --bind /sys "$rootfs_path/sys"
+
+    # Step 4: Install OpenRC and configure the service
+    log "INFO" "Installing OpenRC and configuring service in Debian chroot"
+    sudo chroot "$rootfs_path" /bin/bash <<'EOF'
+# Update apt repositories
+apt update
+
+# Install OpenRC
+apt install -y openrc
+
+# Create OpenRC service script
+cat <<'SERVICE' > /etc/init.d/starter
+#!/sbin/openrc-run
+description="Starter service for running starter.d"
+
+command="/sbin/starter.d"
+command_args=""
+command_user="root"
+pidfile="/var/run/starter.pid"
+SERVICE
+
+# Make the service script executable
+chmod +x /etc/init.d/starter
+
+# Add the service to the default runlevel
+rc-update add starter default
+EOF
+
+    # Step 5: Unmount system directories
+    log "INFO" "Unmounting system directories"
+    sudo umount "$rootfs_path/dev"
+    sudo umount "$rootfs_path/proc"
+    sudo umount "$rootfs_path/sys"
+
+    log "SUCCESS" "OpenRC service for starter.d configured in Debian rootfs"
+}
+
+function unmount_partitions() {
+    log "INFO" "Unmounting partitions..."
+    sudo umount "$PRIMARY_MOUNT"
+    log "SUCCESS" "Partitions unmounted."
+}
+
+function pre_cleanup_and_dir_setup() {
+
+    local image_name=$1
+    local tmp_dir=$2
+    local build_dir=$3
+
+    if [ -f "$image_name" ]; then
+        rm "$image_name"
+    fi
+
+#    if [ -d "$tmp_dir" ]; then
+#        rm -rf "$tmp_dir"
+#    fi
+    mkdir -p "$tmp_dir"
+
+    if [ -d "$build_dir" ]; then
+        rm -rf "$build_dir"
+    fi
+    mkdir "$build_dir"
+}
+
+# Main Script Execution
+UKAMA_ROOT=$1
+NODE_APPS=$2
+NODE_ID=$3
+
+if [[ $# -ne 3 ]]; then
+    log "ERROR" "Error: Exactly 3 arguments are required!"
+    log "INFO"  "Usage: $0 <ukama_root> <node_apps> <node_id>"
+    exit 1
+fi
+
+OS_TYPE="alpine"
+OS_VERSION="0.0.1"
+MANIFEST_FILE="manifest.json"
+export TARGET="access"
+
+check_sudo
+check_requirements
+pre_cleanup_and_dir_setup "$IMG_NAME" "$TMP_DIR" "${CWD}/build_access_node"
+
+cd ${TMP_DIR}
+
+# Build linux kernel and get rpi image (rootfs)
+build_linux_kernel
+download_rpi_rootfs
+
+# Mount partition, create ukama dir, build apps
+mount_partitions
+setup_ukama_dirs
+build_apps_using_container "${UKAMA_ROOT}" "${NODE_APPS}"
+copy_all_apps              "${UKAMA_ROOT}" "${NODE_APPS}"
+copy_misc_files            "${UKAMA_ROOT}" "${NODE_APPS}"
+
+# setup openrc to run starter.d
+configure_openrc_service "${PRIMARY_MOUNT}"
+cp "${TMP_DIR}/${RPI_IMG}" "${CWD}/build_access_node/${IMG_NAME}"
+
+# cleanup
+unmount_partitions
+cleanup
+
+cd ${CWD}
+log "SUCCESS" "Access node image built successfully: $IMG_NAME"

--- a/builder/scripts/make-app.sh
+++ b/builder/scripts/make-app.sh
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright (c) 2021-present, Ukama Inc.
+# Copyright (c) 2024-present, Ukama Inc.
 
 # Script to build and package ukamaOS app
 

--- a/builder/scripts/run-access-node-in-qemu.sh
+++ b/builder/scripts/run-access-node-in-qemu.sh
@@ -34,7 +34,7 @@ log "INFO" "Starting QEMU for access node (rpi cm4) ..."
 if ! qemu-system-aarch64 \
      -machine virt \
      -cpu cortex-a72 \
-     -smp 6 \
+     -smp 4 \
      -m "${RAM_SIZE}" \
      -kernel "${BUILD_DIR}/${KERNEL_IMAGE}" \
      -append "root=/dev/vda2 rootfstype=ext4 rw panic=0 console=ttyAMA0" \

--- a/builder/scripts/run-access-node-in-qemu.sh
+++ b/builder/scripts/run-access-node-in-qemu.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2024-present, Ukama Inc.
+
+# Run the generated disk image in QEMU
+
+set -e
+
+BUILD_DIR="./build_access_node"
+IMG_NAME="access-node.img"
+KERNEL_IMAGE="kernel8.img"
+DTB_FILE="bcm2711-rpi-cm4.dtb"
+RAM_SIZE="2G"
+
+function log() {
+    local type="$1"
+    local message="$2"
+    echo -e "\033[1;34m${type}:\033[0m ${message}"
+}
+
+function error_exit() {
+    log "ERROR" "$1"
+    exit 1
+}
+
+[ -f "$IMG_NAME" ]     || error_exit "Disk image '$IMG_NAME' not found"
+[ -f "$KERNEL_IMAGE" ] || error_exit "Kernel '$KERNEL_IMAGE' not found"
+[ -f "$DTB_FILE" ]     || error_exit "DTB '$DTB_FILE' not found"
+
+log "INFO" "Starting QEMU for access node (rpi cm4) ..." 
+
+if ! qemu-system-aarch64 \
+    -M raspi3 \
+    -cpu cortex-a72 \
+    -m "$RAM_SIZE" \
+    -kernel "${BUILD_DIR}/$KERNEL_IMAGE" \
+    -dtb "${BUILD_DIR}/$DTB_FILE" \
+    -drive file="$IMG_NAME",if=sd,format=raw \
+    -append "rw root=/dev/mmcblk0p2 console=ttyAMA0" \
+    -serial mon:stdio \
+    -nographic \
+    -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+    -device usb-net,netdev=net0; then
+    error_exit "QEMU execution failed."
+fi
+
+log "SUCCESS" "QEMU started successfully."

--- a/nodes/ukamaOS/config.mk
+++ b/nodes/ukamaOS/config.mk
@@ -16,12 +16,12 @@ CUR_BUILD_DIRNAME = $(notdir $(patsubst %/,%,$(CURPATH)))
 NODES_DIR = $(shell echo $(CURPATH) | sed 's|\(.*nodes\)/.*|\1|')
 UKAMAOS_ROOT = $(NODES_DIR)/ukamaOS
 
-#OS
 OS = $(shell uname -s)
 NPROCS = 1
 ifeq ($(OS), Linux)
         NPROCS = $(shell grep -c ^processor /proc/cpuinfo)
 endif
+export NPROCS
 
 # Build system
 BUILD = x86_64-unknown-linux-gnu
@@ -30,19 +30,17 @@ BUILD = x86_64-unknown-linux-gnu
 ARCH_ARM    = arm
 ARCH_X86    = x86
 ARCH_X86_64 = x86_64
+ARCH_ARM64  = aarch64
 
-#if variables are not defined
-#amplifier Node
-override ANODEBOARD = anode
-override CNODEBOARD = cnode
-override HNODEBOARD = hnode
-override LOCAL  = linux
+override AMPLIFIER_NODE = amplifier
+override TOWER_NODE     = tower
+override ACCESS_NODE    = access
+override LOCAL          = linux
 
-#TARGET
 ifndef TARGET
-	override TARGETBOARD = ANODEBOARD
+	override TARGET_BOARD = LOCAL
 else
-	override TARGETBOARD = $(TARGET)
+	override TARGET_BOARD = $(TARGET)
 endif
 
 # Setup paths for configs
@@ -52,9 +50,7 @@ NODE_APP_CONFIG_DIR = /conf
 # Setup paths for apps
 NODE_APP_DIR = /sbin/
 
-# Setup various compilier and linker options for various targets.
-
-ifeq ($(ANODEBOARD), $(TARGETBOARD))
+ifeq ($(AMPLIFIER_NODE), $(TARGET_BOARD))
 	override CC     = arm-linux-gnueabihf-gcc
 	override ARCH   = $(ARCH_ARM)
 	XCROSS_COMPILER = arm-linux-gnueabihf-
@@ -66,8 +62,8 @@ ifeq ($(ANODEBOARD), $(TARGETBOARD))
 	XGCCPATH        = /usr/bin/
 endif
 
-ifeq ($(CNODEBOARD), $(TARGETBOARD))
-	override CC     =
+ifeq ($(TOWER_NODE), $(TARGET_BOARD))
+	override CC     = x86_64-linux-musl-gcc
 	override ARCH   = $(ARCH_X86_64)
 	XCROSS_COMPILER = x86_64-linux-musl-
 	XGCC            = $(XCROSS_COMPILER)gcc
@@ -77,7 +73,19 @@ ifeq ($(CNODEBOARD), $(TARGETBOARD))
 	OPENSSLTARGET   = linux-generic64
 endif
 
-ifeq ($(LOCAL), $(TARGETBOARD))
+ifeq ($(ACCESS_NODE), $(TARGET_BOARD))
+	override CC     = gcc
+	override ARCH   = $(ARCH_ARM64)
+	XCROSS_COMPILER = gcc
+	XGCC            = gcc
+	XLD             = ld
+	XGXX            = g++
+	HOST            = aarch64-linux-gnu
+	OPENSSLTARGET   = linux-aarch64
+	XGCCPATH        = /usr/bin/
+endif
+
+ifeq ($(LOCAL), $(TARGET_BOARD))
 	override CC     = gcc
 	override ARCH   = $(ARCH_X86_64)
 	XGCC            = gcc

--- a/nodes/ukamaOS/config.mk
+++ b/nodes/ukamaOS/config.mk
@@ -76,12 +76,13 @@ ifeq ($(TOWER_NODE), $(TARGET_BOARD))
 endif
 
 ifeq ($(ACCESS_NODE), $(TARGET_BOARD))
-	override CC     = gcc
+	override CC     = aarch64-linux-gnu-gcc
 	override ARCH   = $(ARCH_ARM64)
-	XCROSS_COMPILER = gcc
-	XGCC            = gcc
-	XLD             = ld
-	XGXX            = g++
+
+	XCROSS_COMPILER = aarch64-linux-gnu-gcc
+	XGCC            = aarch64-linux-gnu-gcc
+	XLD             = aarch64-linux-gnu-ld
+	XGXX            = aarch64-linux-gnu-g++
 	HOST            = aarch64-linux-gnu
 	OPENSSLTARGET   = linux-aarch64
 	XGCCPATH        = /usr/bin/

--- a/nodes/ukamaOS/config.mk
+++ b/nodes/ukamaOS/config.mk
@@ -39,8 +39,10 @@ override LOCAL          = linux
 
 ifndef TARGET
 	override TARGET_BOARD = LOCAL
+	export TARGET=$(LOCAL)
 else
 	override TARGET_BOARD = $(TARGET)
+	export TARGET
 endif
 
 # Setup paths for configs


### PR DESCRIPTION
Script to create virtual node (access)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add scripts and configurations to build and run a virtual access node using Raspberry Pi images and QEMU, with updates to Docker and Makefile for cross-compilation support.
> 
>   - **Scripts**:
>     - Add `build-access-node.sh` and `build-virtual-access-node.sh` for creating access node images.
>     - Add `run-access-node-in-qemu.sh` to run the access node image in QEMU.
>   - **Docker**:
>     - Modify `Dockerfile` to support building for `arm64` and `alpine` platforms.
>     - Update `apps_setup.sh` and `apps_build.sh` to handle different target platforms.
>   - **Makefile**:
>     - Change `XCC` to `XGCC` in `builder/Makefile` for consistency.
>   - **Config**:
>     - Update `config.mk` to include `ACCESS_NODE` target with `aarch64` architecture.
>   - **Misc**:
>     - Add logging and error handling improvements across scripts.
>     - Update copyright years to 2024.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for 899f846929da58a63719c2e721c1358d0270dc46. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->