### PR TITLE
Hot fix on dcontroller linting

### DIFF
--- a/testing/services/dummy/dcontroller/pkg/server/dcontroller.go
+++ b/testing/services/dummy/dcontroller/pkg/server/dcontroller.go
@@ -195,7 +195,7 @@ func (s *DControllerServer) UpdateMetrics(ctx context.Context, req *pb.UpdateMet
 		log.Infof("Updated profile to %v for site %s", profile, siteId)
 	}
 
-	if req.PortUpdates != nil && len(req.PortUpdates) > 0 {
+	if len(req.PortUpdates) > 0 {
 		for _, portUpdate := range req.PortUpdates {
 			portNumber := int(portUpdate.PortNumber)
 			portStatus := portUpdate.Status


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove redundant nil check on `req.PortUpdates` in `UpdateMetrics()` in `dcontroller.go`.
> 
>   - **Code Fix**:
>     - Remove redundant nil check on `req.PortUpdates` in `UpdateMetrics()` in `dcontroller.go`. Now only checks `len(req.PortUpdates) > 0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for 6dee6557fe98463c0ddeb7a7fd031c078c521e5f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->