### PR TITLE
Vnode com, anode and trx memory metric key fix

### DIFF
--- a/nodes/configs/apps/metricsd/anode_config.toml
+++ b/nodes/configs/apps/metricsd/anode_config.toml
@@ -215,14 +215,14 @@ metric_server_port = 7001
                 labels = []
 
             [[stats.memory.swap.kpi]]
-                name = "Used memory"
+                name = "used_memory"
                 ext = ""
                 desc = "Used memory"
                 type = "METRICTYPE_GAUGE"
                 labels = []
 
             [[stats.memory.swap.kpi]]
-                name = "Free memory"
+                name = "free_memory"
                 ext = ""
                 desc = "Free memory"
                 type = "METRICTYPE_GAUGE"

--- a/nodes/configs/apps/metricsd/com_config.toml
+++ b/nodes/configs/apps/metricsd/com_config.toml
@@ -215,14 +215,14 @@ metric_server_port = 7001
                 labels = []
 
             [[stats.memory.swap.kpi]]
-                name = "Used memory"
+                name = "used_memory"
                 ext = ""
                 desc = "Used memory"
                 type = "METRICTYPE_GAUGE"
                 labels = []
 
             [[stats.memory.swap.kpi]]
-                name = "Free memory"
+                name = "free_memory"
                 ext = ""
                 desc = "Free memory"
                 type = "METRICTYPE_GAUGE"

--- a/nodes/configs/apps/metricsd/trx_config.toml
+++ b/nodes/configs/apps/metricsd/trx_config.toml
@@ -215,14 +215,14 @@ metric_server_port = 7001
                 labels = []
 
             [[stats.memory.swap.kpi]]
-                name = "Used memory"
+                name = "used_memory"
                 ext = ""
                 desc = "Used memory"
                 type = "METRICTYPE_GAUGE"
                 labels = []
 
             [[stats.memory.swap.kpi]]
-                name = "Free memory"
+                name = "free_memory"
                 ext = ""
                 desc = "Free memory"
                 type = "METRICTYPE_GAUGE"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames memory metric keys in `anode_config.toml`, `com_config.toml`, and `trx_config.toml` for consistency.
> 
>   - **Metric Key Renames**:
>     - In `anode_config.toml`, `com_config.toml`, and `trx_config.toml`, rename `"Used memory"` to `"used_memory"` and `"Free memory"` to `"free_memory"` under `[[stats.memory.swap.kpi]]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for f1fe768da05c2e52d26c572c8c4ad248e1300222. You can [customize](https://app.ellipsis.dev/ukama/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->