### PR TITLE
Node msgcli events added

### DIFF
--- a/builder/scripts/push_node_event.sh
+++ b/builder/scripts/push_node_event.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present, Ukama Inc.
+
+# HOW TO USE: ./push_node_event.sh <orgname>
+
+ORGNAME=$1
+
+DB_URI="postgresql://postgres:Pass2020!@127.0.0.1:5414/component"
+INVENTORY_NODE_IDS=("uk-sa9001-tnode-a1-1234" "uk-sa9001-anode-a1-1234")
+
+NODE_IDS=("uk-sa2450-tnode-v0-4e86" "uk-sa2450-hnode-v0-4e87")
+LATITUDES=(-4.3262161 -4.32758)
+LONGITUDES=(15.311631 15.3109951)
+
+for i in {0..1}; do
+  RESPONSE=$(./bin/msgcli events push --org $ORGNAME --route messaging.mesh.node.online -m "{\"NodeId\":\"${NODE_IDS[$i]}\"}" 2>&1)
+  lowercase_nodeid=$(echo "${NODE_IDS[$i]}" | tr '[:upper:]' '[:lower:]')
+
+  SQL_QUERY="UPDATE components SET part_number = '$lowercase_nodeid' WHERE part_number = '${INVENTORY_NODE_IDS[$i]}';"
+  psql $DB_URI -t -A -c "$SQL_QUERY"
+  echo "Node online event pushed and nodeid updated in inventory for $lowercase_nodeid"
+
+  if [ $i -eq 0 ]; then
+    curl_response=$(curl -s -o /dev/stdout -w "\nHTTP Status: %{http_code}\n" -X 'POST' \
+      'http://localhost:8036/v1/notify' \
+      -H 'accept: application/json' \
+      -H 'Content-Type: application/json' \
+      -d '{
+      "details": {
+        "latitude": -4.3262161,
+        "longitude": 15.311631
+      },
+      "node_id": "uk-sa2450-tnode-v0-4e86",
+      "service_name": "health",
+      "severity": "low",
+      "status": 8100,
+      "time": 1733753967,
+      "type": "event"
+    }')
+    echo "Curl response: $curl_response"
+  fi
+done
+

--- a/utils/msgcli/Makefile
+++ b/utils/msgcli/Makefile
@@ -8,11 +8,13 @@ include ./config.mk
   
 .PHONY: build msgcli tool
 
-
 build: 
 	@echo Building version: \"$(BIN_VER)\"
 	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-X github.com/ukama/ukama/utils/msgcli/cmd/version.Version=$(BIN_VER) -extldflags=-static' -o bin/msgcli main.go
 
+build-mac: 
+	@echo Building version: \"$(BIN_VER)\"
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags='-X github.com/ukama/msgcli/cmd/version.Version=$(BIN_VER) -extldflags=-static' -o bin/msgcli main.go
 
 # Go test
 test:

--- a/utils/msgcli/Makefile
+++ b/utils/msgcli/Makefile
@@ -12,10 +12,6 @@ build:
 	@echo Building version: \"$(BIN_VER)\"
 	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-X github.com/ukama/ukama/utils/msgcli/cmd/version.Version=$(BIN_VER) -extldflags=-static' -o bin/msgcli main.go
 
-build-mac: 
-	@echo Building version: \"$(BIN_VER)\"
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags='-X github.com/ukama/msgcli/cmd/version.Version=$(BIN_VER) -extldflags=-static' -o bin/msgcli main.go
-
 # Go test
 test:
 	go test -v ./...

--- a/utils/msgcli/cmd/push.go
+++ b/utils/msgcli/cmd/push.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	defaultOrg         = "ukamatestorg"
+	defaultOrg         = "ukama"
 	defaultScope       = "local"
 	defaultClusterURL  = "http://localhost:15672"
 	defaultVhost       = "%2F"

