### PR TITLE
Dnode service fixes

### DIFF
--- a/systems/console-bff/subscriptions/resolvers/resolver.ts
+++ b/systems/console-bff/subscriptions/resolvers/resolver.ts
@@ -156,7 +156,7 @@ class SubscriptionsResolvers {
     @Arg("data") data: SubMetricsStatInput
   ): Promise<LatestMetricSubRes> {
     const store = openStore();
-    await addInStore(store, `${data.userId}-${payload.type}-${data.from}`, 0);
+    await addInStore(store, `${data.userId}-${data.type}-${data.from}`, 0);
     await store.close();
     return payload;
   }

--- a/testing/services/dummy/dnode/server/main.go
+++ b/testing/services/dummy/dnode/server/main.go
@@ -132,7 +132,6 @@ func (s *Server) updateHandler(w http.ResponseWriter, r *http.Request) {
 	if cenums.ParseScenarioType(scenario) == cenums.SCENARIO_BACKHAUL_DOWN ||
 		cenums.ParseScenarioType(scenario) == cenums.SCENARIO_NODE_OFF {
 		log.Printf("Scenario is: %s, which leads to coroutine shutdown.", scenario)
-		updateChan, exists := s.coroutines[nodeID.String()]
 		if exists {
 			close(updateChan)
 			delete(s.coroutines, nodeID.String())

--- a/testing/services/dummy/dnode/server/main.go
+++ b/testing/services/dummy/dnode/server/main.go
@@ -116,18 +116,6 @@ func (s *Server) updateHandler(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if cenums.ParseScenarioType(scenario) == cenums.SCENARIO_BACKHAUL_DOWN ||
-		cenums.ParseScenarioType(scenario) == cenums.SCENARIO_NODE_OFF {
-		log.Printf("Scenario is: %s, which leads to coroutine shutdown.", scenario)
-		updateChan, exists := s.coroutines[nodeID.String()]
-		if exists {
-			close(updateChan)
-			delete(s.coroutines, nodeID.String())
-		}
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-
 	updateChan, exists := s.coroutines[nodeID.String()]
 	if !exists {
 		http.Error(w, "Coroutine not found", http.StatusNotFound)
@@ -141,6 +129,15 @@ func (s *Server) updateHandler(w http.ResponseWriter, r *http.Request) {
 		Scenario: cenums.ParseScenarioType(scenario),
 	}
 
+	if cenums.ParseScenarioType(scenario) == cenums.SCENARIO_BACKHAUL_DOWN ||
+		cenums.ParseScenarioType(scenario) == cenums.SCENARIO_NODE_OFF {
+		log.Printf("Scenario is: %s, which leads to coroutine shutdown.", scenario)
+		updateChan, exists := s.coroutines[nodeID.String()]
+		if exists {
+			close(updateChan)
+			delete(s.coroutines, nodeID.String())
+		}
+	}
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte("NodeId: " + nodeID.String()))
 	if err != nil {

--- a/testing/services/dummy/dnode/utils/worker.go
+++ b/testing/services/dummy/dnode/utils/worker.go
@@ -26,10 +26,27 @@ func Worker(id string, updateChan chan config.WMessage, initial config.WMessage)
 
 	fmt.Printf("Coroutine %s started with: %d, %s\n", id, profile, scenario)
 
+	// cleanup := func() {
+    //     fmt.Printf("Shutting down coroutine %s with scenario: %s\n", id, scenario)
+    //     for _, kpi := range kpis.KPIs {
+    //         prometheus.Unregister(kpi.KPI).
+    //     }
+    // }
+
+	cleanup := func() {
+		fmt.Printf("Shutting down coroutine %s with scenario: %s\n", id, scenario)
+		labels := prometheus.Labels{"nodeid": id}
+		for _, kpi := range kpis.KPIs {
+			// Delete removes the metric for this specific label combination.
+			kpi.KPI.Delete(labels)
+		}
+	}
+
 	for {
 		count += 0.1
 		time.Sleep(1 * time.Second)
 		select {
+
 		case msg, ok := <-updateChan:
 			if !ok {
 				fmt.Printf("Coroutine %s with Scenario is: %s, which leads to coroutine shutdown.", id, scenario)
@@ -37,6 +54,11 @@ func Worker(id string, updateChan chan config.WMessage, initial config.WMessage)
 			}
 			profile = msg.Profile
 			scenario = msg.Scenario
+			if scenario == cenums.SCENARIO_BACKHAUL_DOWN || scenario == cenums.SCENARIO_NODE_OFF {
+				cleanup()
+				fmt.Printf("Coroutine %s with Scenario is: %s, which leads to coroutine shutdown.", id, scenario)
+				return
+			}
 			fmt.Printf("Coroutine %s updated args: %d, %s\n", id, profile, scenario)
 		default:
 		}
@@ -54,11 +76,11 @@ func Worker(id string, updateChan chan config.WMessage, initial config.WMessage)
 			default:
 				switch profile {
 				case cenums.PROFILE_MIN:
-					values[kpi.Key] = kpi.Min + rand.Float64()*(kpi.Normal-kpi.Min)*0.1
+					values[kpi.Key] = kpi.Min + rand.Float64()*(kpi.Normal-kpi.Min)*0.3
 				case cenums.PROFILE_MAX:
-					values[kpi.Key] = kpi.Normal + rand.Float64()*(kpi.Max-kpi.Normal)*0.1
+					values[kpi.Key] = kpi.Normal + rand.Float64()*(kpi.Max-kpi.Normal)*0.3
 				default:
-					values[kpi.Key] = kpi.Min + rand.Float64()*(kpi.Normal-kpi.Min)*0.1
+					values[kpi.Key] = kpi.Min + rand.Float64()*(kpi.Normal-kpi.Min)*0.3
 				}
 			}
 

--- a/testing/services/dummy/dnode/utils/worker.go
+++ b/testing/services/dummy/dnode/utils/worker.go
@@ -19,31 +19,21 @@ import (
 )
 
 func Worker(id string, updateChan chan config.WMessage, initial config.WMessage) {
-	count := 1.0
 	kpis := initial.Kpis
 	profile := initial.Profile
 	scenario := initial.Scenario
 
 	fmt.Printf("Coroutine %s started with: %d, %s\n", id, profile, scenario)
 
-	// cleanup := func() {
-    //     fmt.Printf("Shutting down coroutine %s with scenario: %s\n", id, scenario)
-    //     for _, kpi := range kpis.KPIs {
-    //         prometheus.Unregister(kpi.KPI).
-    //     }
-    // }
-
 	cleanup := func() {
 		fmt.Printf("Shutting down coroutine %s with scenario: %s\n", id, scenario)
 		labels := prometheus.Labels{"nodeid": id}
 		for _, kpi := range kpis.KPIs {
-			// Delete removes the metric for this specific label combination.
 			kpi.KPI.Delete(labels)
 		}
 	}
 
 	for {
-		count += 0.1
 		time.Sleep(1 * time.Second)
 		select {
 
@@ -71,8 +61,9 @@ func Worker(id string, updateChan chan config.WMessage, initial config.WMessage)
 		for _, kpi := range kpis.KPIs {
 			switch kpi.Key {
 			case "unit_uptime":
-				values[kpi.Key] = count
-			// TODO: Can handle different scenario cases here
+				kpi.KPI.With(labels).Inc()
+				continue
+			// TODO: Can handle different scenario cases here for different KPIs
 			default:
 				switch profile {
 				case cenums.PROFILE_MIN:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix key construction in `resolver.ts` and refactor coroutine shutdown logic in `main.go` and `worker.go` for `dnode` service.
> 
>   - **Resolvers**:
>     - Fix key construction in `getMetricStatSub()` in `resolver.ts` by changing `${data.userId}-${payload.type}-${data.from}` to `${data.userId}-${data.type}-${data.from}`.
>   - **Server**:
>     - Refactor `updateHandler()` in `main.go` to move coroutine shutdown logic after the `updateChan` existence check.
>     - Remove redundant `count` variable in `Worker()` in `worker.go`.
>     - Add `cleanup()` function in `Worker()` in `worker.go` to handle coroutine shutdown and KPI deletion.
>     - Adjust KPI value calculation in `Worker()` to use `0.3` instead of `0.1` for `PROFILE_MIN` and `PROFILE_MAX` scenarios.
>     - Add coroutine shutdown logic for `SCENARIO_BACKHAUL_DOWN` and `SCENARIO_NODE_OFF` scenarios in `Worker()` in `worker.go`.
>   - **Misc**:
>     - Minor logging adjustments in `main.go` and `worker.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for e53f0ba653047b559857cc180b20be8ce2caf3d6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->