### PR TITLE
Add active subscriber count per site on site page and site d…

### DIFF
--- a/interfaces/console/src/constants/index.tsx
+++ b/interfaces/console/src/constants/index.tsx
@@ -668,6 +668,15 @@ export const SITE_KPIS = {
         description: 'Node uptime',
         format: 'number',
       },
+      {
+        unit: '',
+        show: true,
+        name: 'Active subscribers',
+        format: 'number',
+        id: 'node_active_subscribers',
+        description: 'Current active subscriber on the site',
+        threshold: null,
+      },
     ],
   },
 };
@@ -896,4 +905,5 @@ export const SITE_KPI_TYPES = {
   BACKHAUL_SPEED: 'backhaul_speed',
   SITE_UPTIME_PERCENTAGE: 'site_uptime_percentage',
   NODE_UPTIME: 'unit_uptime',
+  ACTIVE_SUBSCRIBERS: 'node_active_subscribers',
 };

--- a/interfaces/console/src/constants/index.tsx
+++ b/interfaces/console/src/constants/index.tsx
@@ -674,7 +674,7 @@ export const SITE_KPIS = {
         name: 'Active subscribers',
         format: 'number',
         id: 'node_active_subscribers',
-        description: 'Current active subscriber on the site',
+        description: 'Current active subscribers on the site',
         threshold: null,
       },
     ],

--- a/interfaces/console/src/utils/index.tsx
+++ b/interfaces/console/src/utils/index.tsx
@@ -245,6 +245,12 @@ const structureNodeSiteDate = (nodes: Nodes, sites: SitesResDto) => {
 
   return t;
 };
+export const extractMetricValue = (value: any): number | null => {
+  if (Array.isArray(value) && value.length > 1) {
+    return typeof value[1] === 'number' ? value[1] : null;
+  }
+  return typeof value === 'number' ? value : null;
+};
 
 export const getMetricValue = (key: string, metrics: MetricsRes) => {
   const metric = metrics.metrics.find((item: MetricRes) => item.type === key);
@@ -620,9 +626,9 @@ const getStatusStyles = (type: StatusType, value: number): StyleOutput => {
     return value <= 0
       ? { color: colors.red, icon: <RouterIcon sx={{ color: colors.red }} /> }
       : {
-        color: colors.green,
-        icon: <RouterIcon sx={{ color: colors.green }} />,
-      };
+          color: colors.green,
+          icon: <RouterIcon sx={{ color: colors.green }} />,
+        };
   }
 
   if (type === 'battery') {

--- a/systems/console-bff/common/utils/index.ts
+++ b/systems/console-bff/common/utils/index.ts
@@ -223,6 +223,7 @@ const getGraphsKeyByType = (type: string): string[] => {
         "node_switch_port_status",
         "node_switch_port_speed",
         "node_switch_port_power",
+        "node_active_subscribers",
       ];
     default:
       return [];


### PR DESCRIPTION
…etails page
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add active subscriber count display on site and site details pages, with PubSub updates and new metric handling.
> 
>   - **Behavior**:
>     - Display active subscriber count on site pages and site details pages using `getSiteActiveSubscribers()` in `page.tsx` and `index.tsx`.
>     - Subscribe to `node_active_subscribers` updates via PubSub in `page.tsx` and `index.tsx`.
>   - **Components**:
>     - Update `SiteMapComponent` in `page.tsx` to show `userCount`.
>     - Update `SiteCard` in `index.tsx` to display `activeSubscribers`.
>   - **Constants**:
>     - Add `ACTIVE_SUBSCRIBERS` to `SITE_KPI_TYPES` in `constants/index.tsx`.
>     - Add `Active subscribers` metric to `SITE_KPIS` in `constants/index.tsx`.
>   - **Utils**:
>     - Add `extractMetricValue()` to `utils/index.tsx` for extracting metric values.
>     - Update `getGraphsKeyByType()` in `systems/console-bff/common/utils/index.ts` to include `node_active_subscribers`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for 780c98900286916b86e1ed51b7217df5d3f4ac9d. You can [customize](https://app.ellipsis.dev/ukama/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->