### PR TITLE
subscriber/sim-manager: update sim metrics computations. Fixes #832

### DIFF
--- a/systems/subscriber/sim-manager/mocks/SimRepo.go
+++ b/systems/subscriber/sim-manager/mocks/SimRepo.go
@@ -174,55 +174,6 @@ func (_m *SimRepo) GetBySubscriber(subscriberID uuid.UUID) ([]db.Sim, error) {
 	return r0, r1
 }
 
-// GetSimMetrics provides a mock function with no fields
-func (_m *SimRepo) GetSimMetrics() (int64, int64, int64, int64, error) {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetSimMetrics")
-	}
-
-	var r0 int64
-	var r1 int64
-	var r2 int64
-	var r3 int64
-	var r4 error
-	if rf, ok := ret.Get(0).(func() (int64, int64, int64, int64, error)); ok {
-		return rf()
-	}
-	if rf, ok := ret.Get(0).(func() int64); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int64)
-	}
-
-	if rf, ok := ret.Get(1).(func() int64); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Get(1).(int64)
-	}
-
-	if rf, ok := ret.Get(2).(func() int64); ok {
-		r2 = rf()
-	} else {
-		r2 = ret.Get(2).(int64)
-	}
-
-	if rf, ok := ret.Get(3).(func() int64); ok {
-		r3 = rf()
-	} else {
-		r3 = ret.Get(3).(int64)
-	}
-
-	if rf, ok := ret.Get(4).(func() error); ok {
-		r4 = rf()
-	} else {
-		r4 = ret.Error(4)
-	}
-
-	return r0, r1, r2, r3, r4
-}
-
 // List provides a mock function with given fields: iccid, imsi, SubscriberId, networkId, simType, status, TrafficPolicy, IsPhysical, count, sort
 func (_m *SimRepo) List(iccid string, imsi string, SubscriberId string, networkId string, simType ukama.SimType, status ukama.SimStatus, TrafficPolicy uint32, IsPhysical bool, count uint32, sort bool) ([]db.Sim, error) {
 	ret := _m.Called(iccid, imsi, SubscriberId, networkId, simType, status, TrafficPolicy, IsPhysical, count, sort)

--- a/systems/subscriber/sim-manager/pb/gen/sim_manager.validator.pb.go
+++ b/systems/subscriber/sim-manager/pb/gen/sim_manager.validator.pb.go
@@ -7,10 +7,10 @@ import (
 	fmt "fmt"
 	math "math"
 	proto "github.com/golang/protobuf/proto"
-	_ "github.com/mwitkow/go-proto-validators"
-	_ "google.golang.org/protobuf/types/known/timestamppb"
 	_ "google.golang.org/protobuf/types/known/wrapperspb"
 	_ "google.golang.org/protobuf/types/known/structpb"
+	_ "github.com/mwitkow/go-proto-validators"
+	_ "google.golang.org/protobuf/types/known/timestamppb"
 	regexp "regexp"
 	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"
 )

--- a/systems/subscriber/sim-manager/pkg/config.go
+++ b/systems/subscriber/sim-manager/pkg/config.go
@@ -17,11 +17,11 @@ import (
 )
 
 const (
-	NumberOfSubscribers = "number_of_subscribers"
-	ActiveCount         = "active_sim_count"
-	InactiveCount       = "inactive_sim_count"
-	TerminatedCount     = "terminated_sim_count"
-	GaugeType           = "gauge"
+	NumberOfSims    = "number_of_sims"
+	ActiveCount     = "active_sim_count"
+	InactiveCount   = "inactive_sim_count"
+	TerminatedCount = "terminated_sim_count"
+	GaugeType       = "gauge"
 )
 
 type Config struct {
@@ -67,12 +67,13 @@ func NewConfig(name string) *Config {
 	}
 }
 
-var SimMetric = []pmetric.MetricConfig{{
-	Name:   NumberOfSubscribers,
-	Type:   GaugeType,
-	Labels: map[string]string{"network": "", "org": ""},
-	Value:  0,
-},
+var SimMetric = []pmetric.MetricConfig{
+	{
+		Name:   NumberOfSims,
+		Type:   GaugeType,
+		Labels: map[string]string{"network": "", "org": ""},
+		Value:  0,
+	},
 	{
 		Name:   ActiveCount,
 		Type:   GaugeType,

--- a/systems/subscriber/sim-manager/pkg/db/sim_repo.go
+++ b/systems/subscriber/sim-manager/pkg/db/sim_repo.go
@@ -37,7 +37,6 @@ type SimRepo interface {
 
 	Update(sim *Sim, nestedFunc func(*Sim, *gorm.DB) error) error
 	Delete(simID uuid.UUID, nestedFunc func(uuid.UUID, *gorm.DB) error) error
-	GetSimMetrics() (int64, int64, int64, int64, error)
 }
 
 type simRepo struct {
@@ -224,25 +223,4 @@ func (s *simRepo) Delete(simID uuid.UUID, nestedFunc func(uuid.UUID, *gorm.DB) e
 	})
 
 	return err
-}
-func (s *simRepo) GetSimMetrics() (simsCount, activeCount, deactiveCount, terminatedCount int64, err error) {
-	db := s.Db.GetGormDb()
-
-	if err := db.Model(&Sim{}).Count(&simsCount).Error; err != nil {
-		return 0, 0, 0, 0, err
-	}
-
-	if err := db.Model(&Sim{}).Where("status = ?", ukama.SimStatusActive).Count(&activeCount).Error; err != nil {
-		return 0, 0, 0, 0, err
-	}
-
-	if err := db.Model(&Sim{}).Where("status = ?", ukama.SimStatusInactive).Count(&deactiveCount).Error; err != nil {
-		return 0, 0, 0, 0, err
-	}
-
-	if err := db.Model(&Sim{}).Where("status = ?", ukama.SimStatusTerminated).Count(&terminatedCount).Error; err != nil {
-		return 0, 0, 0, 0, err
-	}
-
-	return simsCount, activeCount, deactiveCount, terminatedCount, nil
 }

--- a/systems/subscriber/sim-manager/pkg/server/sim_manager.go
+++ b/systems/subscriber/sim-manager/pkg/server/sim_manager.go
@@ -1277,7 +1277,7 @@ func (s *SimManagerServer) pushActiveSimsCountMetric(networkId string) error {
 }
 
 func (s *SimManagerServer) pushInactiveSimsCountMetric(networkId string) error {
-	sims, err := s.simRepo.List("", "", "", networkId, ukama.SimTypeUnknown, ukama.SimStatusTerminated, 0, false, 0, false)
+	sims, err := s.simRepo.List("", "", "", networkId, ukama.SimTypeUnknown, ukama.SimStatusInactive, 0, false, 0, false)
 	if err != nil {
 		log.Errorf("Error while collecting inactive sims count metric for network: %s. Error: %v",
 			networkId, err)

--- a/systems/subscriber/sim-manager/pkg/server/sim_manager_test.go
+++ b/systems/subscriber/sim-manager/pkg/server/sim_manager_test.go
@@ -542,7 +542,10 @@ func TestSimManagerServer_AllocateSim(t *testing.T) {
 			}, nil).Once()
 
 		msgbusClient.On("PublishRequest", mock.Anything, mock.Anything).Return(nil).Once()
-		simRepo.On("GetSimMetrics").Return(int64(0), int64(0), int64(0), int64(0), nil).Once()
+
+		simRepo.On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]db.Sim{}, nil).Once()
+
 		mailerClient.On("SendEmail", mock.MatchedBy(func(req cnotif.SendEmailReq) bool {
 			return req.To[0] == "test@example.com"
 		})).Return(nil).Once()
@@ -1102,7 +1105,9 @@ func TestSimManagerServer_DeleteSim(t *testing.T) {
 			},
 			mock.Anything).Return(nil).Once()
 		msgbusClient.On("PublishRequest", mock.Anything, mock.Anything).Return(nil).Once()
-		simRepo.On("GetSimMetrics").Return(int64(0), int64(0), int64(0), int64(0), nil).Once()
+
+		simRepo.On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]db.Sim{}, nil).Once()
 
 		s := NewSimManagerServer(OrgName, simRepo, nil, agentFactory,
 			nil, nil, nil, "", msgbusClient, "", "", nil, nil, nil, nil)

