### PR TITLE
Added top-up email notification when new plan is added to sim

### DIFF
--- a/systems/common/emailTemplate/emailTemplate.go
+++ b/systems/common/emailTemplate/emailTemplate.go
@@ -1,11 +1,13 @@
 package emailTemplate
 
-const (
-	EmailTemplateSimAllocation = "sim-allocation"
-	EmailTemplateMemberInvite  = "member-invite"
-	EmailTemplateOrgInvite     = "org-invite"
-)
 
+
+const (
+    EmailTemplateSimAllocation     = "sim-allocation"
+    EmailTemplateMemberInvite      = "member-invite"
+    EmailTemplateOrgInvite         = "org-invite"
+    EmailTemplatePackageAddition   = "topup-plan"
+)
 type EmailTemplateKeys struct {
 	TemplateName string
 	Keys         []string
@@ -33,7 +35,22 @@ var EmailTemplateConfig = map[string]EmailTemplateKeys{
 			"ROLE",
 		},
 	},
+	EmailTemplatePackageAddition: { 
+        TemplateName: EmailTemplatePackageAddition,
+        Keys: []string{
+            "SUBSCRIBER",
+            "NETWORK",
+            "NAME",
+            "VOLUME",
+            "UNIT",
+            "ORG",
+            "START_DATE",
+            "END_DATE",
+        },
+    },
 }
+
+
 
 const (
 	EmailKeySubscriber = "SUBSCRIBER"
@@ -45,4 +62,6 @@ const (
 	EmailKeyOrg        = "ORG"
 	EmailKeyOwner      = "OWNER"
 	EmailKeyRole       = "ROLE"
+	EmailKeyStartDate  = "START_DATE"  
+    EmailKeyEndDate    = "END_DATE"   
 )

--- a/systems/common/emailTemplate/emailTemplate.go
+++ b/systems/common/emailTemplate/emailTemplate.go
@@ -6,7 +6,7 @@ const (
     EmailTemplateSimAllocation     = "sim-allocation"
     EmailTemplateMemberInvite      = "member-invite"
     EmailTemplateOrgInvite         = "org-invite"
-    EmailTemplatePackageAddition   = "topup-plan"
+    EmailTemplatePackageAddition   = "topup-plan" 
 )
 type EmailTemplateKeys struct {
 	TemplateName string
@@ -44,8 +44,12 @@ var EmailTemplateConfig = map[string]EmailTemplateKeys{
             "VOLUME",
             "UNIT",
             "ORG",
-            "START_DATE",
-            "END_DATE",
+			"AMOUNT",
+			"DURATION",
+			"PACKAGE",
+			"EXPIRATION_DATE",
+			"PACKAGES_COUNT",
+			"PACKAGES_DETAILS",
         },
     },
 }
@@ -62,6 +66,10 @@ const (
 	EmailKeyOrg        = "ORG"
 	EmailKeyOwner      = "OWNER"
 	EmailKeyRole       = "ROLE"
-	EmailKeyStartDate  = "START_DATE"  
-    EmailKeyEndDate    = "END_DATE"   
+	EmailKeyPackage    = "PACKAGE"
+	EmailKeyAmount     = "AMOUNT"
+	EmailKeyDuration   = "DURATION"
+	EmailKeyExpiration = "EXPIRATION_DATE"
+	EmailKeyPackagesCount = "PACKAGES_COUNT"
+	EmailKeyPackagesDetails = "PACKAGES_DETAILS"
 )

--- a/systems/notification/mailer/Dockerfile
+++ b/systems/notification/mailer/Dockerfile
@@ -4,5 +4,6 @@ COPY bin/mailer /usr/bin/mailer
 COPY templates/test-template.tmpl /templates/test-template.tmpl
 COPY templates/member-invite.tmpl /templates/member-invite.tmpl
 COPY templates/sim-allocation.tmpl /templates/sim-allocation.tmpl
+COPY templates/topup-plan.tmpl /templates/topup-plan.tmpl
 
 CMD ["/usr/bin/mailer"]

