### PR TITLE
Refactor get site stats resolver logic

### DIFF
--- a/interfaces/console/src/app/console/sites/[id]/page.tsx
+++ b/interfaces/console/src/app/console/sites/[id]/page.tsx
@@ -20,7 +20,7 @@ import SiteComponents from '@/components/SiteComponents';
 import SiteDetailsHeader from '@/components/SiteDetailsHeader';
 import SiteInfo from '@/components/SiteInfos';
 import SiteOverview from '@/components/SiteOverView';
-import { SITE_KPIS } from '@/constants';
+import { SITE_KPI_TYPES, SITE_KPIS } from '@/constants';
 import { SectionData } from '@/constants/index';
 import { useAppContext } from '@/context';
 import { ActiveView, KPIType } from '@/types';
@@ -319,6 +319,25 @@ const Page: React.FC<SiteDetailsProps> = ({ params }) => {
       });
     }
   }, [activeSite.id, fetchNodesForSite]);
+  const getInitialNodeUptimes = (): Record<string, number> => {
+    if (!statData?.getSiteStat?.metrics || !nodeIds || nodeIds.length === 0) {
+      return {};
+    }
+
+    const nodeUptimes: Record<string, number> = {};
+    statData.getSiteStat.metrics.forEach((metric: any) => {
+      if (
+        metric.type === SITE_KPI_TYPES.NODE_UPTIME &&
+        metric.nodeId &&
+        metric.success
+      ) {
+        nodeUptimes[metric.nodeId] = metric.value;
+      }
+    });
+
+    return nodeUptimes;
+  };
+  const initialNodeUptimes = getInitialNodeUptimes();
 
   if (!isDataReady) {
     return (
@@ -402,6 +421,7 @@ const Page: React.FC<SiteDetailsProps> = ({ params }) => {
           onComponentClick={handleViewChange}
           onSwitchChange={handleSwitchChange}
           nodeIds={nodeIds}
+          initialNodeUptimes={initialNodeUptimes}
         />
       </Box>
     </Box>

--- a/interfaces/console/src/components/SiteCard/index.tsx
+++ b/interfaces/console/src/components/SiteCard/index.tsx
@@ -59,7 +59,7 @@ const getSiteMetricValue = (
   if (!metricsData || !metricsData.metrics || !siteId) return null;
 
   const metric = metricsData.metrics.find(
-    (m) => m.type === metricId && m.success == true && m.siteId === siteId,
+    (m) => m.type === metricId && m.success === true && m.siteId === siteId,
   );
 
   return metric ? extractMetricValue(metric.value) : null;
@@ -86,80 +86,95 @@ const SiteCard: React.FC<SiteCardProps> = memo(
 
     useEffect(() => {
       if (
-        metricsData &&
-        metricsData.metrics &&
-        metricsData.metrics.length > 0
-      ) {
-        const uptime = getSiteMetricValue(
-          SITE_KPI_TYPES.SITE_UPTIME,
-          metricsData,
-          siteId,
-        );
-        if (uptime !== null) setUptimeValue(uptime);
+        !metricsData ||
+        !metricsData.metrics ||
+        metricsData.metrics.length === 0
+      )
+        return;
 
-        const batteryCharge = getSiteMetricValue(
-          SITE_KPI_TYPES.BATTERY_CHARGE_PERCENTAGE,
-          metricsData,
-          siteId,
-        );
-        if (batteryCharge !== null) setBatteryValue(batteryCharge);
+      const uptime = getSiteMetricValue(
+        SITE_KPI_TYPES.SITE_UPTIME,
+        metricsData,
+        siteId,
+      );
+      if (uptime !== null) setUptimeValue(uptime);
 
-        const backhaul = getSiteMetricValue(
-          SITE_KPI_TYPES.BACKHAUL_SPEED,
-          metricsData,
-          siteId,
-        );
-        if (backhaul !== null) setBackhaulValue(backhaul);
-      }
+      const batteryCharge = getSiteMetricValue(
+        SITE_KPI_TYPES.BATTERY_CHARGE_PERCENTAGE,
+        metricsData,
+        siteId,
+      );
+      if (batteryCharge !== null) setBatteryValue(batteryCharge);
+
+      const backhaul = getSiteMetricValue(
+        SITE_KPI_TYPES.BACKHAUL_SPEED,
+        metricsData,
+        siteId,
+      );
+      if (backhaul !== null) setBackhaulValue(backhaul);
     }, [metricsData, siteId]);
 
     useEffect(() => {
-      Object.values(subscriptionsRef.current).forEach((token) => {
-        PubSub.unsubscribe(token);
-      });
-      subscriptionsRef.current = {};
-
-      const uptimeTopic = `stat-${SITE_KPI_TYPES.SITE_UPTIME}-${siteId}`;
-      const batteryChargeTopic = `stat-${SITE_KPI_TYPES.BATTERY_CHARGE_PERCENTAGE}-${siteId}`;
-      const backhaulTopic = `stat-${SITE_KPI_TYPES.BACKHAUL_SPEED}-${siteId}`;
-
-      const uptimeToken = PubSub.subscribe(uptimeTopic, (_, data) => {
-        if (data && data.length > 1) {
-          const value = extractMetricValue(data[1]);
-          if (value !== null) setUptimeValue(value);
-        }
-      });
-
-      const batteryChargeToken = PubSub.subscribe(
-        batteryChargeTopic,
-        (_, data) => {
-          if (data && data.length > 1) {
-            const value = extractMetricValue(data[1]);
-            if (value !== null) setBatteryValue(value);
-          }
-        },
-      );
-
-      const backhaulToken = PubSub.subscribe(backhaulTopic, (_, data) => {
-        if (data && data.length > 1) {
-          const value = extractMetricValue(data[1]);
-          if (value !== null) setBackhaulValue(value);
-        }
-      });
-
-      subscriptionsRef.current = {
-        uptime: uptimeToken,
-        battery: batteryChargeToken,
-        backhaul: backhaulToken,
-      };
-
-      return () => {
+      const cleanup = () => {
         Object.values(subscriptionsRef.current).forEach((token) => {
           PubSub.unsubscribe(token);
         });
         subscriptionsRef.current = {};
       };
-    }, [siteId]);
+
+      cleanup();
+
+      if (loading || !siteId) return;
+
+      const handleUptimeUpdate = (_: any, data: any) => {
+        if (data !== null && data !== undefined) {
+          const value =
+            Array.isArray(data) && data.length > 1
+              ? extractMetricValue(data[1])
+              : extractMetricValue(data);
+          if (value !== null) setUptimeValue(value);
+        }
+      };
+
+      const handleBatteryUpdate = (_: any, data: any) => {
+        if (data !== null && data !== undefined) {
+          const value =
+            Array.isArray(data) && data.length > 1
+              ? extractMetricValue(data[1])
+              : extractMetricValue(data);
+          if (value !== null) setBatteryValue(value);
+        }
+      };
+
+      const handleBackhaulUpdate = (_: any, data: any) => {
+        if (data !== null && data !== undefined) {
+          const value =
+            Array.isArray(data) && data.length > 1
+              ? extractMetricValue(data[1])
+              : extractMetricValue(data);
+          if (value !== null) setBackhaulValue(value);
+        }
+      };
+
+      const uptimeTopic = `stat-${SITE_KPI_TYPES.SITE_UPTIME}-${siteId}`;
+      const batteryTopic = `stat-${SITE_KPI_TYPES.BATTERY_CHARGE_PERCENTAGE}-${siteId}`;
+      const backhaulTopic = `stat-${SITE_KPI_TYPES.BACKHAUL_SPEED}-${siteId}`;
+
+      subscriptionsRef.current.uptime = PubSub.subscribe(
+        uptimeTopic,
+        handleUptimeUpdate,
+      );
+      subscriptionsRef.current.battery = PubSub.subscribe(
+        batteryTopic,
+        handleBatteryUpdate,
+      );
+      subscriptionsRef.current.backhaul = PubSub.subscribe(
+        backhaulTopic,
+        handleBackhaulUpdate,
+      );
+
+      return cleanup;
+    }, [siteId, loading]);
 
     const displayAddress = loading
       ? ''
@@ -186,7 +201,6 @@ const SiteCard: React.FC<SiteCardProps> = memo(
       window.location.href = `/console/sites/${siteId}`;
     }, [siteId]);
 
-    // Updated to always provide icons with appropriate colors
     const connectionStyles =
       uptimeValue !== null
         ? getStatusStyles('uptime', uptimeValue)
@@ -354,6 +368,16 @@ const SiteCard: React.FC<SiteCardProps> = memo(
           </Box>
         </CardContent>
       </Card>
+    );
+  },
+  (prevProps, nextProps) => {
+    return (
+      prevProps.siteId === nextProps.siteId &&
+      prevProps.name === nextProps.name &&
+      prevProps.address === nextProps.address &&
+      prevProps.loading === nextProps.loading &&
+      prevProps.userCount === nextProps.userCount &&
+      prevProps.metricsData === nextProps.metricsData
     );
   },
 );

