### PR TITLE
Hot fixes for #1010

### DIFF
--- a/builder/scripts/build-system/build-distro.sh
+++ b/builder/scripts/build-system/build-distro.sh
@@ -59,3 +59,25 @@ if [ $? -eq 0 ]; then
 else
     exit 1
 fi
+
+# Temporary - mocksysfs
+cwd=`pwd`
+cd "${UKAMA_REPO}/nodes/ukamaOS/distro/system/noded"
+rm -rf /tmp/sys/
+rm -rf "${cwd}/mocksysfs"
+./utils/prepare_env.sh -u tnode -u anode
+./build/genSchema --u UK-SA9001-HNODE-A1-1103 \
+                  --n com --m UK-SA9001-COM-A1-1103  \
+                  --f mfgdata/schema/com.json --n trx \
+                  --m UK-SA9001-TRX-A1-1103  \
+                  --f mfgdata/schema/trx.json --n mask \
+                  --m UK-SA9001-MSK-A1-1103\
+                  --f mfgdata/schema/mask.json
+./build/genInventory --n com --m UK-SA9001-COM-A1-1103 \
+                     --f mfgdata/schema/com.json -n trx \
+                     --m UK-SA9001-TRX-A1-1103 \
+                     --f mfgdata/schema/trx.json \
+                     --n mask -m UK-SA9001-MSK-A1-1103 \
+                     --f mfgdata/schema/mask.json
+cp -rf /tmp/sys "${cwd}/mocksysfs"
+cd "${cwd}"

