### PR TITLE
Subscriber/sim-manager: use initClient for ukamaAgentHost lookups. Fixes #959

### DIFF
--- a/systems/subscriber/docker-compose.yml
+++ b/systems/subscriber/docker-compose.yml
@@ -70,7 +70,6 @@ services:
    - SIMMANAGER_SERVICE_HOST=simmanager
    - SIMMANAGER_SERVICE_PORT=9090
    - OPERATORAGENT=http://api-gateway-operator-agent:8080
-   - UKAMAAGENT=http://api-gateway-ukama-agent:8080
    - HTTP_INITCLIENT=http://api-gateway-init:8080
    - HTTP_NUCLEUSCLIENT=http://api-gateway-nucleus:8080
   restart: always

--- a/systems/subscriber/sim-manager/cmd/server/main.go
+++ b/systems/subscriber/sim-manager/cmd/server/main.go
@@ -36,7 +36,6 @@ import (
 	cnotif "github.com/ukama/ukama/systems/common/rest/client/notification"
 	cnuc "github.com/ukama/ukama/systems/common/rest/client/nucleus"
 	creg "github.com/ukama/ukama/systems/common/rest/client/registry"
-
 	generated "github.com/ukama/ukama/systems/subscriber/sim-manager/pb/gen"
 )
 
@@ -73,7 +72,8 @@ func initConfig() {
 		}
 	}
 
-	log.Debugf("\nService: %s DB Config: %+v Service: %+v MsgClient Config %+v", pkg.ServiceName, serviceConfig.DB, serviceConfig.Service, serviceConfig.MsgClient)
+	log.Debugf("\nService: %s DB Config: %+v Service: %+v MsgClient Config %+v",
+		pkg.ServiceName, serviceConfig.DB, serviceConfig.Service, serviceConfig.MsgClient)
 
 	pkg.IsDebugMode = serviceConfig.DebugMode
 }
@@ -108,19 +108,28 @@ func runGrpcServer(gormDB sql.Db) {
 
 	log.Debugf("MessageBus Client is %+v", mbClient)
 
-	regUrl, err := ic.GetHostUrl(ic.CreateHostString(serviceConfig.OrgName, "registry"), serviceConfig.Http.InitClient, &serviceConfig.OrgName, serviceConfig.DebugMode)
+	regUrl, err := ic.GetHostUrl(ic.CreateHostString(serviceConfig.OrgName, "registry"),
+		serviceConfig.Http.InitClient, &serviceConfig.OrgName, serviceConfig.DebugMode)
 	if err != nil {
 		log.Errorf("Failed to resolve registry address: %v", err)
 	}
 
-	dataplanUrl, err := ic.GetHostUrl(ic.CreateHostString(serviceConfig.OrgName, "dataplan"), serviceConfig.Http.InitClient, &serviceConfig.OrgName, serviceConfig.DebugMode)
+	dataplanUrl, err := ic.GetHostUrl(ic.CreateHostString(serviceConfig.OrgName, "dataplan"),
+		serviceConfig.Http.InitClient, &serviceConfig.OrgName, serviceConfig.DebugMode)
 	if err != nil {
 		log.Errorf("Failed to resolve dataplan address: %v", err)
 	}
 
-	notificationUrl, err := ic.GetHostUrl(ic.CreateHostString(serviceConfig.OrgName, "notification"), serviceConfig.Http.InitClient, &serviceConfig.OrgName, serviceConfig.DebugMode)
+	notificationUrl, err := ic.GetHostUrl(ic.CreateHostString(serviceConfig.OrgName, "notification"),
+		serviceConfig.Http.InitClient, &serviceConfig.OrgName, serviceConfig.DebugMode)
 	if err != nil {
 		log.Errorf("Failed to resolve notification address: %v", err)
+	}
+
+	ukamaAgentUrl, err := ic.GetHostUrl(ic.CreateHostString(serviceConfig.OrgName, "ukamaagent"),
+		serviceConfig.Http.InitClient, &serviceConfig.OrgName, serviceConfig.DebugMode)
+	if err != nil {
+		log.Errorf("Failed to resolve ukama agent address: %v", err)
 	}
 
 	netClient := creg.NewNetworkClient(regUrl.String())
@@ -134,7 +143,7 @@ func runGrpcServer(gormDB sql.Db) {
 		db.NewSimRepo(gormDB),
 		db.NewPackageRepo(gormDB),
 		adapters.NewAgentFactory(serviceConfig.TestAgent, serviceConfig.OperatorAgent,
-			serviceConfig.UkamaAgent, serviceConfig.Timeout, pkg.IsDebugMode),
+			ukamaAgentUrl.String(), serviceConfig.Timeout, pkg.IsDebugMode),
 		pckgClient,
 		providers.NewSubscriberRegistryClientProvider(serviceConfig.Registry, serviceConfig.Timeout),
 		providers.NewSimPoolClientProvider(serviceConfig.SimPool, serviceConfig.Timeout),

--- a/systems/subscriber/sim-manager/pkg/config.go
+++ b/systems/subscriber/sim-manager/pkg/config.go
@@ -37,7 +37,6 @@ type Config struct {
 	Registry          string            `default:"registry:9090"`
 	TestAgent         string            `default:"testagent:9090"`
 	OperatorAgent     string            `default:"http://operator-agent:8080"`
-	UkamaAgent        string            `default:"http://ukama-agent:8080"`
 	Service           *config.Service
 	Key               string
 	OrgId             string


### PR DESCRIPTION
This PR fixes #959  and closes #959   by providing the following:

- Remove static URL for ukama agent
- Add InitClient lookups for ukama agent host
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces static Ukama agent URL with dynamic InitClient lookup in `sim-manager`.
> 
>   - **Behavior**:
>     - Removes static URL for Ukama agent in `docker-compose.yml`.
>     - Implements dynamic host lookup for Ukama agent using `InitClient` in `main.go`.
>   - **Configuration**:
>     - Removes `UkamaAgent` from `Config` struct in `config.go`.
>   - **Misc**:
>     - Minor formatting changes in `main.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for c73625c15dcf30278a55ffe8c7671d4bcd4d8122. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->