--- a/systems/subscriber/sim-manager/pkg/server/sim_manager_test.go
+++ b/systems/subscriber/sim-manager/pkg/server/sim_manager_test.go
@@ -544,7 +544,7 @@ func TestSimManagerServer_AllocateSim(t *testing.T) {
 		msgbusClient.On("PublishRequest", mock.Anything, mock.Anything).Return(nil).Once()
 
 		simRepo.On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]db.Sim{}, nil).Once()
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]db.Sim{}, nil).Twice()
 
 		mailerClient.On("SendEmail", mock.MatchedBy(func(req cnotif.SendEmailReq) bool {
 			return req.To[0] == "test@example.com"
@@ -1107,7 +1107,7 @@ func TestSimManagerServer_DeleteSim(t *testing.T) {
 		msgbusClient.On("PublishRequest", mock.Anything, mock.Anything).Return(nil).Once()
 
 		simRepo.On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]db.Sim{}, nil).Once()
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]db.Sim{}, nil).Twice()
 
 		s := NewSimManagerServer(OrgName, simRepo, nil, agentFactory,
 			nil, nil, nil, "", msgbusClient, "", "", nil, nil, nil, nil)


### PR DESCRIPTION
This PR fixes #852  and closes #952  by providing the  following: 

- Remove sim metrics functions from sim repo as these are now useless
- Use generic List with appropriate filters to collect sim metrics

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update SIM metrics computation by removing `GetSimMetrics` and using filtered `List` calls in `sim-manager`.
> 
>   - **Behavior**:
>     - Removed `GetSimMetrics` from `SimRepo` in `sim_repo.go` and `SimRepo.go`.
>     - Updated `SimManagerServer` in `sim_manager.go` to use `List` with filters for sim metrics.
>     - Added functions `pushTotalSimsCountMetric`, `pushActiveSimsCountMetric`, `pushInactiveSimsCountMetric`, and `pushTerminatedSimsCountMetric` in `sim_manager.go`.
>   - **Config**:
>     - Renamed `NumberOfSubscribers` to `NumberOfSims` in `config.go`.
>   - **Tests**:
>     - Updated tests in `sim_manager_test.go` to mock `List` instead of `GetSimMetrics`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for 5fedceb69c7652748f30d321191891f778dc5977. You can [customize](https://app.ellipsis.dev/ukama/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->