--- a/builder/scripts/build-system/build-rootfs.sh
+++ b/builder/scripts/build-system/build-rootfs.sh
@@ -365,7 +365,8 @@ setup_rootfs() {
         libidn2 libmicrohttpd gnutls openssl-dev curl-dev linux-headers bsd-compat-headers \
         tree libtool sqlite-dev openssl-dev readline cmake autoconf automake alpine-sdk \
         build-base git tcpdump ethtool iperf3 htop vim doas \
-        e2fsprogs dosfstools util-linux
+        e2fsprogs dosfstools util-linux \
+        jansson
 
     # Set timezone
     ln -sf /usr/share/zoneinfo/UTC /etc/localtime

--- a/builder/scripts/build-system/build-rootfs.sh
+++ b/builder/scripts/build-system/build-rootfs.sh
@@ -255,6 +255,13 @@ function copy_misc_files() {
     sudo mkdir -p "/etc"
     sudo cp "${UKAMA_ROOT}/nodes/ukamaOS/distro/scripts/files/services" \
          "/etc/services"
+
+    # copy mocksysfs related files (not needed for actual HW) - XXX
+    mkdir -p "/tmp/sys"
+    cp -rf ${UKAMA_ROOT}/builder/scripts/build-system/mocksysfs/* \
+       "/tmp/sys/"
+    cp -rf "${UKAMA_ROOT}/nodes/ukamaOS/distro/system/noded/mfgdata" \
+       "/ukama/mocksysfs/"
 }
 
 # Update /etc/fstab based on partition type
@@ -417,6 +424,7 @@ function setup_ukama_dirs() {
     mkdir -p "/ukama/apps/pkgs"
     mkdir -p "/ukama/apps/rootfs"
     mkdir -p "/ukama/apps/registry"
+    mkdir -p "/ukama/mocksysfs"
     mkdir -p "/passive"
     mkdir -p "/boot/firmware"
     mkdir -p "/data"

--- a/builder/scripts/build-system/run-ukama-image.sh
+++ b/builder/scripts/build-system/run-ukama-image.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This script mounts the rootfs from a partitioned disk image, creates a Docker image from it,
+# and launches an interactive shell inside a container using that image.
+
+set -euo pipefail
+
+### === CONFIGURATION ===
+IMG_FILE="ukama-com-image.img"
+ROOTFS_PART_NUM=2
+MOUNT_POINT="/mnt/ukama-com-rootfs"
+TARBALL="/tmp/ukama-com-rootfs.tar.gz"
+DOCKER_IMAGE_NAME="ukama-com-musl"
+DOCKER_CONTAINER_NAME="ukama-com-musl"
+
+if [ ! -f "$IMG_FILE" ]; then
+    echo "[ERROR] Image file '$IMG_FILE' not found."
+    exit 1
+fi
+
+if ! command -v losetup >/dev/null || ! command -v docker >/dev/null; then
+    echo "[ERROR] Required tools 'losetup' and/or 'docker' are missing."
+    exit 1
+fi
+
+### === MOUNT IMAGE PARTITION ===
+echo "[INFO] Attaching loop device for $IMG_FILE..."
+LOOPDEV=$(sudo losetup --find --partscan --show "$IMG_FILE")
+PART_DEV="${LOOPDEV}p${ROOTFS_PART_NUM}"
+
+if [ ! -b "$PART_DEV" ]; then
+    echo "[ERROR] Partition device $PART_DEV not found. Aborting."
+    sudo losetup -d "$LOOPDEV"
+    exit 1
+fi
+
+echo "[INFO] Mounting rootfs partition $PART_DEV..."
+sudo mkdir -p "$MOUNT_POINT"
+sudo mount "$PART_DEV" "$MOUNT_POINT"
+
+### === CREATE TAR.GZ ROOTFS ===
+echo "[INFO] Creating tarball from rootfs..."
+sudo tar -czf "$TARBALL" -C "$MOUNT_POINT" .
+
+### === CLEANUP MOUNT & LOOP ===
+echo "[INFO] Cleaning up mount and loop device..."
+sudo umount "$MOUNT_POINT"
+sudo losetup -d "$LOOPDEV"
+
+### === IMPORT ROOTFS INTO DOCKER ===
+echo "[INFO] Importing rootfs into Docker as image: $DOCKER_IMAGE_NAME"
+cat "$TARBALL" | docker import - "$DOCKER_IMAGE_NAME"
+
+### === RUN DOCKER CONTAINER IN BACKGROUND ===
+echo "[INFO] Starting container in background from image: $DOCKER_IMAGE_NAME"
+docker run -it -d \
+    --name "$DOCKER_CONTAINER_NAME" \
+    "$DOCKER_IMAGE_NAME" /bin/sh
+
+echo "[INFO] Container '$DOCKER_CONTAINER_NAME' is running."
+
+echo
+echo "✅ To connect:    docker exec -it $DOCKER_CONTAINER_NAME /bin/sh"
+echo "✅ To attach:     docker attach $DOCKER_CONTAINER_NAME"
+echo "✅ To stop:       docker stop $DOCKER_CONTAINER_NAME"

--- a/builder/scripts/build-system/run-ukama-image.sh
+++ b/builder/scripts/build-system/run-ukama-image.sh
@@ -23,6 +23,18 @@ if ! command -v losetup >/dev/null || ! command -v docker >/dev/null; then
     exit 1
 fi
 
+### === CLEANUP EXISTING CONTAINER ===
+if docker ps -a --format '{{.Names}}' | grep -q "^${DOCKER_CONTAINER_NAME}$"; then
+    echo "[INFO] Removing existing container named ${DOCKER_CONTAINER_NAME}..."
+    docker rm -f "$DOCKER_CONTAINER_NAME"
+fi
+
+### === CLEANUP EXISTING IMAGE ===
+if docker images -q "$DOCKER_IMAGE_NAME" >/dev/null; then
+    echo "[INFO] Removing existing Docker image: $DOCKER_IMAGE_NAME"
+    docker rmi -f "$DOCKER_IMAGE_NAME"
+fi
+
 ### === MOUNT IMAGE PARTITION ===
 echo "[INFO] Attaching loop device for $IMG_FILE..."
 LOOPDEV=$(sudo losetup --find --partscan --show "$IMG_FILE")

--- a/nodes/ukamaOS/distro/platform/log/src/websocket.c
+++ b/nodes/ukamaOS/distro/platform/log/src/websocket.c
@@ -202,7 +202,8 @@ void log_remote_init(char *serviceName) {
 
     if (handler.websocket) return;
     if (rlogdPort == 0)    return;
-    if (strcmp(serviceName, SERVICE_RLOG) == 0) return;
+    if (strcmp(serviceName, SERVICE_RLOG) == 0)    return;
+    if (strcmp(serviceName, SERVICE_STARTER) == 0) return;
 
     pthread_mutex_init(&mutex, NULL);
     pthread_cond_init(&hasData, NULL);

--- a/nodes/ukamaOS/distro/system/bootstrap/src/config.c
+++ b/nodes/ukamaOS/distro/system/bootstrap/src/config.c
@@ -16,7 +16,6 @@
 #include "config.h"
 #include "toml.h"
 
-
 int parse_config(Config *config, toml_table_t *configData) {
 
 	toml_datum_t nodedHost;
@@ -88,7 +87,7 @@ bool read_bootstrap_server_info(char **buffer) {
     }
 
     fread(*buffer, sizeof(char), length-1, file);
-    buffer[length] = '\0';
+    (*buffer)[length] = '\0';
 
     fclose(file);
 


### PR DESCRIPTION
Hot fixes for #1010 . 
Added script to run created image within docker container. 
```
➜  noded git:(node-north) ✗ docker images
REPOSITORY               TAG       IMAGE ID       CREATED          SIZE
ukama-com-musl           latest    e8f045aaaf66   17 minutes ago   640MB
```
`➜  noded git:(node-north) ✗ docker container ls
CONTAINER ID   IMAGE            COMMAND     CREATED          STATUS          PORTS     NAMES
b15a1b1ac685   ukama-com-musl   "/bin/sh"   18 minutes ago   Up 18 minutes             ukama-com-musl
`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Docker container script, handle mocksysfs, improve logging and fix buffer issue in configuration.
> 
>   - **Docker Image Handling**:
>     - Added `run-ukama-image.sh` to create and run a Docker container from a disk image.
>     - Cleans up existing Docker containers and images before creating new ones.
>   - **Mocksysfs Handling**:
>     - Temporary mocksysfs setup in `build-distro.sh` and `build-rootfs.sh`.
>     - Copies mocksysfs files to `/tmp/sys` and `/ukama/mocksysfs/`.
>   - **Logging System**:
>     - In `websocket.c`, added check for `SERVICE_STARTER` in `log_remote_init()` to prevent initialization.
>   - **Configuration Fix**:
>     - Fixed buffer null-termination issue in `read_bootstrap_server_info()` in `config.c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for 06ff681a17deee9591fcfd8ac6dc127abb424466. You can [customize](https://app.ellipsis.dev/ukama/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->