### PR TITLE
Sim manager: Usage query updates

### DIFF
--- a/systems/common/pb/events/node.proto
+++ b/systems/common/pb/events/node.proto
@@ -66,5 +66,3 @@ message NodeOnlineEvent{
 message NodeOfflineEvent{
     string nodeId = 1;
 }
-
-

--- a/systems/common/rest/client/operatoragent/operator_agent.go
+++ b/systems/common/rest/client/operatoragent/operator_agent.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 
 	"github.com/ukama/ukama/systems/common/rest/client"
+	"github.com/ukama/ukama/systems/common/validation"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -83,6 +84,16 @@ func (o *operatorAgentClient) GetUsages(iccid, cdrType, from, to, region string)
 	log.Debugf("Getting operator sim usages: %v", iccid)
 
 	usage := OperatorSimUsage{}
+
+	_, err := validation.FromString(from)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid format for from: %s. Error: %s", from, err)
+	}
+
+	_, err = validation.FromString(to)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid format for to: %s. Error: %s", to, err)
+	}
 
 	resp, err := o.R.Get(o.u.String() + OperatorUsagesEndpoint +
 		fmt.Sprintf("?iccid=%s&cdr_type=%s&from=%s&to=%s&region=%s", iccid, cdrType, from, to, region))

--- a/systems/common/rest/client/operatoragent/operator_agent_test.go
+++ b/systems/common/rest/client/operatoragent/operator_agent_test.go
@@ -182,6 +182,44 @@ func TestOperatorClient_GetUsages(t *testing.T) {
 		assert.Nil(tt, c)
 	})
 
+	t.Run("InvalidParameterFrom", func(tt *testing.T) {
+		mockTransport := func(req *http.Request) *http.Response {
+			assert.Equal(tt, req.URL.String(), fmt.Sprintf("%s?iccid=%s&cdr_type=%s&from=%s&to=%s&region=%s",
+				operatoragent.OperatorUsagesEndpoint, testIccid, cdrType, "lol", to, region))
+
+			return nil
+		}
+
+		testOperatorClient := operatoragent.NewOperatorAgentClient("")
+
+		testOperatorClient.R.C.SetTransport(RoundTripFunc(mockTransport))
+
+		u, c, err := testOperatorClient.GetUsages(testIccid, cdrType, "lol", to, region)
+
+		assert.Error(tt, err)
+		assert.Nil(tt, u)
+		assert.Nil(tt, c)
+	})
+
+	t.Run("InvalidParameterTo", func(tt *testing.T) {
+		mockTransport := func(req *http.Request) *http.Response {
+			assert.Equal(tt, req.URL.String(), fmt.Sprintf("%s?iccid=%s&cdr_type=%s&from=%s&to=%s&region=%s",
+				operatoragent.OperatorUsagesEndpoint, testIccid, cdrType, from, "lol", region))
+
+			return nil
+		}
+
+		testOperatorClient := operatoragent.NewOperatorAgentClient("")
+
+		testOperatorClient.R.C.SetTransport(RoundTripFunc(mockTransport))
+
+		u, c, err := testOperatorClient.GetUsages(testIccid, cdrType, from, "lol", region)
+
+		assert.Error(tt, err)
+		assert.Nil(tt, u)
+		assert.Nil(tt, c)
+	})
+
 	t.Run("RequestFailure", func(tt *testing.T) {
 		mockTransport := func(req *http.Request) *http.Response {
 			assert.Equal(tt, req.URL.String(), fmt.Sprintf("%s?iccid=%s&cdr_type=%s&from=%s&to=%s&region=%s",

--- a/systems/common/rest/client/ukamaagent/ukama_agent_test.go
+++ b/systems/common/rest/client/ukamaagent/ukama_agent_test.go
@@ -195,6 +195,44 @@ func TestUkamaClient_GetUsages(t *testing.T) {
 		assert.Nil(tt, c)
 	})
 
+	t.Run("InvalidParameterFrom", func(tt *testing.T) {
+		mockTransport := func(req *http.Request) *http.Response {
+			assert.Equal(tt, req.URL.String(), ukamaagent.UkamaUsageEndpoint+
+				fmt.Sprintf("/%s?from=%d&to=%d", testIccid, startTime, endTime))
+
+			return nil
+		}
+
+		testUkamaClient := ukamaagent.NewUkamaAgentClient("")
+
+		testUkamaClient.R.C.SetTransport(RoundTripFunc(mockTransport))
+
+		u, c, err := testUkamaClient.GetUsages(testIccid, cdrType, "lol", to, region)
+
+		assert.Error(tt, err)
+		assert.Nil(tt, u)
+		assert.Nil(tt, c)
+	})
+
+	t.Run("InvalidParameterTo", func(tt *testing.T) {
+		mockTransport := func(req *http.Request) *http.Response {
+			assert.Equal(tt, req.URL.String(), ukamaagent.UkamaUsageEndpoint+
+				fmt.Sprintf("/%s?from=%d&to=%d", testIccid, startTime, endTime))
+
+			return nil
+		}
+
+		testUkamaClient := ukamaagent.NewUkamaAgentClient("")
+
+		testUkamaClient.R.C.SetTransport(RoundTripFunc(mockTransport))
+
+		u, c, err := testUkamaClient.GetUsages(testIccid, cdrType, from, "to", region)
+
+		assert.Error(tt, err)
+		assert.Nil(tt, u)
+		assert.Nil(tt, c)
+	})
+
 	t.Run("RequestFailure", func(tt *testing.T) {
 		mockTransport := func(req *http.Request) *http.Response {
 			assert.Equal(tt, req.URL.String(), ukamaagent.UkamaUsageEndpoint+


### PR DESCRIPTION
This PR fixes #1036  and closes #1036  by providing the following:

-  Update date time validation conditions for ukama & operator rest clients.
-  Remove mandatory From and To requirements by adding sensible defaults for these values when they are missing.

fixes #1036 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update date time validation and default `from`/`to` parameters in `ukama` and `operator` clients, with corresponding tests.
> 
>   - **Behavior**:
>     - Update date time validation in `GetUsages()` in `operator_agent.go` and `ukama_agent.go`.
>     - Remove mandatory `from` and `to` parameters in `GetUsages()` by adding defaults in `ukama_agent.go`.
>   - **Tests**:
>     - Add tests for invalid `from` and `to` parameters in `operator_agent_test.go` and `ukama_agent_test.go`.
>     - Add tests for default `from` and `to` behavior in `ukama_agent_test.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for 92710789a7413e5c26756a0617a96a89e6e8b13b. You can [customize](https://app.ellipsis.dev/ukama/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->