--- a/systems/notification/mailer/templates/topup-plan.tmpl
+++ b/systems/notification/mailer/templates/topup-plan.tmpl
@@ -1,0 +1,48 @@
+Subject: [{{ .Values.ORG}}] Top Up Successful
+
+MIME-version: 1.0;
+Content-Type: multipart/mixed;
+        boundary="XXXXboundary text"
+
+This is a multipart message in MIME format.
+
+--XXXXboundary text
+Content-Type: text/html; charset="UTF-8";
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body align="center">
+    <center>
+      <table border="0" cellpadding="0" cellspacing="0" width="100%" id="backgroundTable" align="center" style="background-color: #f5f5f5;">
+        <tr>
+          <td align="center" valign="top">
+            <table border="0" cellpadding="0" cellspacing="0" width="600" id="templateContainer" style="background-color: #ffffff; padding: 30px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+              <tr>
+                <td style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+                  <h1 style="color: #000000; font-size: 24px; margin-bottom: 20px;">Top Up Success!</h1>
+                  <p>Hi {{.Values.SUBSCRIBER}},</p>
+                  <p>
+                    You have successfully purchased a new data plan, and it has been activated. The {{.Values.PLAN_NAME}} (${{.Values.PRICE}} / {{.Values.DATA}} / {{.Values.DURATION}}) expires {{.Values.EXPIRATION_DATE}} EOD.
+                  </p>
+                  <p>Thanks,<br />The Ukama Team</p>
+                  <footer style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #ddd; font-size: 12px; color: #666; text-align: center;">
+                    <p>&copy; Ukama Inc. 1233 Quarry Lane #115, Pleasanton, CA 94566</p>
+                    <div style="margin-top: 10px;">
+                      <a href="https://x.com/ukamanetworks" target="_blank"><img src="https://img.icons8.com/color/48/000000/twitter--v1.png" alt="Twitter" style="width: 24px; height: 24px; margin: 0 10px; display: inline-block;"/></a>
+                      <a href="https://slack.com" target="_blank"><img src="https://img.icons8.com/color/48/000000/slack-new.png" alt="Slack" style="width: 24px; height: 24px; margin: 0 10px; display: inline-block;"/></a>
+                      <a href="https://www.linkedin.com/company/ukama" target="_blank"><img src="https://img.icons8.com/color/48/000000/linkedin.png" alt="LinkedIn" style="width: 24px; height: 24px; margin: 0 10px; display: inline-block;"/></a>
+                    </div>
+                  </footer>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </center>
+  </body>
+</html>

--- a/systems/notification/mailer/templates/topup-plan.tmpl
+++ b/systems/notification/mailer/templates/topup-plan.tmpl
@@ -1,5 +1,4 @@
-Subject: [{{ .Values.ORG}}] Top Up Successful
-
+Subject:[{{ .Values.ORG}}] Top Up Successful
 MIME-version: 1.0;
 Content-Type: multipart/mixed;
         boundary="XXXXboundary text"
@@ -26,8 +25,28 @@ Content-Type: text/html; charset="UTF-8";
                   <h1 style="color: #000000; font-size: 24px; margin-bottom: 20px;">Top Up Success!</h1>
                   <p>Hi {{.Values.SUBSCRIBER}},</p>
                   <p>
-                    You have successfully purchased a new data plan, and it has been activated. The {{.Values.PLAN_NAME}} (${{.Values.PRICE}} / {{.Values.DATA}} / {{.Values.DURATION}}) expires {{.Values.EXPIRATION_DATE}} EOD.
+                    You have successfully purchased {{.Values.PACKAGES_COUNT}} new data plans; they will be activated in the order of purchase. 
                   </p>
+                  
+                  <table width="100%" style="border-collapse: collapse; margin-bottom: 20px;">
+                    <thead>
+                      <tr style="background-color: #f2f2f2;">
+                        <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">Package Name</th>
+                        <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">Details</th>
+                        <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">Expiration</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                  <tr>
+                      <td style="border: 1px solid #ddd; padding: 8px;">{{.Values.PACKAGE}}</td>
+                      <td style="border: 1px solid #ddd; padding: 8px;">{{.Values.PACKAGES_DETAILS}}</td>
+                      <td style="border: 1px solid #ddd; padding: 8px;">{{.Values.EXPIRATION_DATE}}</td>
+                  </tr>
+                    </tbody>
+                  </table>
+                  
+                  <p>Please note that each queued data plan will only be activated once the previous one has been used up, or expires.</p>
+                  
                   <p>Thanks,<br />The Ukama Team</p>
                   <footer style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #ddd; font-size: 12px; color: #666; text-align: center;">
                     <p>&copy; Ukama Inc. 1233 Quarry Lane #115, Pleasanton, CA 94566</p>

