### PR TITLE
Slack workflows daily notifications. Fixes #896

### DIFF
--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -10,7 +10,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Notify slack's github channel for failling workflows 
+      - name: Notify slack's github channel for failing workflows 
         if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
         uses: ravsamhq/notify-slack-action@v2
         with:

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT-0
+
+name: slack notify
+on:
+  workflow_run:
+    workflows: ["*daily.yaml"]
+    types: [completed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify slack's github channel for failling workflows 
+        if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ github.event.workflow_run.conclusion }}
+          notification_title: >
+            ${{github.event.workflow_run.name}} failed on ${{github.event.workflow_run.head_branch}} -
+            <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>
+          message_format: |
+            Result: ${{github.event.workflow_run.conclusion}}
+            Run: ${{github.event.workflow_run.run_number}}
+            Branch: <${{github.server_url}}/${{github.repository}}/tree/${{github.event.workflow_run.head_branch}}|${{github.repository}}/${{github.event.workflow_run.head_branch}}>
+          footer: "Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_URL }}

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Notify slack's github channel for failing workflows 
         if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
-        uses: ravsamhq/notify-slack-action@v2.5.0
+        uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ github.event.workflow_run.conclusion }}
           notification_title: >

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -3,7 +3,7 @@
 name: slack notify
 on:
   workflow_run:
-    workflows: ["*daily.yaml"]
+    workflows: [daily*]
     types: [completed]
 
 jobs:

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -10,7 +10,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Notify slack's github channel for failing workflows 
+      - name: Notify slack's github channel for failing or timed out workflows
         if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
         uses: ravsamhq/notify-slack-action@v2
         with:
@@ -24,4 +24,4 @@ jobs:
             Branch: <${{github.server_url}}/${{github.repository}}/tree/${{github.event.workflow_run.head_branch}}|${{github.repository}}/${{github.event.workflow_run.head_branch}}>
           footer: "Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>"
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Notify slack's github channel for failing workflows 
         if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@v2.5.0
         with:
           status: ${{ github.event.workflow_run.conclusion }}
           notification_title: >


### PR DESCRIPTION
This PR fixes #896  and closes #896  by providing the following:

- Add an additional workflows that publish failed workflows reports in appropriate ukama's slack channel.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a GitHub Actions workflow to notify Slack about failed or timed-out daily workflows.
> 
>   - **New Workflow**:
>     - Adds `.github/workflows/slack.yaml` to notify Slack on failed or timed-out workflows.
>     - Triggered by completion of workflows named `daily*`.
>   - **Notification Details**:
>     - Uses `ravsamhq/notify-slack-action@v2` to send notifications.
>     - Includes workflow name, branch, and link to failure in notification.
>     - Sends to Slack channel using `SLACK_WEBHOOK_URL` secret.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for edefb1b2029c5e38fd4e01812d4bbf47169b74cc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->