### PR TITLE
Fix port type, char* to int #1197

### DIFF
--- a/systems/messaging/mesh/inc/config.h
+++ b/systems/messaging/mesh/inc/config.h
@@ -15,7 +15,7 @@ typedef struct {
 
     char *bindingIP;      /* binding IP for websocket */
 	char *websocketPort;  /* to accept nodes via websocket */
-	char *servicesPort;   /* to accept services */
+	int  servicesPort;   /* to accept services */
     char *adminPort;      /* to accept admin services */
 
 	char *amqpHost;       /* Host where AMQP exchange is running (IP) */

--- a/systems/messaging/mesh/src/amqp.c
+++ b/systems/messaging/mesh/src/amqp.c
@@ -649,15 +649,23 @@ int publish_event(MeshEvent event, char *orgName,
                   char *meshIP, int meshPort) {
 
     WAMQPConn *conn=NULL;
-    char *amqpHost=NULL, *amqpPort=NULL, *amqpUser=NULL, *amqpPassword=NULL;
+    char *amqpHost=NULL;
+    char *amqpPort=NULL;
+    char *amqpUser=NULL;
+    char *amqpPassword=NULL;
 
-    amqpHost = getenv(ENV_AMQP_HOST);
-    amqpPort = getenv(ENV_AMQP_PORT);
-    amqpUser = getenv(ENV_AMQP_USER);
+    amqpHost     = getenv(ENV_AMQP_HOST);
+    amqpPort     = getenv(ENV_AMQP_PORT);
+    amqpUser     = getenv(ENV_AMQP_USER);
     amqpPassword = getenv(ENV_AMQP_PASSWORD);
+
     conn = init_amqp_connection(amqpHost, amqpPort, amqpUser, amqpPassword);
     if (conn == NULL) {
-        log_error("Failed to connect with AMQP at %s:%s@%s:%s", amqpUser, amqpPassword, amqpHost, amqpPort);
+        log_error("Failed to connect with AMQP at %s:%s@%s:%s",
+                  amqpUser,
+                  amqpPassword,
+                  amqpHost,
+                  amqpPort);
         return FALSE;
     }
 

--- a/systems/messaging/mesh/src/callback.c
+++ b/systems/messaging/mesh/src/callback.c
@@ -50,12 +50,12 @@ extern int start_forward_service(Config *config, UInst **forwardInst);
 int callback_websocket(const URequest *request, UResponse *response,
                        void *data) {
 	int ret, forwardPort;
-	char *nodeID=NULL;
-	Config *config=NULL;
-    MapItem *map=NULL;
+	char *nodeID = NULL;
+	Config *config = NULL;
+    MapItem *map = NULL;
     char ip[INET_ADDRSTRLEN]={0};
     struct sockaddr_in *sin = NULL;
-    UInst *forwardInst      = NULL;
+    UInst *forwardInst = NULL;
 
     config = (Config *)data;
 
@@ -108,19 +108,19 @@ int callback_websocket(const URequest *request, UResponse *response,
 
     map->configData = data;
 
-	/* Publish device (nodeID) 'connect' event to AMQP exchange */
-	if (publish_event(CONN_CONNECT,
+    /* Publish device (nodeID) 'connect' event to AMQP exchange */
+    if (publish_event(CONN_CONNECT,
                       config->orgName,
                       nodeID,
                       &ip[0], sin->sin_port,
                       config->bindingIP,
                       config->servicesPort) == FALSE) {
-		log_error("Error publishing device connect msg on AMQP exchange");
+        log_error("Error publishing device connect msg on AMQP exchange");
         remove_map_item_from_table(NodesTable, nodeID);
         ulfius_stop_framework(forwardInst);
         ulfius_clean_instance(forwardInst);
         return U_CALLBACK_ERROR;
-	}
+    }
 
     log_debug("Forward service started on port: %d for NodeID: %s",
               config->servicesPort, nodeID);

--- a/systems/messaging/mesh/src/config.c
+++ b/systems/messaging/mesh/src/config.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdio.h>
+#include <errno.h>
 
 #include "mesh.h"
 #include "config.h"
@@ -57,7 +58,6 @@ int read_config_from_env(Config **config) {
 
     (*config)->bindingIP      = strdup(bindingIP);
 	(*config)->websocketPort  = strdup(websocketPort);
-    (*config)->servicesPort   = strdup(servicesPort);
     (*config)->adminPort      = strdup(adminPort);
     (*config)->amqpHost       = strdup(amqpHost);
     (*config)->amqpPort       = strdup(amqpPort);
@@ -68,6 +68,22 @@ int read_config_from_env(Config **config) {
     (*config)->initClientPort = strdup(initClientPort);
     (*config)->orgName        = strdup(orgName);
     (*config)->orgID          = strdup(orgID);
+
+    /* get servicesPort */
+    {
+        char *end = NULL;
+        long portVal = 0;
+
+        errno = 0;
+        portVal = strtol(servicesPort, &end, 10);
+        if (errno != 0 || end == servicesPort || *end != '\0' ||
+            portVal < 1 || portVal > 65535) {
+            log_error("Invalid servicesPort: %s", servicesPort);
+            return FALSE;
+        }
+
+        (*config)->servicesPort = (int)portVal;
+    }
 
     if (!(*config)->logLevel) {
         log_debug("Log level not defined, setting to default: DEBUG");
@@ -83,7 +99,7 @@ void print_config(Config *config) {
     log_debug("Ukama org ID:   %s",  config->orgID);
     log_debug("Binding IP:     %s",  config->bindingIP);
 	log_debug("Websocket port: %s",  config->websocketPort);
-    log_debug("Services port:  %s",  config->servicesPort);
+    log_debug("Services port:  %d",  config->servicesPort);
     log_debug("Admin port:     %s",  config->adminPort);
 	log_debug("AMQP: %s:***@%s:%s",  config->amqpUser,
                                      config->amqpHost, config->amqpPort);
@@ -99,7 +115,6 @@ void clear_config(Config *config) {
 
     free(config->bindingIP);
     free(config->websocketPort);
-    free(config->servicesPort);
     free(config->adminPort);
 	free(config->amqpHost);
 	free(config->amqpPort);

--- a/systems/messaging/mesh/src/network.c
+++ b/systems/messaging/mesh/src/network.c
@@ -212,12 +212,12 @@ int start_forward_service(Config *config, UInst *forwardInst) {
 
     memset(&bindAddr, 0, sizeof(bindAddr));
     bindAddr.sin_family      = AF_INET;
-    bindAddr.sin_port        = htons(config->servicesPort);
+    bindAddr.sin_port        = config->servicesPort;
     bindAddr.sin_addr.s_addr = inet_addr(config->bindingIP);
 
 	if (init_framework(forwardInst,
                        NULL,
-                       atoi(config->servicesPort)) != TRUE) {
+                       config->servicesPort) != TRUE) {
 		log_error("Error initializing forward framework");
 		return FALSE;
 	}
@@ -228,12 +228,12 @@ int start_forward_service(Config *config, UInst *forwardInst) {
                         forwardInst,
                         FORWARD) == FALSE) {
 		log_error("Failed to start forward service at port %d",
-                  atoi(config->servicesPort));
+                  config->servicesPort);
 		return FALSE;
 	}
 
 	log_debug("Forward service accepting on port: %d",
-              atoi(config->servicesPort));
+              config->servicesPort);
 
     return TRUE;
 }
@@ -276,7 +276,7 @@ int start_admin_services(Config *config, UInst *adminInst) {
 	setup_admin_endpoints(config, adminInst);
 
 	if (!start_framework(config, adminInst, ADMIN)) {
-		log_error("Failed to start webservices for admin: %s",
+		log_error("Failed to start webservices for admin: %d",
                   config->adminPort);
 		return FALSE;
 	}


### PR DESCRIPTION
Fix #1197 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `servicesPort` type from `char*` to `int` in `Config` struct and update related code to handle it as an integer.
> 
>   - **Behavior**:
>     - Change `servicesPort` type from `char*` to `int` in `Config` struct in `config.h`.
>     - Update `read_config_from_env()` in `config.c` to convert `servicesPort` from string to integer using `strtol()`.
>     - Modify `print_config()` in `config.c` to log `servicesPort` as an integer.
>     - Update `clear_config()` in `config.c` to remove `free()` call for `servicesPort`.
>   - **Functions**:
>     - Update `start_forward_service()` in `network.c` to use `config->servicesPort` directly as an integer.
>     - Modify `callback_websocket()` in `callback.c` to pass `config->servicesPort` as an integer.
>   - **Misc**:
>     - Minor formatting changes in `amqp.c` for better readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for beab410e9c59fd0ca69891a3c9a8cc0292a93dd8. You can [customize](https://app.ellipsis.dev/ukama/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->