--- a/utils/msgcli/internal/push/messages/messages.go
+++ b/utils/msgcli/internal/push/messages/messages.go
@@ -28,6 +28,10 @@ var RoutingMap = map[string]func(string) (protoreflect.ProtoMessage, error){
 	"subscriber.simmanager.sim.expirepackage": NewSimPackageExpire,
 	"subscriber.simmanager.sim.usage":         NewSimUsage,
 	"inventory.accounting.accounting.sync":    NewAccountingSync,
+	"messaging.mesh.node.online":              NewNodeOnline,
+	"messaging.mesh.node.offline":             NewNodeOffline,
+	"messaging.mesh.node.assign":              NewNodeAssign,
+	"messaging.mesh.node.release":             NewNodeRelease,
 }
 
 func WrapProto(f func(string) (protoreflect.ProtoMessage, error), data string) (*anypb.Any, error) {

--- a/utils/msgcli/internal/push/messages/node.go
+++ b/utils/msgcli/internal/push/messages/node.go
@@ -18,18 +18,13 @@ import (
 	u "github.com/ukama/ukama/systems/common/ukama"
 )
 
-const (
-	NodePort = 7070
-	MeshPort = 7071
-)
+
 
 func NewNodeOnline(data string) (protoreflect.ProtoMessage, error) {
 	nodeOnline := &epb.NodeOnlineEvent{
 		NodeId:       string(u.NewVirtualNodeId(u.NODE_ID_TYPE_TOWERNODE)),
 		NodeIp:       gofakeit.IPv4Address(),
-		NodePort:     NodePort,
 		MeshIp:       gofakeit.IPv4Address(),
-		MeshPort:     MeshPort,
 		MeshHostName: gofakeit.DomainName(),
 	}
 

--- a/utils/msgcli/internal/push/messages/node.go
+++ b/utils/msgcli/internal/push/messages/node.go
@@ -1,0 +1,95 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2023-present, Ukama Inc.
+ */
+
+package messages
+
+import (
+	"fmt"
+
+	"github.com/brianvoe/gofakeit/v7"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	epb "github.com/ukama/ukama/systems/common/pb/gen/events"
+	u "github.com/ukama/ukama/systems/common/ukama"
+)
+
+const (
+	NodePort = 7070
+	MeshPort = 7071
+)
+
+func NewNodeOnline(data string) (protoreflect.ProtoMessage, error) {
+	nodeOnline := &epb.NodeOnlineEvent{
+		NodeId:       string(u.NewVirtualNodeId(u.NODE_ID_TYPE_TOWERNODE)),
+		NodeIp:       gofakeit.IPv4Address(),
+		NodePort:     NodePort,
+		MeshIp:       gofakeit.IPv4Address(),
+		MeshPort:     MeshPort,
+		MeshHostName: gofakeit.DomainName(),
+	}
+
+	if data != "" {
+		err := updateProto(nodeOnline, data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update event proto: %w", err)
+		}
+	}
+
+	return nodeOnline, nil
+}
+
+func NewNodeOffline(data string) (protoreflect.ProtoMessage, error) {
+	nodeOffline := &epb.NodeOfflineEvent{
+		NodeId: string(u.NewVirtualNodeId(u.NODE_ID_TYPE_TOWERNODE)),
+	}
+
+	if data != "" {
+		err := updateProto(nodeOffline, data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update event proto: %w", err)
+		}
+	}
+
+	return nodeOffline, nil
+}
+
+func NewNodeAssign(data string) (protoreflect.ProtoMessage, error) {
+	nodeAssign := &epb.NodeAssignedEvent{
+		NodeId:  string(u.NewVirtualNodeId(u.NODE_ID_TYPE_TOWERNODE)),
+		Type:    u.NODE_ID_TYPE_TOWERNODE,
+		Network: gofakeit.UUID(),
+		Site:    gofakeit.UUID(),
+	}
+
+	if data != "" {
+		err := updateProto(nodeAssign, data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update event proto: %w", err)
+		}
+	}
+
+	return nodeAssign, nil
+}
+
+func NewNodeRelease(data string) (protoreflect.ProtoMessage, error) {
+	nodeRelease := &epb.NodeReleasedEvent{
+		NodeId:  string(u.NewVirtualNodeId(u.NODE_ID_TYPE_TOWERNODE)),
+		Type:    u.NODE_ID_TYPE_TOWERNODE,
+		Network: gofakeit.UUID(),
+		Site:    gofakeit.UUID(),
+	}
+
+	if data != "" {
+		err := updateProto(nodeRelease, data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update event proto: %w", err)
+		}
+	}
+
+	return nodeRelease, nil
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds new node event handling in `msgcli` and a script to push node events and update database records.
> 
>   - **Behavior**:
>     - Adds `push_node_event.sh` script to push node events and update node IDs in the database.
>     - Updates `msgcli` to handle new node events: `online`, `offline`, `assign`, and `release`.
>   - **Functions**:
>     - Adds `NewNodeOnline`, `NewNodeOffline`, `NewNodeAssign`, and `NewNodeRelease` in `node.go` for creating node event messages.
>     - Updates `RoutingMap` in `messages.go` to include new node events.
>   - **Misc**:
>     - Changes default organization in `push.go` from `ukamatestorg` to `ukama`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for 97c5dab5540b80de8d19b2d2a12b122c4d123373. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->