### PR TITLE
add node-id to the http map header

### DIFF
--- a/nodes/ukamaOS/distro/system/meshd/src/network.c
+++ b/nodes/ukamaOS/distro/system/meshd/src/network.c
@@ -114,10 +114,7 @@ int start_websocket_client(Config *config,
 
         if (config->deviceInfo && config->deviceInfo->nodeID) {
             u_map_put(request.map_header, "User-Agent", config->deviceInfo->nodeID);
-        }
-
-        if (config->orgName && *config->orgName) {
-            u_map_put(request.map_header, "X-org-name", config->orgName);
+            u_map_put(request.map_header, "X-node-id",  config->deviceInfo->nodeID);
         }
 
         ulfius_add_websocket_client_deflate_extension(handler);


### PR DESCRIPTION
Fix #1172 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `X-node-id` header to websocket client requests in `network.c`.
> 
>   - **Behavior**:
>     - Adds `X-node-id` header in `start_websocket_client()` in `network.c` using `config->deviceInfo->nodeID`.
>     - Retains existing `User-Agent` header with `nodeID` value.
>   - **Misc**:
>     - Fixes #1172 by ensuring `nodeID` is included in headers for websocket connections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for 3362f8ed1506a3d457ae151c8519bc46aa215520. You can [customize](https://app.ellipsis.dev/ukama/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->