### PR TITLE
Common/Rest: Update ukama agent usages client for Sim Manager. Fixes #963

### DIFF
--- a/systems/common/rest/client/ukamaagent/ukama_agent.go
+++ b/systems/common/rest/client/ukamaagent/ukama_agent.go
@@ -84,8 +84,8 @@ func (o *ukamaAgentClient) GetUsages(iccid, cdrType, from, to, region string) (m
 
 	usage := UkamaSimUsage{}
 
-	resp, err := o.R.Get(o.u.String() + UkamaSimsEndpoint + "/usage/" +
-		fmt.Sprintf("?iccid=%s&cdr_type=%s&from=%s&to=%s&region=%s", iccid, cdrType, from, to, region))
+	resp, err := o.R.Get(o.u.String() + UkamaSimsEndpoint +
+		fmt.Sprintf("/%s/period?start_time=%s&end_time=%s", iccid, from, to))
 	if err != nil {
 		log.Errorf("GetSim usages failure. error: %s", err.Error())
 

--- a/systems/common/rest/client/ukamaagent/ukama_agent.go
+++ b/systems/common/rest/client/ukamaagent/ukama_agent.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 
 	"github.com/ukama/ukama/systems/common/rest/client"
+	"github.com/ukama/ukama/systems/common/validation"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -84,8 +85,22 @@ func (o *ukamaAgentClient) GetUsages(iccid, cdrType, from, to, region string) (m
 
 	usage := UkamaSimUsage{}
 
+	frm, err := validation.FromString(from)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid format for from: %s. Error: %s", from, err)
+	}
+
+	startTime := frm.Unix()
+
+	t, err := validation.FromString(to)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid format for to: %s. Error: %s", to, err)
+	}
+
+	endTime := t.Unix()
+
 	resp, err := o.R.Get(o.u.String() + UkamaSimsEndpoint +
-		fmt.Sprintf("/%s/period?start_time=%s&end_time=%s", iccid, from, to))
+		fmt.Sprintf("/%s/period?start_time=%d&end_time=%d", iccid, startTime, endTime))
 	if err != nil {
 		log.Errorf("GetSim usages failure. error: %s", err.Error())
 
@@ -100,9 +115,8 @@ func (o *ukamaAgentClient) GetUsages(iccid, cdrType, from, to, region string) (m
 	}
 
 	log.Infof("ukama data usage (of type %T): %+v", usage.Usage, usage.Usage)
-	log.Infof("ukama data cost (of type %T): %+v", usage.Cost, usage.Cost)
 
-	return usage.Usage, usage.Cost, nil
+	return map[string]any{iccid: usage.Usage}, nil, nil
 }
 
 func (o *ukamaAgentClient) ActivateSim(req client.AgentRequestData) error {
@@ -155,8 +169,7 @@ type UkamaSim struct {
 }
 
 type UkamaSimUsage struct {
-	Usage map[string]any `json:"usage"`
-	Cost  map[string]any `json:"cost"`
+	Usage uint64 `json:"usage,string"`
 }
 
 type UkamaSimInfo struct {

--- a/systems/common/rest/client/ukamaagent/ukama_agent_test.go
+++ b/systems/common/rest/client/ukamaagent/ukama_agent_test.go
@@ -137,8 +137,8 @@ func TestUkamaClient_GetUsages(t *testing.T) {
 	t.Run("UsageFound", func(tt *testing.T) {
 		mockTransport := func(req *http.Request) *http.Response {
 			// Test request parameters
-			assert.Equal(tt, req.URL.String(), fmt.Sprintf("%s?iccid=%s&cdr_type=%s&from=%s&to=%s&region=%s",
-				ukamaagent.UkamaSimsEndpoint+"/usage/", testIccid, cdrType, from, to, region))
+			assert.Equal(tt, req.URL.String(), ukamaagent.UkamaSimsEndpoint+
+				fmt.Sprintf("/%s/period?start_time=%s&end_time=%s", testIccid, from, to))
 
 			// fake usage usage
 			usage := `{"usage":{"890000000000000001234": 28901234567}, "cost":{"890000000000000001234":100.99}}`
@@ -170,8 +170,8 @@ func TestUkamaClient_GetUsages(t *testing.T) {
 
 	t.Run("InvalidResponsePayload", func(tt *testing.T) {
 		mockTransport := func(req *http.Request) *http.Response {
-			assert.Equal(tt, req.URL.String(), fmt.Sprintf("%s?iccid=%s&cdr_type=%s&from=%s&to=%s&region=%s",
-				ukamaagent.UkamaSimsEndpoint+"/usage/", testIccid, cdrType, from, to, region))
+			assert.Equal(tt, req.URL.String(), ukamaagent.UkamaSimsEndpoint+
+				fmt.Sprintf("/%s/period?start_time=%s&end_time=%s", testIccid, from, to))
 
 			return &http.Response{
 				StatusCode: 200,
@@ -193,8 +193,8 @@ func TestUkamaClient_GetUsages(t *testing.T) {
 
 	t.Run("RequestFailure", func(tt *testing.T) {
 		mockTransport := func(req *http.Request) *http.Response {
-			assert.Equal(tt, req.URL.String(), fmt.Sprintf("%s?iccid=%s&cdr_type=%s&from=%s&to=%s&region=%s",
-				ukamaagent.UkamaSimsEndpoint+"/usage/", testIccid, cdrType, from, to, region))
+			assert.Equal(tt, req.URL.String(), ukamaagent.UkamaSimsEndpoint+
+				fmt.Sprintf("/%s/period?start_time=%s&end_time=%s", testIccid, from, to))
 
 			return nil
 		}

--- a/systems/common/rest/client/ukamaagent/ukama_agent_test.go
+++ b/systems/common/rest/client/ukamaagent/ukama_agent_test.go
@@ -31,12 +31,17 @@ const (
 	cost      = 100.99
 )
 
-var req = client.AgentRequestData{
-	Iccid:     testIccid,
-	Imsi:      testImsi,
-	NetworkId: "5248eefa-23a0-4222-b80b-e1af5047eaf8",
-	SimId:     "0ba2f8d9-e888-4071-aa09-7300daa986aa",
-}
+var (
+	req = client.AgentRequestData{
+		Iccid:     testIccid,
+		Imsi:      testImsi,
+		NetworkId: "5248eefa-23a0-4222-b80b-e1af5047eaf8",
+		SimId:     "0ba2f8d9-e888-4071-aa09-7300daa986aa",
+	}
+
+	startTime = 1669852800
+	endTime   = 1701388800
+)
 
 func TestUkamaClient_GetSimInfo(t *testing.T) {
 	t.Run("SimFound", func(tt *testing.T) {
@@ -138,10 +143,10 @@ func TestUkamaClient_GetUsages(t *testing.T) {
 		mockTransport := func(req *http.Request) *http.Response {
 			// Test request parameters
 			assert.Equal(tt, req.URL.String(), ukamaagent.UkamaSimsEndpoint+
-				fmt.Sprintf("/%s/period?start_time=%s&end_time=%s", testIccid, from, to))
+				fmt.Sprintf("/%s/period?start_time=%d&end_time=%d", testIccid, startTime, endTime))
 
 			// fake usage usage
-			usage := `{"usage":{"890000000000000001234": 28901234567}, "cost":{"890000000000000001234":100.99}}`
+			usage := `{"usage":28901234567}`
 
 			// Send mock response
 			return &http.Response{
@@ -160,18 +165,16 @@ func TestUkamaClient_GetUsages(t *testing.T) {
 		// so that the test stays a unit test e.g no server/network call.
 		testUkamaClient.R.C.SetTransport(RoundTripFunc(mockTransport))
 
-		u, c, err := testUkamaClient.GetUsages(testIccid, cdrType, from, to, region)
+		u, _, err := testUkamaClient.GetUsages(testIccid, cdrType, from, to, region)
 
 		assert.NoError(tt, err)
 		assert.NotNil(tt, u[testIccid])
-		assert.NotNil(tt, c[testIccid])
-		assert.Equal(tt, 100.99, c[testIccid])
 	})
 
 	t.Run("InvalidResponsePayload", func(tt *testing.T) {
 		mockTransport := func(req *http.Request) *http.Response {
 			assert.Equal(tt, req.URL.String(), ukamaagent.UkamaSimsEndpoint+
-				fmt.Sprintf("/%s/period?start_time=%s&end_time=%s", testIccid, from, to))
+				fmt.Sprintf("/%s/period?start_time=%d&end_time=%d", testIccid, startTime, endTime))
 
 			return &http.Response{
 				StatusCode: 200,
@@ -194,7 +197,7 @@ func TestUkamaClient_GetUsages(t *testing.T) {
 	t.Run("RequestFailure", func(tt *testing.T) {
 		mockTransport := func(req *http.Request) *http.Response {
 			assert.Equal(tt, req.URL.String(), ukamaagent.UkamaSimsEndpoint+
-				fmt.Sprintf("/%s/period?start_time=%s&end_time=%s", testIccid, from, to))
+				fmt.Sprintf("/%s/period?start_time=%d&end_time=%d", testIccid, startTime, endTime))
 
 			return nil
 		}

--- a/systems/ukama-agent/api-gateway/pkg/rest/router.go
+++ b/systems/ukama-agent/api-gateway/pkg/rest/router.go
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2023-present, Ukama Inc.
  */
- 
+
 package rest
 
 import (
@@ -15,16 +15,17 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/loopfz/gadgeto/tonic"
 	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
-	"github.com/ukama/ukama/systems/common/config"
 	"github.com/wI2L/fizz"
+	"github.com/wI2L/fizz/openapi"
 
+	"github.com/ukama/ukama/systems/common/config"
 	"github.com/ukama/ukama/systems/common/rest"
 	"github.com/ukama/ukama/systems/ukama-agent/api-gateway/cmd/version"
 	"github.com/ukama/ukama/systems/ukama-agent/api-gateway/pkg"
 	"github.com/ukama/ukama/systems/ukama-agent/api-gateway/pkg/client"
+
+	log "github.com/sirupsen/logrus"
 	pb "github.com/ukama/ukama/systems/ukama-agent/asr/pb/gen"
-	"github.com/wI2L/fizz/openapi"
 )
 
 const ORG_URL_PARAMETER = "org"

--- a/systems/ukama-agent/cdr/pkg/server/cdr.go
+++ b/systems/ukama-agent/cdr/pkg/server/cdr.go
@@ -12,15 +12,16 @@ import (
 	"sort"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-	mb "github.com/ukama/ukama/systems/common/msgBusServiceClient"
 	"github.com/ukama/ukama/systems/common/msgbus"
-	epb "github.com/ukama/ukama/systems/common/pb/gen/events"
 	"github.com/ukama/ukama/systems/common/sql"
-	dsql "github.com/ukama/ukama/systems/common/sql"
-	pb "github.com/ukama/ukama/systems/ukama-agent/cdr/pb/gen"
 	"github.com/ukama/ukama/systems/ukama-agent/cdr/pkg"
 	"github.com/ukama/ukama/systems/ukama-agent/cdr/pkg/db"
+
+	log "github.com/sirupsen/logrus"
+	mb "github.com/ukama/ukama/systems/common/msgBusServiceClient"
+	epb "github.com/ukama/ukama/systems/common/pb/gen/events"
+	dsql "github.com/ukama/ukama/systems/common/sql"
+	pb "github.com/ukama/ukama/systems/ukama-agent/cdr/pb/gen"
 )
 
 type CDRServer struct {

--- a/systems/ukama-agent/cdr/pkg/server/cdr_test.go
+++ b/systems/ukama-agent/cdr/pkg/server/cdr_test.go
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2023-present, Ukama Inc.
  */
- 
+
 package server
 
 import (
@@ -18,13 +18,13 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/ukama/ukama/systems/common/ukama"
+	"github.com/ukama/ukama/systems/common/uuid"
+	"github.com/ukama/ukama/systems/ukama-agent/cdr/pkg/db"
 
 	cmocks "github.com/ukama/ukama/systems/common/mocks"
 	epb "github.com/ukama/ukama/systems/common/pb/gen/events"
-	"github.com/ukama/ukama/systems/common/uuid"
 	mocks "github.com/ukama/ukama/systems/ukama-agent/cdr/mocks"
 	pb "github.com/ukama/ukama/systems/ukama-agent/cdr/pb/gen"
-	"github.com/ukama/ukama/systems/ukama-agent/cdr/pkg/db"
 )
 
 var cdr = db.CDR{

--- a/testing/services/dummy/docker-compose.yml
+++ b/testing/services/dummy/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     networks:
       - ukama-net
 
-  api-gateway:
+  api-gateway-dummy:
     build: ./api-gateway
     ports:
       - 8083:8080


### PR DESCRIPTION
This PR fixes #963  and closes #963  by providing the following: 

-  Add conversions from RFC339 dates to unix timestapps
-  Update ukama agent client in common/rest for sim manager