--- a/interfaces/console/src/components/SiteComponents/index.tsx
+++ b/interfaces/console/src/components/SiteComponents/index.tsx
@@ -37,6 +37,7 @@ interface SiteComponentsProps {
   onComponentClick: (kpiType: string) => void;
   onSwitchChange?: (portNumber: number, currentStatus: boolean) => void;
   nodeIds?: string[];
+  initialNodeUptimes?: Record<string, number>;
 }
 
 const SiteComponents: React.FC<SiteComponentsProps> = ({
@@ -50,6 +51,7 @@ const SiteComponents: React.FC<SiteComponentsProps> = ({
   onComponentClick,
   onSwitchChange,
   nodeIds,
+  initialNodeUptimes,
 }) => {
   const hasMetricsData =
     metrics && metrics.metrics && metrics.metrics.length > 0;
@@ -67,7 +69,11 @@ const SiteComponents: React.FC<SiteComponentsProps> = ({
   >({});
 
   const [nodeUptimes, setNodeUptimes] = useState<Record<string, number>>({});
-
+  useEffect(() => {
+    if (initialNodeUptimes && Object.keys(initialNodeUptimes).length > 0) {
+      setNodeUptimes(initialNodeUptimes);
+    }
+  }, [initialNodeUptimes]);
   useEffect(() => {
     if (!siteId || !nodeIds || nodeIds.length === 0) return;
 

--- a/interfaces/console/src/constants/index.tsx
+++ b/interfaces/console/src/constants/index.tsx
@@ -11,7 +11,6 @@ import { ColumnsWithOptions, MenuItemType } from '@/types';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import UpdateIcon from '@mui/icons-material/SystemUpdateAltRounded';
-import { format } from 'path';
 
 export const STAT_STEP_29 = 29;
 export const METRIC_RANGE_3600 = 3600;

--- a/interfaces/console/src/constants/index.tsx
+++ b/interfaces/console/src/constants/index.tsx
@@ -11,6 +11,7 @@ import { ColumnsWithOptions, MenuItemType } from '@/types';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import UpdateIcon from '@mui/icons-material/SystemUpdateAltRounded';
+import { format } from 'path';
 
 export const STAT_STEP_29 = 29;
 export const METRIC_RANGE_3600 = 3600;
@@ -661,13 +662,10 @@ export const SITE_KPIS = {
       {
         unit: '',
         show: true,
-        format: 'number',
-        name: 'Nde uptime',
+        name: 'Node uptime',
         id: 'unit_uptime',
         description: 'Node uptime',
-        threshold: null,
-        tickInterval: undefined,
-        tickPositions: undefined,
+        format: 'number',
       },
     ],
   },

--- a/interfaces/console/src/lib/MetricStatBySiteSubscription.ts
+++ b/interfaces/console/src/lib/MetricStatBySiteSubscription.ts
@@ -20,7 +20,6 @@ interface IMetricStatBySiteSubscription {
 }
 
 const activeSubscriptions = new Map<string, AbortController>();
-
 function parseEvent(eventStr: string) {
   if (!eventStr || eventStr.startsWith(':')) return null;
 
@@ -37,8 +36,7 @@ function parseEvent(eventStr: string) {
     }
   }
 
-  const result = event.data || event.id || event.event ? event : null;
-  return result;
+  return event.data || event.id || event.event ? event : null;
 }
 export default function MetricStatBySiteSubscription(
   params: IMetricStatBySiteSubscription,

--- a/interfaces/console/src/lib/MetricStatBySiteSubscription.ts
+++ b/interfaces/console/src/lib/MetricStatBySiteSubscription.ts
@@ -37,9 +37,9 @@ function parseEvent(eventStr: string) {
     }
   }
 
-  return event.data || event.id || event.event ? event : null;
+  const result = event.data || event.id || event.event ? event : null;
+  return result;
 }
-
 export default function MetricStatBySiteSubscription(
   params: IMetricStatBySiteSubscription,
 ) {
@@ -118,7 +118,6 @@ export default function MetricStatBySiteSubscription(
         if (activityTimeout) clearTimeout(activityTimeout);
         activityTimeout = setTimeout(
           () => {
-            console.log('Connection timeout, closing...');
             controller.abort();
             activeSubscriptions.delete(key);
           },
@@ -157,13 +156,9 @@ export default function MetricStatBySiteSubscription(
       }
     } catch (error: any) {
       if (error.name === 'AbortError') {
-        console.log('Fetch aborted');
       } else {
-        console.error('SSE connection error:', error);
-
         if (activeSubscriptions.has(key)) {
           setTimeout(() => {
-            console.log('Attempting to reconnect...');
             startSSE();
           }, 2000);
         }

--- a/interfaces/console/src/utils/index.tsx
+++ b/interfaces/console/src/utils/index.tsx
@@ -494,7 +494,7 @@ const kpiToGraphType: Record<string, Graphs_Type> = {
   main_backhaul: Graphs_Type.MainBackhaul,
   backhaul: Graphs_Type.MainBackhaul,
   switch: Graphs_Type.Switch,
-  node: Graphs_Type.Solar,
+  node: Graphs_Type.Site,
 };
 const graphTypeToSection: Record<Graphs_Type | string, string> = {
   [Graphs_Type.Solar]: 'SOLAR',

--- a/interfaces/console/src/utils/useMetricSubscriptions.ts
+++ b/interfaces/console/src/utils/useMetricSubscriptions.ts
@@ -123,7 +123,7 @@ export const useMetricSubscriptions = ({
 
         MetricStatBySiteSubscription({
           key: sKey,
-          nodeIds,
+          nodeIds: [],
           siteIds: [siteId],
           userId,
           url: metricUrl,
@@ -200,35 +200,16 @@ export const useMetricSubscriptions = ({
           withSubscription: true,
           type: Stats_Type.Site,
           siteIds: [siteId],
-          nodeIds,
+          nodeIds: [],
         },
       },
-    });
-
-    MetricStatBySiteSubscription({
-      key: sKey,
-      siteIds: [siteId],
-      userId,
-      url: metricUrl,
-      orgName,
-      type: Stats_Type.Site,
-      from,
-      nodeIds,
     });
 
     return () => {
       PubSub.unsubscribe(sKey);
       delete subscriptionsRef.current[sKey];
     };
-  }, [
-    siteId,
-    nodeIds,
-    nodesFetched,
-    userId,
-    orgName,
-    metricUrl,
-    getSiteMetricStat,
-  ]);
+  }, [siteId, nodesFetched, userId, orgName, getSiteMetricStat]);
 
   const resetMetrics = useCallback(() => {
     setMetrics({ metrics: [] });

--- a/systems/console-bff/subscriptions/datasource/mapper.ts
+++ b/systems/console-bff/subscriptions/datasource/mapper.ts
@@ -5,12 +5,9 @@
  *
  * Copyright (c) 2023-present, Ukama Inc.
  */
-import { METRICS_INTERVAL } from "../../common/configs";
-import { logger } from "../../common/logger";
 import { formatKPIValue } from "../../common/utils";
 import {
   GetLatestMetricInput,
-  GetMetricRangeInput,
   GetMetricsStatInput,
   LatestMetricRes,
   MetricRes,
@@ -28,20 +25,6 @@ const ERROR_RESPONSE = {
   orgId: "",
   nodeId: "",
   type: "",
-};
-
-const getEmptyMetric = (
-  args: GetMetricRangeInput | GetMetricsStatInput
-): MetricRes => {
-  const result: MetricRes = {
-    ...ERROR_RESPONSE,
-    type: args.type,
-    nodeId: args.nodeId ?? "",
-    siteId: args.siteId ?? "",
-    networkId: "",
-    values: [[0, 0]],
-  };
-  return result;
 };
 
 export const parseLatestMetricRes = (
@@ -102,59 +85,6 @@ export const parseMetricsResponse = (
   return metricsRes;
 };
 
-export const parseSiteMetricRes = (
-  res: any,
-  type: string,
-  args: GetMetricRangeInput
-): MetricRes => {
-  let result: any[] = [];
-  if (res.data?.data?.result) {
-    result = res.data.data.result;
-  } else if (res.data?.result) {
-    result = res.data.result;
-  } else if (res.data) {
-    result = Array.isArray(res.data) ? res.data : [res.data];
-  } else {
-    result = res.result || (Array.isArray(res) ? res : [res]);
-  }
-
-  if (!Array.isArray(result)) {
-    logger.error(`Unexpected result structure:`, result);
-    result = [];
-  }
-
-  const hasValues = result.length > 0 && result[0]?.values?.length > 0;
-
-  let siteId = "";
-  if (result.length > 0 && result[0]?.metric) {
-    siteId = result[0].metric.site || result[0].metric.siteid || "";
-  }
-
-  return hasValues
-    ? {
-        type: type,
-        success: true,
-        msg: "success",
-        siteId: siteId,
-        values: fixTimestampInMetricData(
-          result[0].values,
-          METRICS_INTERVAL,
-          args.to || Date.now(),
-          args.from,
-          type
-        ),
-      }
-    : getEmptyMetric({
-        orgId: "",
-        to: args.to,
-        type: args.type,
-        siteId: siteId || args.siteId || "",
-        from: args.from,
-        step: args.step,
-        userId: args.userId,
-        withSubscription: false,
-      });
-};
 function fixTimestampInMetricData(
   data: [number, string | null][],
   step: number,

--- a/systems/console-bff/subscriptions/resolvers/resolver.ts
+++ b/systems/console-bff/subscriptions/resolvers/resolver.ts
@@ -365,9 +365,10 @@ class SubscriptionsResolvers {
 
   private processSiteMetricResults(results: any[], siteId: string): any[] {
     return results.map(res => {
-      let avg = 0;
-      if (Array.isArray(res.values)) {
-        res.values = res.values.filter((value: any) => value[1] !== 0);
+      let avg = null;
+      let success = res.success;
+
+      if (Array.isArray(res.values) && res.values.length > 0) {
         if (res.values.length === 1 || res.type === "site_uptime_seconds") {
           avg = res.values[res.values.length - 1][1];
         } else if (res.type === "site_uptime_percentage") {
@@ -383,18 +384,24 @@ class SubscriptionsResolvers {
           );
           avg = sum / res.values.length;
         }
+
+        if (avg < 0) {
+          success = false;
+        }
+      } else {
+        success = false;
       }
+
       return {
         msg: res.msg,
         type: res.type,
         siteId: res.siteId || siteId || "",
         nodeId: "",
-        success: res.success,
-        value: formatKPIValue(res.type, avg),
+        success: success,
+        value: success ? formatKPIValue(res.type, avg) : null,
       };
     });
   }
-
   private async fetchNodeMetrics(
     baseURL: string,
     metricKeys: string[],

--- a/systems/console-bff/subscriptions/resolvers/resolver.ts
+++ b/systems/console-bff/subscriptions/resolvers/resolver.ts
@@ -28,7 +28,6 @@ import {
 import {
   getNodeMetricRange,
   getNotifications,
-  getSiteMetricRange,
 } from "../datasource/subscriptions-api";
 import { pubSub } from "./pubsub";
 import {
@@ -42,7 +41,6 @@ import {
   MetricsStateRes,
   NotificationsRes,
   NotificationsResDto,
-  SiteMetricsStateRes,
   SubMetricsStatInput,
   SubSiteMetricByTabInput,
   SubSiteMetricsStatInput,
@@ -103,6 +101,93 @@ const handleWebSocketMessage = (data: any, topic: string, pubSub: any) => {
       logger.error(`Failed to parse WebSocket message: ${error}`);
     }
   }
+};
+const setupWebSocketWorkers = (
+  wsUrl: string,
+  data: GetMetricsSiteStatInput,
+  metricsKey: string[],
+  siteIds: string[],
+  nodeIds: string[],
+  store: any
+): Worker[] => {
+  const workers: Worker[] = [];
+  const sites = siteIds && siteIds.length > 0 ? siteIds : [""];
+  const nodes = nodeIds && nodeIds.length > 0 ? nodeIds : [""];
+
+  for (const siteId of sites) {
+    for (const nodeId of nodes) {
+      const topic = `stat-${data.orgName}-${data.userId}-${data.type}-${data.from}`;
+      let url = `${wsUrl}/v1/live/metrics?interval=${METRIC_WS_INTERVAL}&operation=${
+        data.operation
+      }&metric=${metricsKey.join(",")}`;
+
+      if (nodeId) {
+        url += `&node=${encodeURIComponent(nodeId)}`;
+      }
+      if (siteId) {
+        url += `&site=${encodeURIComponent(siteId)}`;
+      }
+
+      const worker = new Worker(WS_THREAD, {
+        workerData: { topic, url },
+      });
+
+      worker.on("message", (wsData: any) =>
+        handleWebSocketMessage(wsData, topic, pubSub)
+      );
+
+      worker.on("exit", async (code: any) => {
+        await store.close();
+        logger.info(`WS_THREAD exited with code [${code}] for ${topic}`);
+      });
+
+      workers.push(worker);
+    }
+  }
+
+  return workers;
+};
+const fetchMetricsForSiteNodeCombination = async (
+  baseURL: string,
+  metricsKey: string[],
+  siteId: string,
+  nodeId: string,
+  data: GetMetricsSiteStatInput
+): Promise<any[]> => {
+  const processedMetrics: any[] = [];
+  const metricPromises = metricsKey.map(async key => {
+    const combinedData = {
+      ...data,
+      siteIds: undefined,
+      nodeIds: undefined,
+      siteId: siteId || undefined,
+      nodeId: nodeId || undefined,
+    };
+
+    try {
+      const res = await getNodeMetricRange(baseURL, key, combinedData);
+      if (Array.isArray(res.metrics)) {
+        res.metrics.forEach(metric => {
+          const processedMetric = processMetricResult(metric);
+          if (!processedMetric.siteId && siteId) {
+            processedMetric.siteId = siteId;
+          }
+          if (!processedMetric.nodeId && nodeId) {
+            processedMetric.nodeId = nodeId;
+          }
+          processedMetrics.push(processedMetric);
+        });
+      }
+    } catch (error) {
+      logger.error(
+        `Error fetching metrics for site ${siteId}, node ${nodeId}, key ${key}:`,
+        error
+      );
+    }
+  });
+
+  await Promise.all(metricPromises);
+  return processedMetrics;
 };
 
 @Resolver(String)
@@ -335,329 +420,58 @@ class SubscriptionsResolvers {
     return payload;
   }
 
-  private async fetchSiteMetrics(
-    baseURL: string,
-    metricKeys: string[],
-    data: GetMetricsSiteStatInput,
-    siteId: string
-  ): Promise<any[]> {
-    const results = await Promise.all(
-      metricKeys.map(async key => {
-        try {
-          return await getSiteMetricRange(baseURL, key, { ...data, siteId });
-        } catch (error) {
-          logger.error(
-            `Error processing site metric ${key} for site ${siteId}: ${error}`
-          );
-          return {
-            msg: "Error",
-            type: key,
-            siteId: siteId || "",
-            nodeId: "",
-            success: false,
-            values: [],
-          };
-        }
-      })
-    );
-    return results;
-  }
-
-  private processSiteMetricResults(results: any[], siteId: string): any[] {
-    return results.map(res => {
-      let avg = null;
-      let success = res.success;
-
-      if (Array.isArray(res.values) && res.values.length > 0) {
-        if (res.values.length === 1 || res.type === "site_uptime_seconds") {
-          avg = res.values[res.values.length - 1][1];
-        } else if (res.type === "site_uptime_percentage") {
-          const sum = res.values.reduce(
-            (acc: number, val: any) => acc + val[1],
-            0
-          );
-          avg = sum / res.values.length;
-        } else {
-          const sum = res.values.reduce(
-            (acc: number, val: any) => acc + val[1],
-            0
-          );
-          avg = sum / res.values.length;
-        }
-
-        if (avg < 0) {
-          success = false;
-        }
-      } else {
-        success = false;
-      }
-
-      return {
-        msg: res.msg,
-        type: res.type,
-        siteId: res.siteId || siteId || "",
-        nodeId: "",
-        success: success,
-        value: success ? formatKPIValue(res.type, avg) : null,
-      };
-    });
-  }
-  private async fetchNodeMetrics(
-    baseURL: string,
-    metricKeys: string[],
-    data: GetMetricsSiteStatInput,
-    siteId: string,
-    nodeId: string
-  ): Promise<any[]> {
-    const nodeResults: MetricsStateRes = { metrics: [] };
-    if (metricKeys.length > 0) {
-      const metricPromises = metricKeys.map(async key => {
-        const res = await getNodeMetricRange(baseURL, key, { ...data, nodeId });
-        if (Array.isArray(res.metrics)) {
-          res.metrics.forEach(metric => {
-            nodeResults.metrics.push(processMetricResult(metric));
-          });
-        }
-      });
-      await Promise.all(metricPromises);
-    }
-    return nodeResults.metrics.map(res => ({
-      msg: res.msg,
-      type: res.type,
-      siteId: siteId || "",
-      nodeId: nodeId || "",
-      success: res.success,
-      value: formatKPIValue(res.type, res.value),
-    }));
-  }
-
-  private setupSiteStateWSWorkers(
-    wsUrl: string,
-    metricKeys: string[],
-    data: GetMetricsSiteStatInput,
-    siteIds: string[],
-    nodeIds: string[] | undefined,
-    baseTopic: string
-  ) {
-    const handleSiteWSMessage = (
-      wsData: any,
-      topic: string,
-      siteId: string,
-      nodeId: string = ""
-    ) => {
-      if (!wsData.isError) {
-        try {
-          const res = JSON.parse(wsData.data);
-          if (res?.data?.result && res.data.result.length > 0) {
-            res.data.result.forEach((result: any) => {
-              if (
-                result &&
-                result.metric &&
-                result.value &&
-                result.value.length > 0
-              ) {
-                if (!nodeId) {
-                  const resultSiteId =
-                    result.metric.site || result.metric.instance || siteId;
-
-                  pubSub.publish(topic, {
-                    success: true,
-                    msg: "success",
-                    type: res.Name,
-                    siteId: resultSiteId,
-                    nodeId: "",
-                    value: [
-                      Math.floor(result.value[0]) * 1000,
-                      formatKPIValue(res.Name, result.value[1]),
-                    ],
-                  });
-                } else {
-                  const resultNodeId =
-                    result.metric.node || result.metric.nodeid || nodeId;
-
-                  pubSub.publish(topic, {
-                    success: true,
-                    msg: "success",
-                    type: res.Name,
-                    siteId: siteId,
-                    nodeId: resultNodeId,
-                    value: [
-                      Math.floor(result.value[0]) * 1000,
-                      formatKPIValue(res.Name, result.value[1]),
-                    ],
-                  });
-                }
-              }
-            });
-          }
-        } catch (error) {
-          logger.error(
-            `Failed to parse WebSocket message for ${
-              nodeId ? `node ${nodeId}` : `site ${siteId}`
-            }: ${error}`
-          );
-        }
-      }
-    };
-
-    for (const siteId of siteIds) {
-      const siteUrlParams = new URLSearchParams();
-      siteUrlParams.append("interval", data.step.toString());
-      siteUrlParams.append("metric", metricKeys.join(","));
-      siteUrlParams.append("site", siteId);
-
-      const siteMetricUrl = `${wsUrl}/v1/live/metrics?${siteUrlParams.toString()}`;
-
-      const siteWorker = new Worker(WS_THREAD, {
-        workerData: { topic: baseTopic, url: siteMetricUrl },
-      });
-
-      siteWorker.on("message", (wsData: any) =>
-        handleSiteWSMessage(wsData, baseTopic, siteId)
-      );
-
-      siteWorker.on("exit", (code: any) => {
-        logger.info(
-          `WS_THREAD for site ${siteId} with metrics [${metricKeys.join(
-            ", "
-          )}] exited with code [${code}] for ${baseTopic}`
-        );
-      });
-    }
-
-    if (Array.isArray(nodeIds) && nodeIds.length > 0) {
-      for (const nodeId of nodeIds) {
-        const nodeUrlParams = new URLSearchParams();
-        nodeUrlParams.append("interval", data.step.toString());
-        nodeUrlParams.append("metric", metricKeys.join(","));
-        nodeUrlParams.append("node", nodeId);
-
-        const nodeMetricUrl = `${wsUrl}/v1/live/metrics?${nodeUrlParams.toString()}`;
-
-        const nodeWorker = new Worker(WS_THREAD, {
-          workerData: { topic: baseTopic, url: nodeMetricUrl },
-        });
-
-        for (const siteId of siteIds) {
-          nodeWorker.on("message", (wsData: any) =>
-            handleSiteWSMessage(wsData, baseTopic, siteId, nodeId)
-          );
-        }
-
-        nodeWorker.on("exit", (code: any) => {
-          logger.info(
-            `WS_THREAD for node ${nodeId} with metrics [${metricKeys.join(
-              ", "
-            )}] exited with code [${code}] for ${baseTopic}`
-          );
-        });
-      }
-    }
-  }
-
-  @Query(() => SiteMetricsStateRes)
+  @Query(() => MetricsStateRes)
   async getSiteStat(
     @Arg("data") data: GetMetricsSiteStatInput
-  ): Promise<SiteMetricsStateRes> {
+  ): Promise<MetricsStateRes> {
     const store = openStore();
-    try {
-      const { message: baseURL, status } = await getBaseURL(
-        "metrics",
-        data.orgName,
+    const { message: baseURL, status } = await getBaseURL(
+      "metrics",
+      data.orgName,
+      store
+    );
+    if (status !== 200) {
+      logger.error(`Error getting base URL for metrics stat: ${baseURL}`);
+      return { metrics: [] };
+    }
+
+    const wsUrl = wsUrlResolver(baseURL);
+    const { type, from, withSubscription, nodeIds, siteIds } = data;
+    if (from === 0) throw new Error("Argument 'from' can't be zero.");
+
+    const metricsKey = getGraphsKeyByType(type);
+    const metrics: MetricsStateRes = { metrics: [] };
+
+    if (metricsKey.length > 0) {
+      const sites = siteIds && siteIds.length > 0 ? siteIds : [""];
+      const nodes = nodeIds && nodeIds.length > 0 ? nodeIds : [""];
+
+      for (const siteId of sites) {
+        for (const nodeId of nodes) {
+          const processedMetrics = await fetchMetricsForSiteNodeCombination(
+            baseURL,
+            metricsKey,
+            siteId,
+            nodeId,
+            data
+          );
+          metrics.metrics.push(...processedMetrics);
+        }
+      }
+    }
+
+    if (withSubscription && metrics.metrics.length > 0) {
+      setupWebSocketWorkers(
+        wsUrl,
+        data,
+        metricsKey,
+        siteIds || [],
+        nodeIds || [],
         store
       );
-      if (status !== 200) {
-        logger.error(`Error getting base URL for site stat: ${baseURL}`);
-        return { metrics: [] };
-      }
-
-      const wsUrl = wsUrlResolver(baseURL);
-      const { from, userId, withSubscription, siteIds, type, nodeIds } = data;
-      if (from === 0) throw new Error("Argument 'from' can't be zero.");
-      if (!siteIds || siteIds.length === 0) {
-        throw new Error("At least one siteId must be provided");
-      }
-
-      const metrics: SiteMetricsStateRes = { metrics: [] };
-      const metricKeys = getGraphsKeyByType(type);
-
-      for (const siteId of siteIds) {
-        try {
-          const siteResults = await this.fetchSiteMetrics(
-            baseURL,
-            metricKeys,
-            data,
-            siteId
-          );
-          metrics.metrics.push(
-            ...this.processSiteMetricResults(siteResults, siteId)
-          );
-        } catch (error) {
-          logger.error(
-            `Error processing site metrics for site ${siteId}: ${error}`
-          );
-          for (const key of metricKeys) {
-            metrics.metrics.push({
-              msg: "Error",
-              type: key,
-              siteId: siteId || "",
-              nodeId: "",
-              success: false,
-              value: 0,
-            });
-          }
-        }
-
-        if (Array.isArray(nodeIds) && nodeIds.length > 0) {
-          for (const nodeId of nodeIds) {
-            try {
-              const nodeMetrics = await this.fetchNodeMetrics(
-                baseURL,
-                metricKeys,
-                data,
-                siteId,
-                nodeId
-              );
-              metrics.metrics.push(...nodeMetrics);
-            } catch (error) {
-              logger.error(
-                `Error processing node metrics for node ${nodeId} in site ${siteId}: ${error}`
-              );
-              for (const key of metricKeys) {
-                metrics.metrics.push({
-                  msg: "Error",
-                  type: key,
-                  siteId: siteId || "",
-                  nodeId: nodeId || "",
-                  success: false,
-                  value: 0,
-                });
-              }
-            }
-          }
-        }
-      }
-
-      if (withSubscription && metrics.metrics.length > 0) {
-        const baseTopic = `stat-${data.orgName}-${userId}-${type}-${from}`;
-        this.setupSiteStateWSWorkers(
-          wsUrl,
-          metricKeys,
-          data,
-          siteIds,
-          nodeIds,
-          baseTopic
-        );
-      }
-
-      metrics.metrics = metrics.metrics.filter(
-        metric => metric.success === true
-      );
-
-      return metrics;
-    } finally {
-      await store.close();
     }
+
+    return metrics;
   }
 
   @Subscription(() => LatestMetricSubRes, {
@@ -688,74 +502,33 @@ class SubscriptionsResolvers {
       store
     );
     if (status !== 200) {
-      logger.error(`Error getting base URL for site metrics: ${baseURL}`);
+      logger.error(`Error getting base URL for metrics stat: ${baseURL}`);
       return { metrics: [] };
     }
-    logger.info(`Using metrics base URL for site: ${baseURL}`);
 
-    const wsUrl = wsUrlResolver(baseURL);
-
-    const { type, from, userId, withSubscription, siteId } = data;
+    const { type, from, userId, siteId, to } = data;
     if (from === 0) throw new Error("Argument 'from' can't be zero.");
 
     const metricsKey = getGraphsKeyByType(type);
-    const metrics: MetricsRes = { metrics: [] };
 
     if (metricsKey.length > 0) {
-      const metricPromises = metricsKey.map(async key => {
-        const result = await getSiteMetricRange(baseURL, key, { ...data });
-        return result;
-      });
+      const metricPromises = metricsKey.map(
+        async key =>
+          await getNodeMetricRange(baseURL, key, {
+            to,
+            from,
+            userId,
+            siteId,
+            step: data.step,
+            orgName: data.orgName,
+            withSubscription: false,
+            type: STATS_TYPE.SITE,
+          })
+      );
 
-      metrics.metrics = await Promise.all(metricPromises);
+      const m = await Promise.all(metricPromises);
+      return transformMetricsArray(m);
     }
-
-    if (withSubscription && metrics.metrics.length > 0) {
-      const workerData = {
-        topic: `${userId}/${type}/${from}`,
-        url: `${wsUrl}/v1/live/metrics?interval=${
-          data.step
-        }&metric=${metricsKey.join(",")}&site=${siteId}`,
-      };
-
-      const worker = new Worker(WS_THREAD, {
-        workerData,
-      });
-
-      worker.on("message", (_data: any) => {
-        if (!_data.isError) {
-          try {
-            const res = JSON.parse(_data.data);
-            const result = res.data.result[0];
-            if (result && result.metric && result.value.length > 0) {
-              pubSub.publish(workerData.topic, {
-                type: res.Name,
-                success: true,
-                msg: "success",
-                siteId: siteId,
-                value: [
-                  Math.floor(result.value[0]) * 1000,
-                  parseFloat(Number(result.value[1] || 0).toFixed(2)),
-                ],
-              });
-            }
-          } catch (error) {
-            logger.error(
-              `Failed to parse WebSocket message for site: ${error}`
-            );
-          }
-        }
-      });
-
-      worker.on("exit", async (code: any) => {
-        await store.close();
-        logger.info(
-          `WS_THREAD exited with code [${code}] for ${userId}/${type}/${from}`
-        );
-      });
-    }
-
-    return metrics;
   }
 
   @Subscription(() => LatestMetricSubRes, {

--- a/systems/console-bff/subscriptions/resolvers/types.ts
+++ b/systems/console-bff/subscriptions/resolvers/types.ts
@@ -351,33 +351,6 @@ export class MetricsStateRes {
   metrics: MetricStateRes[];
 }
 
-@ObjectType()
-export class SiteMetricsStateRes {
-  @Field(() => [SiteMetricStateRes])
-  metrics: SiteMetricStateRes[];
-}
-
-@ObjectType()
-export class SiteMetricStateRes {
-  @Field()
-  success: boolean;
-
-  @Field()
-  msg: string;
-
-  @Field()
-  siteId?: string;
-
-  @Field({ nullable: true })
-  nodeId?: string;
-
-  @Field()
-  type: string;
-
-  @Field()
-  value: number;
-}
-
 @InputType()
 export class SubMetricRangeInput {
   @Field()

--- a/systems/console-bff/subscriptions/resolvers/types.ts
+++ b/systems/console-bff/subscriptions/resolvers/types.ts
@@ -197,6 +197,9 @@ export class GetMetricsSiteStatInput {
   @Field()
   to: number;
 
+  @Field({ nullable: true, defaultValue: "avg" })
+  operation?: string;
+
   @Field({ defaultValue: 30 })
   step: number;
 
@@ -298,6 +301,9 @@ export class MetricStateRes {
 
   @Field()
   type: string;
+
+  @Field({ nullable: true })
+  siteId?: string;
 
   @Field()
   value: number;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor site statistics resolver logic to improve metric fetching and subscription management across multiple components and utilities.
> 
>   - **Behavior**:
>     - Refactor `getSiteStat` in `resolver.ts` to streamline metric fetching and subscription setup.
>     - Introduce `setupWebSocketWorkers` and `fetchMetricsForSiteNodeCombination` in `resolver.ts` for handling WebSocket connections and metric fetching.
>     - Remove `getSiteMetricRange` from `subscriptions-api.ts` and related logic from `mapper.ts`.
>   - **Subscriptions**:
>     - Update `useMetricSubscriptions` in `useMetricSubscriptions.ts` to handle metric subscriptions more efficiently.
>     - Modify `MetricStatBySiteSubscription` in `MetricStatBySiteSubscription.ts` to improve subscription management.
>   - **Components**:
>     - Add `initialNodeUptimes` prop to `SiteComponents` in `SiteComponents/index.tsx` for initial node uptime data.
>     - Update `SiteCard` in `SiteCard/index.tsx` to handle metric updates via PubSub more robustly.
>   - **Constants**:
>     - Add `SITE_KPI_TYPES` to `constants/index.tsx` for better KPI type management.
>   - **Utils**:
>     - Add `handleMetricWSMessage` to `utils/index.tsx` for WebSocket message handling.
>     - Refactor `getGraphsKeyByType` in `utils/index.tsx` to support new metric types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for 9b9c8fa0b9352954fcbd36a207e51506ef664d69. You can [customize](https://app.ellipsis.dev/ukama/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->