### PR TITLE
Empty string response #1199

### DIFF
--- a/nodes/ukamaOS/distro/system/meshd/src/jserdes.c
+++ b/nodes/ukamaOS/distro/system/meshd/src/jserdes.c
@@ -100,32 +100,36 @@ int serialize_device_info(json_t **json, NodeInfo *device) {
 
 int serialize_local_service_response(char **response, Message *message,
                                      int code, int len, char *data) {
+    json_t *json;
+    json_t *obj;
 
-    json_t *json, *obj;
-    
-    /* basic sanity check */
-	if (len == 0 || data == NULL || message == NULL)
-		return FALSE;
+    if (response == NULL || message == NULL) {
+        return FALSE;
+    }
 
-	json = json_object();
-	if (json == NULL) {
-		return FALSE;
-	}
+    if (data == NULL) {
+        data = "";
+        len = 0;
+    }
 
-	json_object_set_new(json, JSON_TYPE, json_string(MESH_SERVICE_RESPONSE));
+    json = json_object();
+    if (json == NULL)
+        return FALSE;
+
+    json_object_set_new(json, JSON_TYPE, json_string(MESH_SERVICE_RESPONSE));
     json_object_set_new(json, JSON_UUID, json_string(message->seqNo));
 
-	/* Add response info. */
-	json_object_set_new(json, JSON_MESSAGE, json_object());
-	obj = json_object_get(json, JSON_MESSAGE);
+    json_object_set_new(json, JSON_MESSAGE, json_object());
+    obj = json_object_get(json, JSON_MESSAGE);
+
     json_object_set_new(obj, JSON_CODE,   json_integer(code));
-	json_object_set_new(obj, JSON_LENGTH, json_integer(len));
-	json_object_set_new(obj, JSON_DATA,   json_string(data));
+    json_object_set_new(obj, JSON_LENGTH, json_integer(len));
+    json_object_set_new(obj, JSON_DATA,   json_string(data));
 
     *response = json_dumps(json, 0);
     json_decref(json);
 
-	return TRUE;
+    return (*response != NULL);
 }
 
 STATIC void serialize_message_data(URequest *request, char **data) {


### PR DESCRIPTION
Ok to have empty response with valid status code.

>➜  ukamaOS git:(mesh_1199) ✗ curl -X GET localhost:4444/device/v1/ping
➜  ukamaOS git:(mesh_1199) ✗ curl -X GET localhost:4444/device/v1/version
old_arch-95ff8c25e%                                                                                     ➜  ukamaOS git:(mesh_1199) ✗ pwd

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `serialize_local_service_response()` in `jserdes.c` now handles `NULL` `data` by setting it to an empty string, ensuring valid JSON responses with empty data.
> 
>   - **Behavior**:
>     - `serialize_local_service_response()` in `jserdes.c` now handles `NULL` `data` by setting `data` to an empty string and `len` to 0.
>     - Ensures valid JSON response even with empty data.
>   - **Misc**:
>     - Minor formatting changes in `serialize_local_service_response()` in `jserdes.c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ukama%2Fukama&utm_source=github&utm_medium=referral)<sup> for e8bde5aa10216ddcff6319559904784aef4e230f. You can [customize](https://app.ellipsis.dev/ukama/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->