--- a/systems/subscriber/sim-manager/pkg/server/sim_manager.go
+++ b/systems/subscriber/sim-manager/pkg/server/sim_manager.go
@@ -748,18 +748,19 @@ func (s *SimManagerServer) AddPackageForSim(ctx context.Context, req *pb.AddPack
 		return nil, err
 	}
 
+
 	err = s.mailerClient.SendEmail(cnotif.SendEmailReq{
 		To:           []string{remoteSubResp.Subscriber.Email},
 		TemplateName: emailTemplate.EmailTemplatePackageAddition,
 		Values: map[string]interface{}{
-			emailTemplate.EmailKeySubscriber: remoteSubResp.Subscriber.Name,
-			emailTemplate.EmailKeyNetwork:    netInfo.Name,
-			emailTemplate.EmailKeyName:       userInfos.Name,
-			emailTemplate.EmailKeyVolume:     fmt.Sprintf("%v", pkgInfo.DataVolume),
-			emailTemplate.EmailKeyUnit:       pkgInfo.DataUnit,
-			emailTemplate.EmailKeyOrg:        s.orgName,
-			emailTemplate.EmailKeyStartDate:  pkg.StartDate.Format(time.RFC3339),
-			emailTemplate.EmailKeyEndDate:    pkg.EndDate.Format(time.RFC3339),
+			emailTemplate.EmailKeySubscriber:       remoteSubResp.Subscriber.Name,
+			emailTemplate.EmailKeyNetwork:         netInfo.Name,
+			emailTemplate.EmailKeyName:            userInfos.Name,
+			emailTemplate.EmailKeyOrg:             s.orgName,
+			emailTemplate.EmailKeyPackagesCount:  fmt.Sprintf("%v", len(packages)),
+			emailTemplate.EmailKeyPackagesDetails: fmt.Sprintf("$%.2f / %v %s / %d days", pkgInfo.Amount, pkgInfo.DataVolume, pkgInfo.DataUnit, pkgInfo.Duration),
+			emailTemplate.EmailKeyExpiration: pkg.EndDate.Format("January 2, 2006"),
+			emailTemplate.EmailKeyPackage:pkgInfo.Name,   
 		},
 	})
 	if err != nil {

--- a/systems/subscriber/sim-manager/pkg/server/sim_manager.go
+++ b/systems/subscriber/sim-manager/pkg/server/sim_manager.go
@@ -757,7 +757,7 @@ func (s *SimManagerServer) AddPackageForSim(ctx context.Context, req *pb.AddPack
 			emailTemplate.EmailKeyNetwork:         netInfo.Name,
 			emailTemplate.EmailKeyName:            userInfos.Name,
 			emailTemplate.EmailKeyOrg:             s.orgName,
-			emailTemplate.EmailKeyPackagesCount:  fmt.Sprintf("%v", len(packages)),
+			emailTemplate.EmailKeyPackagesCount:  fmt.Sprintf("%v", len(packages) + 1),
 			emailTemplate.EmailKeyPackagesDetails: fmt.Sprintf("$%.2f / %v %s / %d days", pkgInfo.Amount, pkgInfo.DataVolume, pkgInfo.DataUnit, pkgInfo.Duration),
 			emailTemplate.EmailKeyExpiration: pkg.EndDate.Format("January 2, 2006"),
 			emailTemplate.EmailKeyPackage:pkgInfo.Name,   


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds email notification for new plan addition to SIM, including new template and tests.
> 
>   - **Behavior**:
>     - Adds email notification for new plan addition to SIM in `AddPackageForSim()` in `sim_manager.go`.
>     - Sends email using new template `topup-plan.tmpl`.
>   - **Email Templates**:
>     - Adds `EmailTemplatePackageAddition` to `emailTemplate.go`.
>     - New template `topup-plan.tmpl` added for email notifications.
>   - **Docker**:
>     - Updates `Dockerfile` to include `topup-plan.tmpl`.
>   - **Tests**:
>     - Updates `TestSimManagerServer_AddPackageForSim` in `sim_manager_test.go` to test new email notification feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for 5c3f937ae8ae032196490df76f4338cb4b83dfcc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->