### PR TITLE
add check for newly connected nodeID, with inventory #1138

### DIFF
--- a/systems/messaging/mesh/src/callback.c
+++ b/systems/messaging/mesh/src/callback.c
@@ -71,7 +71,7 @@ int callback_websocket(const URequest *request, UResponse *response,
 	}
 
     if (verify_nodeid_with_inventory_system(nodeID) == FALSE) {
-        log_error("Unrecoganized nodeID for org. Rejecting. %s", nodeID);
+        log_error("Unrecognized nodeID for org. Rejecting. %s", nodeID);
         return U_CALLBACK_ERROR;
     }
 

--- a/systems/messaging/mesh/src/initClient.c
+++ b/systems/messaging/mesh/src/initClient.c
@@ -199,7 +199,7 @@ int get_systemInfo_from_initClient(char *systemName,
 /*
  * 1) Ask init system for "inventory" system credentials (host + port)
  * 2) Call inventory verify endpoint:
- *      http://{ip}:{port}/v1/orgs/{ORGNAME}/components/verify/{node_id}
+ *      http://{ip}:{port}/v1/components/verify/{node_id}
  *    (ORGNAME comes from ENV_SYSTEM_ORG)
  * 3) Return TRUE only if HTTP 200, otherwise FALSE (including if unreachable).
  */


### PR DESCRIPTION
before accepting the websocket connection. #1138
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds node ID verification against inventory system before accepting WebSocket connections in `callback.c`.
> 
>   - **Behavior**:
>     - Adds node ID verification in `callback_websocket()` in `callback.c` before accepting WebSocket connections.
>     - Rejects connection if `verify_nodeid_with_inventory_system()` returns `FALSE`.
>   - **Functions**:
>     - Adds `verify_nodeid_with_inventory_system()` in `initClient.c` to verify node ID against inventory system.
>     - Uses `get_systemInfo_from_initClient()` to get inventory system credentials.
>     - Constructs URL and sends HTTP request to verify node ID.
>   - **Error Handling**:
>     - Logs error and returns `U_CALLBACK_ERROR` if node ID is unrecognized or verification fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for a50084ecfd5a50978ad6da23159998f8c83f9104. You can [customize](https://app.ellipsis.dev/ukama/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->