### PR TITLE
Lookout #1273

### DIFF
--- a/nodes/configs/apps/aggregator/virtual_anode_config.toml
+++ b/nodes/configs/apps/aggregator/virtual_anode_config.toml
@@ -5,5 +5,5 @@ stale_grace_sec = 15
 
 [[source]]
 name = "local"
-url = "http://127.0.0.1:18007/metrics"
+url = "http://127.0.0.1:7001/metrics"
 required = true

--- a/nodes/configs/apps/aggregator/virtual_cnode_config.toml
+++ b/nodes/configs/apps/aggregator/virtual_cnode_config.toml
@@ -5,5 +5,5 @@ stale_grace_sec = 15
 
 [[source]]
 name = "local"
-url = "http://127.0.0.1:18007/metrics"
+url = "http://127.0.0.1:7001/metrics"
 required = true

--- a/nodes/configs/apps/metricsd/amplifier_config.toml
+++ b/nodes/configs/apps/metricsd/amplifier_config.toml
@@ -9,6 +9,8 @@
 version = "0.0.1"
 scraping_time_period = 5
 ukamnode = "CTL"
+# +1 will be for admin
+port = "7001"
 
 [[stats]]
         [[stats.generic]]

--- a/nodes/configs/apps/metricsd/cnode_config.toml
+++ b/nodes/configs/apps/metricsd/cnode_config.toml
@@ -9,6 +9,8 @@
 version = "0.0.1"
 scraping_time_period = 5
 ukamnode = "COM"
+# +1 will be for admin
+port = "7001"
 
 [[stats]]
         [[stats.generic]]

--- a/nodes/ukamaOS/distro/system/lookoutd/inc/config.h
+++ b/nodes/ukamaOS/distro/system/lookoutd/inc/config.h
@@ -9,13 +9,24 @@
 #ifndef CONFIG_H_
 #define CONFIG_H_
 
+#include <stdbool.h>
+
+typedef enum {
+    LOOKOUT_APP_MANAGER_STARTERD = 0,
+    LOOKOUT_APP_MANAGER_SUPERVISORD
+} LookoutAppManager;
+
 /* Service configuration */
 typedef struct {
 
-    int   servicePort;
-    int   nodedPort;
-    int   starterdPort;
-    char  *nodeID;
+    int servicePort;
+    int nodedPort;
+    int starterdPort;
+
+    char *nodeID;
+
+    LookoutAppManager appManager;
+    bool isTowerNode;
 } Config;
 
 #endif /* CONFIG_H_ */

--- a/nodes/ukamaOS/distro/system/lookoutd/inc/http_status.h
+++ b/nodes/ukamaOS/distro/system/lookoutd/inc/http_status.h
@@ -85,7 +85,7 @@ enum HttpStatusCode {
 	HttpStatus_NetworkAuthenticationRequired = 511,
 };
 
-static const char *HttpStatusStr(int code) {
+static inline const char *HttpStatusStr(int code) {
 
 	switch (code) {
 

--- a/nodes/ukamaOS/distro/system/lookoutd/inc/jserdes.h
+++ b/nodes/ukamaOS/distro/system/lookoutd/inc/jserdes.h
@@ -30,6 +30,8 @@ bool json_deserialize_capps(CappList **cappList, JsonObj *json);
 bool json_serialize_health_report(JsonObj **json,
                                   char *nodeID,
                                   CappList *list,
-                                  GPSClientData *gps);
+                                  GPSClientData *gps,
+                                  bool radioAvailable);
 
 #endif /* JSERDES_H_ */
+

--- a/nodes/ukamaOS/distro/system/lookoutd/inc/lookout.h
+++ b/nodes/ukamaOS/distro/system/lookoutd/inc/lookout.h
@@ -34,6 +34,14 @@
 #define DEF_NODE_ID            "ukama-aaa-bbbb-ccc-dddd"
 #define ENV_LOOKOUT_DEBUG_MODE "LOOKOUT_DEBUG_MODE"
 
+#define ENV_LOOKOUT_APP_MANAGER    "LOOKOUT_APP_MANAGER"
+#define LOOKOUT_MANAGER_STARTER    "starter"
+#define LOOKOUT_MANAGER_SUPERVISOR "supervisor"
+
+#define LOOKOUT_STATUS_NA         "not-available"
+#define LOOKOUT_GPS_COORD_NA      "-999.000000,-999.000000"
+#define LOOKOUT_GPS_TIME_NA       "not-available"
+
 #define EP_BS              "/"
 #define REST_API_VERSION   "v1"
 #define URL_PREFIX         EP_BS REST_API_VERSION
@@ -71,9 +79,9 @@ typedef struct _cappList {
     struct _cappList *next;
 } CappList;
 
-
 typedef struct {
 
+    bool  available;
     bool  gpsLock;
     char *coordinates; /* "lon,lat" */
     char *gpsTime;     /* string */

--- a/nodes/ukamaOS/distro/system/lookoutd/src/jserdes.c
+++ b/nodes/ukamaOS/distro/system/lookoutd/src/jserdes.c
@@ -21,10 +21,7 @@
 #include "usys_string.h"
 #include "usys_types.h"
 
-/* define in resources.c */
-extern int get_memory_usage(int pid);
-extern int get_disk_usage(int pid);
-extern double get_cpu_usage(int pid);
+/* defined in resources.c */
 extern char *get_radio_status(void);
 
 void json_log(json_t *json) {
@@ -38,11 +35,14 @@ void json_log(json_t *json) {
     }
 }
 
-static bool get_json_entry(json_t *json, char *key, json_type type,
-                           char **strValue, int *intValue,
+static bool get_json_entry(json_t *json,
+                           char *key,
+                           json_type type,
+                           char **strValue,
+                           int *intValue,
                            double *doubleValue) {
 
-    json_t *jEntry=NULL;
+    json_t *jEntry = NULL;
 
     if (json == NULL || key == NULL) return USYS_FALSE;
 
@@ -53,15 +53,18 @@ static bool get_json_entry(json_t *json, char *key, json_type type,
     }
 
     switch(type) {
-    case (JSON_STRING): 
+    case (JSON_STRING):
         *strValue = strdup(json_string_value(jEntry));
         break;
+
     case (JSON_INTEGER):
         *intValue = json_integer_value(jEntry);
         break;
+
     case (JSON_REAL):
         *doubleValue = json_real_value(jEntry);
         break;
+
     default:
         log_error("Invalid type for json key-value: %d", type);
         return USYS_FALSE;
@@ -70,35 +73,9 @@ static bool get_json_entry(json_t *json, char *key, json_type type,
     return USYS_TRUE;
 }
 
-/*
- * deserialize_node_info --
- *
- * {
- * "nodeInfo": {
- *   "UUID": "ukma-7001-tnode-sa03-1100",
- *   "name": "tNode",
- *   "type": 2,
- *   "partNumber": "LTE-BAND-3-0XXXX",
- *   "skew": "UK_TNODE-LTE-0001",
- *   "mac": "10:20:30:20:50:60",
- *   "prodSwVersion": {
- *     "major": 1,
- *     "minor": 1
- *   },
- *   "swVersion": {
- *     "major": 0,
- *     "minor": 0
- *   },
- *   "assemblyDate": "30-07-2020",
- *   "oemName": "SANMINA",
- *   "moduleCount": 3
- * }
- *}
- *
- */
 bool json_deserialize_node_id(char **nodeID, JsonObj *json) {
 
-    JsonObj *jNodeInfo=NULL;
+    JsonObj *jNodeInfo = NULL;
 
     if (json == NULL) return USYS_FALSE;
 
@@ -107,70 +84,180 @@ bool json_deserialize_node_id(char **nodeID, JsonObj *json) {
         log_error("Missing mandatory %s from JSON", JTAG_NODE_INFO);
         return USYS_FALSE;
     }
-    
-    if (get_json_entry(jNodeInfo, JTAG_UUID, JSON_STRING,
-                       nodeID, NULL, NULL) == USYS_FALSE) {
+
+    if (get_json_entry(jNodeInfo,
+                       JTAG_UUID,
+                       JSON_STRING,
+                       nodeID,
+                       NULL,
+                       NULL) == USYS_FALSE) {
         log_error("Error deserializing node info");
         json_log(json);
         *nodeID = NULL;
 
         return USYS_FALSE;
     }
-    
+
     return USYS_TRUE;
 }
 
+static const char *starter_state_to_ukama_status(const char *state) {
+
+    if (state == NULL) {
+        return "Unknown";
+    }
+
+    if (strcmp(state, "running") == 0) {
+        return "Active";
+    }
+
+    if (strcmp(state, "starting") == 0 ||
+        strcmp(state, "pending") == 0 ||
+        strcmp(state, "switching") == 0 ||
+        strcmp(state, "installing") == 0) {
+        return "Pending";
+    }
+
+    if (strcmp(state, "stopped") == 0 ||
+        strcmp(state, "exited") == 0 ||
+        strcmp(state, "failed") == 0 ||
+        strcmp(state, "fatal") == 0) {
+        return "Failure";
+    }
+
+    return "Unknown";
+}
+
+static void add_starter_app(CappList **cappList,
+                            const char *spaceName,
+                            JsonObj *jApp) {
+
+    JsonObj *jName = NULL;
+    JsonObj *jTag = NULL;
+    JsonObj *jState = NULL;
+    JsonObj *jPid = NULL;
+
+    const char *name = NULL;
+    const char *tag = NULL;
+    const char *state = NULL;
+    const char *status = NULL;
+    int pid = 0;
+
+    if (cappList == NULL || spaceName == NULL || jApp == NULL) {
+        return;
+    }
+
+    jName  = json_object_get(jApp, JTAG_NAME);
+    jTag   = json_object_get(jApp, JTAG_TAG);
+    jState = json_object_get(jApp, "state");
+    jPid   = json_object_get(jApp, JTAG_PID);
+
+    if (!json_is_string(jName)) {
+        return;
+    }
+
+    name = json_string_value(jName);
+
+    if (json_is_string(jTag)) {
+        tag = json_string_value(jTag);
+    } else {
+        tag = "latest";
+    }
+
+    if (json_is_string(jState)) {
+        state = json_string_value(jState);
+    } else {
+        state = "unknown";
+    }
+
+    if (json_is_integer(jPid)) {
+        pid = (int)json_integer_value(jPid);
+    }
+
+    status = starter_state_to_ukama_status(state);
+
+    add_capp_to_list(cappList,
+                     spaceName,
+                     name,
+                     tag,
+                     status,
+                     pid);
+}
+
 /*
- * "capps" : [
- *    {
- *      "space" : "boot",
- *      "name" : "example",
- *      "tag" : "0.0.1",
- *      "status" : "run",
- *      "pid" : "123"
- *    }
- * ]
+ * Latest starter.d status:
+ *
+ * {
+ *   "spaces": [
+ *     {
+ *       "name": "boot",
+ *       "apps": [
+ *         {
+ *           "name": "noded",
+ *           "tag": "old_arch-7bd935d06",
+ *           "state": "running",
+ *           "pid": 11
+ *         }
+ *       ]
+ *     }
+ *   ],
+ *   "starterd": {
+ *     "exitCode": 0,
+ *     "switchRequested": false,
+ *     "updateInProgress": false
+ *   }
+ * }
  */
 bool json_deserialize_capps(CappList **cappList, JsonObj *json) {
 
-    int i=0, count=0;
-    JsonObj *jCapp=NULL, *jArray=NULL;
-    JsonObj *jName=NULL, *jTag=NULL;
-    JsonObj *jStatus=NULL, *jPid=NULL;
-    JsonObj *jSpace=NULL;
+    int i = 0;
+    int j = 0;
+    int spaceCount = 0;
+    int appCount = 0;
+    int totalApps = 0;
 
-    if (json == NULL) {
+    JsonObj *jSpaces = NULL;
+    JsonObj *jSpace = NULL;
+    JsonObj *jSpaceName = NULL;
+    JsonObj *jApps = NULL;
+    JsonObj *jApp = NULL;
+
+    const char *spaceName = NULL;
+
+    if (json == NULL || cappList == NULL) {
         return USYS_FALSE;
     }
 
-    jArray = json_object_get(json, JTAG_CAPPS);
-    if (!json_is_array(jArray)) {
+    jSpaces = json_object_get(json, "spaces");
+    if (!json_is_array(jSpaces)) {
+        usys_log_error("starter.d status missing spaces[]");
         return USYS_FALSE;
     }
 
-    count = json_array_size(jArray);
-    for (i=0; i<count; i++) {
-        jCapp = json_array_get(jArray, i);
+    spaceCount = json_array_size(jSpaces);
 
-        if (jCapp == NULL) continue;
+    for (i = 0; i < spaceCount; i++) {
+        jSpace = json_array_get(jSpaces, i);
+        if (jSpace == NULL) continue;
 
-        jSpace  = json_object_get(jCapp, JTAG_SPACE);
-        jName   = json_object_get(jCapp, JTAG_NAME);
-        jTag    = json_object_get(jCapp, JTAG_TAG);
-        jStatus = json_object_get(jCapp, JTAG_STATUS);
-        jPid    = json_object_get(jCapp, JTAG_PID);
+        jSpaceName = json_object_get(jSpace, JTAG_NAME);
+        jApps = json_object_get(jSpace, "apps");
 
-        if (jSpace && jName && jTag && jStatus && jPid) {
-            add_capp_to_list(cappList,
-                             json_string_value(jSpace),
-                             json_string_value(jName),
-                             json_string_value(jTag),
-                             json_string_value(jStatus),
-                             json_integer_value(jPid));
+        if (!json_is_string(jSpaceName) || !json_is_array(jApps)) {
+            continue;
+        }
+
+        spaceName = json_string_value(jSpaceName);
+        appCount = json_array_size(jApps);
+
+        for (j = 0; j < appCount; j++) {
+            jApp = json_array_get(jApps, j);
+            add_starter_app(cappList, spaceName, jApp);
+            totalApps++;
         }
     }
 
-    usys_log_debug("Recevied %d capps from starter.d", count);
+    usys_log_debug("Received %d capps from starter.d", totalApps);
 
     return USYS_TRUE;
 }
@@ -179,7 +266,9 @@ static void json_add_resources_to_capp_report(JsonObj **json,
                                               CappRuntime *runtime) {
 
     JsonObj *jArray = NULL;
-    JsonObj *jMemory = NULL, *jDisk = NULL, *jCpu = NULL;
+    JsonObj *jMemory = NULL;
+    JsonObj *jDisk = NULL;
+    JsonObj *jCpu = NULL;
 
     char buffer[MAX_BUFFER] = {0};
 
@@ -191,7 +280,6 @@ static void json_add_resources_to_capp_report(JsonObj **json,
     jDisk   = json_object();
     jCpu    = json_object();
 
-    /* memory */
     sprintf(buffer, "%d", runtime->memory);
     json_object_set_new(jMemory,
                         JTAG_NAME,
@@ -200,7 +288,6 @@ static void json_add_resources_to_capp_report(JsonObj **json,
                         JTAG_VALUE,
                         json_string(buffer));
 
-    /* disk */
     sprintf(buffer, "%d", runtime->disk);
     json_object_set_new(jDisk,
                         JTAG_NAME,
@@ -209,7 +296,6 @@ static void json_add_resources_to_capp_report(JsonObj **json,
                         JTAG_VALUE,
                         json_string(buffer));
 
-    /* cpu */
     sprintf(buffer, "%f", runtime->cpu);
     json_object_set_new(jCpu,
                         JTAG_NAME,
@@ -223,25 +309,31 @@ static void json_add_resources_to_capp_report(JsonObj **json,
     json_array_append_new(jArray, jCpu);
 }
 
-static void json_add_system_info_to_report(JsonObj **json) {
+static void json_add_system_info_to_report(JsonObj **json,
+                                           bool radioAvailable) {
 
     JsonObj *jArray = NULL;
     JsonObj *jRadio = NULL;
 
     jRadio = json_object();
 
-    /* system */
     json_object_set_new(*json, JTAG_SYSTEM, json_array());
     jArray = json_object_get(*json, JTAG_SYSTEM);
     if (jArray == NULL) return;
 
-    /* radio */
     json_object_set_new(jRadio,
                         JTAG_NAME,
                         json_string("radio"));
-    json_object_set_new(jRadio,
-                        JTAG_VALUE,
-                        json_string(get_radio_status()));
+
+    if (radioAvailable == USYS_TRUE) {
+        json_object_set_new(jRadio,
+                            JTAG_VALUE,
+                            json_string(get_radio_status()));
+    } else {
+        json_object_set_new(jRadio,
+                            JTAG_VALUE,
+                            json_string(LOOKOUT_STATUS_NA));
+    }
 
     json_array_append_new(jArray, jRadio);
 }
@@ -251,17 +343,17 @@ static void json_add_gps_info_to_report(JsonObj **json, GPSClientData *gps) {
     JsonObj *jArray = NULL;
     JsonObj *jEntry = NULL;
 
-    const char *lockStr = "false";
-    const char *coord   = "";
-    const char *timeStr = "";
+    const char *lockStr = LOOKOUT_STATUS_NA;
+    const char *coord = LOOKOUT_GPS_COORD_NA;
+    const char *timeStr = LOOKOUT_GPS_TIME_NA;
 
     if (json == NULL || *json == NULL || gps == NULL) return;
 
     jArray = json_object_get(*json, JTAG_SYSTEM);
     if (jArray == NULL || !json_is_array(jArray)) return;
 
-    if (gps->gpsLock == USYS_TRUE) {
-        lockStr = "true";
+    if (gps->available == USYS_TRUE) {
+        lockStr = gps->gpsLock ? "true" : "false";
 
         if (gps->coordinates && gps->coordinates[0] != '\0') {
             coord = gps->coordinates;
@@ -272,108 +364,65 @@ static void json_add_gps_info_to_report(JsonObj **json, GPSClientData *gps) {
         }
     }
 
-    /* coordinates */
     jEntry = json_object();
-    json_object_set_new(jEntry, JTAG_NAME,  json_string("coordinates"));
+    json_object_set_new(jEntry, JTAG_NAME, json_string("coordinates"));
     json_object_set_new(jEntry, JTAG_VALUE, json_string(coord));
     json_array_append_new(jArray, jEntry);
 
-    /* gpsLock */
     jEntry = json_object();
-    json_object_set_new(jEntry, JTAG_NAME,  json_string("gpsLock"));
+    json_object_set_new(jEntry, JTAG_NAME, json_string("gpsLock"));
     json_object_set_new(jEntry, JTAG_VALUE, json_string(lockStr));
     json_array_append_new(jArray, jEntry);
 
-    /* gpsTime */
     jEntry = json_object();
-    json_object_set_new(jEntry, JTAG_NAME,  json_string("gpsTime"));
+    json_object_set_new(jEntry, JTAG_NAME, json_string("gpsTime"));
     json_object_set_new(jEntry, JTAG_VALUE, json_string(timeStr));
     json_array_append_new(jArray, jEntry);
 }
-/*
-{
-  "nodeID": "ukma-xx-xxx-xxxx-xxx",
-  "timestamp": "12345678",
-  "system": [
-    {
-      "name": "radio",
-      "value": "off"
-    },
-    {
-      "name": "coordinates",
-      "value": "90.0000, 0.00000"
-    },
-    {
-      "name": "gpsLock",
-      "value": "true"
-    },
-    {
-      "name": "gpsTime",
-      "value": "123456789"
-    }
-  ],
-  "capps": [
-    {
-      "space": "boot",
-      "name": "bootstrap",
-      "tag": "0.0.1",
-      "status": "run",
-      "resources": [
-        {
-          "name": "disk",
-          "value": "3456"
-        },
-        {
-          "name": "memory",
-          "value": "12345"
-        }
-      ]
-    }
-  ]
-  }
-*/
+
 bool json_serialize_health_report(JsonObj **json,
                                   char *nodeID,
                                   CappList *list,
-                                  GPSClientData *gps) {
+                                  GPSClientData *gps,
+                                  bool radioAvailable) {
 
-    JsonObj *jArray     = NULL;
-    JsonObj *jCapp      = NULL;
-    JsonObj *jResources = NULL;
-    CappList *ptr       = NULL;
-    Capp     *capp      = NULL;
-    char     buffer[MAX_BUFFER] = {0};
-    time_t   currTime;
+    JsonObj *jArray = NULL;
+    JsonObj *jCapp = NULL;
+    CappList *ptr = NULL;
+    Capp *capp = NULL;
+
+    char buffer[MAX_BUFFER] = {0};
+    time_t currTime;
 
     *json = json_object();
     if (*json == NULL) return USYS_FALSE;
 
-    /* nodeID */
     json_object_set_new(*json,
                         JTAG_NODE_ID,
-                        json_string(nodeID));
+                        json_string(nodeID ? nodeID : ""));
 
-    /* time-stamp */
     time(&currTime);
     sprintf(buffer, "%ld", (long)currTime);
     json_object_set_new(*json,
                         JTAG_TIMESTAMP,
                         json_string(buffer));
 
-    /* capps */
     json_object_set_new(*json, JTAG_CAPPS, json_array());
     jArray = json_object_get(*json, JTAG_CAPPS);
     if (jArray == NULL) {
         json_decref(*json);
+        *json = NULL;
         return USYS_FALSE;
     }
 
     for (ptr = list; ptr; ptr = ptr->next) {
         capp = ptr->capp;
+        if (capp == NULL || capp->runtime == NULL) {
+            continue;
+        }
 
-        jCapp      = json_object();
-        jResources = json_object();
-        if (jCapp == NULL || jResources == NULL) {
+        jCapp = json_object();
+        if (jCapp == NULL) {
             json_decref(*json);
             *json = NULL;
             return USYS_FALSE;
@@ -381,34 +430,31 @@ bool json_serialize_health_report(JsonObj **json,
 
         json_object_set_new(jCapp,
                             JTAG_SPACE,
-                            json_string(capp->space));
+                            json_string(capp->space ? capp->space : ""));
         json_object_set_new(jCapp,
                             JTAG_NAME,
-                            json_string(capp->name));
+                            json_string(capp->name ? capp->name : ""));
         json_object_set_new(jCapp,
                             JTAG_TAG,
-                            json_string(capp->tag));
+                            json_string(capp->tag ? capp->tag : ""));
         json_object_set_new(jCapp,
                             JTAG_STATUS,
-                            json_string(capp->runtime->status));
+                            json_string(capp->runtime->status ?
+                                        capp->runtime->status : "Unknown"));
 
         json_add_resources_to_capp_report(&jCapp, capp->runtime);
         json_array_append_new(jArray, jCapp);
     }
 
-    /* system */
-    json_add_system_info_to_report(json);
-
-    /* gps */
-    if (gps != NULL) {
-        json_add_gps_info_to_report(json, gps);
-    }
+    json_add_system_info_to_report(json, radioAvailable);
+    json_add_gps_info_to_report(json, gps);
 
     return USYS_TRUE;
 }
 
 void json_free(JsonObj** json) {
-    if (*json){
+
+    if (*json) {
         json_decref(*json);
         *json = NULL;
     }

--- a/nodes/ukamaOS/distro/system/lookoutd/src/main.c
+++ b/nodes/ukamaOS/distro/system/lookoutd/src/main.c
@@ -6,7 +6,11 @@
  * Copyright (c) 2023-present, Ukama Inc.
  */
 
+#include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "lookout.h"
 #include "config.h"
@@ -27,6 +31,7 @@
 extern int start_web_services(Config *config, UInst *serviceInst);
 
 void handle_sigint(int signum) {
+
     usys_log_debug("Terminate signal.\n");
     usys_exit(0);
 }
@@ -37,6 +42,42 @@ static UsysOption longOptions[] = {
     { "version",       no_argument, 0, 'v' },
     { 0, 0, 0, 0 }
 };
+
+static bool str_eq(const char *a, const char *b) {
+
+    if (a == NULL || b == NULL) return false;
+
+    return strcmp(a, b) == 0;
+}
+
+static bool node_id_is_tower(const char *nodeID) {
+
+    if (nodeID == NULL || nodeID[0] == '\0') {
+        return false;
+    }
+
+    if (strstr(nodeID, "tnode") != NULL) {
+        return true;
+    }
+
+    if (strstr(nodeID, "tower") != NULL) {
+        return true;
+    }
+
+    return false;
+}
+
+static void configure_app_manager(Config *config) {
+
+    char *mgr = NULL;
+
+    config->appManager = LOOKOUT_APP_MANAGER_STARTERD;
+
+    mgr = getenv(ENV_LOOKOUT_APP_MANAGER);
+    if (str_eq(mgr, LOOKOUT_MANAGER_SUPERVISOR)) {
+        config->appManager = LOOKOUT_APP_MANAGER_SUPERVISORD;
+    }
+}
 
 void set_log_level(char *slevel) {
 
@@ -49,6 +90,7 @@ void set_log_level(char *slevel) {
     } else if (!strcmp(slevel, "INFO")) {
         ilevel = USYS_LOG_INFO;
     }
+
     usys_log_set_level(ilevel);
 }
 
@@ -64,14 +106,13 @@ void usage() {
 int main(int argc, char **argv) {
 
     int opt, optIdx;
-    char *debug        = DEF_LOG_LEVEL;
-    UInst  serviceInst; 
+    char *debug = DEF_LOG_LEVEL;
+
+    UInst  serviceInst;
     Config serviceConfig = {0};
 
     usys_log_set_service(SERVICE_NAME);
-    //    usys_log_remote_init(SERVICE_NAME);
 
-    /* Parsing command line args. */
     while (true) {
 
         opt = 0;
@@ -105,50 +146,67 @@ int main(int argc, char **argv) {
         }
     }
 
-    serviceConfig.servicePort    = usys_find_service_port(SERVICE_NAME);
-    serviceConfig.nodedPort      = usys_find_service_port(SERVICE_NODE);
-    serviceConfig.starterdPort   = usys_find_service_port(SERVICE_STARTER);
-    serviceConfig.nodeID         = NULL;
+    configure_app_manager(&serviceConfig);
+
+    serviceConfig.servicePort  = usys_find_service_port(SERVICE_NAME);
+    serviceConfig.nodedPort    = usys_find_service_port(SERVICE_NODE);
+    serviceConfig.starterdPort = usys_find_service_port(SERVICE_STARTER);
+    serviceConfig.nodeID       = NULL;
+    serviceConfig.isTowerNode  = false;
 
     if (!usys_find_service_port(SERVICE_UKAMA)) {
         usys_log_error("Unable to determine the port for Ukama");
         usys_exit(1);
     }
 
-    if (!serviceConfig.servicePort  ||
-        !serviceConfig.nodedPort    ||
+    if (!serviceConfig.servicePort || !serviceConfig.nodedPort) {
+        usys_log_error("Unable to determine the port for required services");
+        usys_exit(1);
+    }
+
+    if (serviceConfig.appManager == LOOKOUT_APP_MANAGER_STARTERD &&
         !serviceConfig.starterdPort) {
-        usys_log_error("Unable to determine the port for services");
+        usys_log_error("Unable to determine the port for starter.d");
         usys_exit(1);
     }
 
     usys_log_debug("Starting %s ... ", SERVICE_NAME);
 
-    /* Signal handler */
     signal(SIGINT, handle_sigint);
 
-    /* Read Node Info from noded */
     if (getenv(ENV_LOOKOUT_DEBUG_MODE)) {
-       serviceConfig.nodeID = strdup(DEF_NODE_ID);
-       usys_log_debug("%s: Using default Node ID: %s", SERVICE_NAME, DEF_NODE_ID);
+        serviceConfig.nodeID = strdup(DEF_NODE_ID);
+        usys_log_debug("%s: Using default Node ID: %s",
+                       SERVICE_NAME,
+                       DEF_NODE_ID);
     } else {
         if (get_nodeid_from_noded(&serviceConfig) == STATUS_NOK) {
-            usys_log_error("%s: Unable to connect with node.d", SERVICE_NAME);
+            usys_log_error("%s: Unable to connect with node.d",
+                           SERVICE_NAME);
             goto done;
         }
     }
 
-    /* start web service */
+    serviceConfig.isTowerNode = node_id_is_tower(serviceConfig.nodeID);
+
+    usys_log_info("%s: nodeID=%s nodeType=%s appManager=%s",
+                  SERVICE_NAME,
+                  serviceConfig.nodeID,
+                  serviceConfig.isTowerNode ? "tower" : "non-tower",
+                  serviceConfig.appManager == LOOKOUT_APP_MANAGER_STARTERD ?
+                      "starter" : "supervisor");
+
     if (start_web_services(&serviceConfig, &serviceInst) != USYS_TRUE) {
-        usys_log_error("%s: unable to start webservice. Exiting.", SERVICE_NAME);
+        usys_log_error("%s: unable to start webservice. Exiting.",
+                       SERVICE_NAME);
         exit(1);
     }
 
-    /* until interrupted by SIG */
     while (USYS_TRUE) {
         if (send_health_report(&serviceConfig) == USYS_FALSE) {
             usys_log_error("Failed to send health report to ukama system");
         }
+
         sleep(DEF_REPORT_INTERVAL);
     }
 

--- a/nodes/ukamaOS/distro/system/lookoutd/src/web_client.c
+++ b/nodes/ukamaOS/distro/system/lookoutd/src/web_client.c
@@ -22,21 +22,6 @@ extern int    get_memory_usage(int pid);
 extern int    get_disk_usage(int pid);
 extern double get_cpu_usage(int pid);
 
-static bool is_container_environment(void) {
-
-    /* podman / docker / k8s */
-    if (getenv("container") != NULL) {
-        return USYS_TRUE;
-    }
-
-    /* podman guarantee */
-    if (access("/run/.containerenv", F_OK) == 0) {
-        return USYS_TRUE;
-    }
-
-    return USYS_FALSE;
-}
-
 static int wc_send_http_request(URequest* httpReq, UResponse** httpResp) {
 
     int ret = STATUS_NOK;
@@ -55,9 +40,11 @@ static int wc_send_http_request(URequest* httpReq, UResponse** httpResp) {
 
     ret = ulfius_send_http_request(httpReq, *httpResp);
     if (ret != STATUS_OK) {
-        usys_log_error( "Web client failed to send %s web request to %s",
-                        httpReq->http_verb, httpReq->http_url);
+        usys_log_error("Web client failed to send %s web request to %s",
+                       httpReq->http_verb,
+                       httpReq->http_url);
     }
+
     return ret;
 }
 
@@ -66,9 +53,9 @@ static URequest* wc_create_http_request(char* url,
                                         char* body) {
 
     JsonObj *jBody = NULL;
+    URequest* httpReq = NULL;
 
-    /* Preparing Request */
-    URequest* httpReq = (URequest *)usys_calloc(1, sizeof(URequest));
+    httpReq = (URequest *)usys_calloc(1, sizeof(URequest));
     if (!httpReq) {
         usys_log_error("Error allocating memory of size: %lu for http Request",
                        sizeof(URequest));
@@ -77,13 +64,15 @@ static URequest* wc_create_http_request(char* url,
 
     if (ulfius_init_request(httpReq)) {
         usys_log_error("Error initializing new http request.");
+        usys_free(httpReq);
         return NULL;
     }
 
     ulfius_set_request_properties(httpReq,
                                   U_OPT_HTTP_VERB, method,
                                   U_OPT_HTTP_URL, url,
-                                  U_OPT_HEADER_PARAMETER, "User-Agent", SERVICE_NAME,
+                                  U_OPT_HEADER_PARAMETER, "User-Agent",
+                                  SERVICE_NAME,
                                   U_OPT_TIMEOUT, 20,
                                   U_OPT_NONE);
 
@@ -133,7 +122,9 @@ static int wc_send_request_raw(char *url,
     if (respBody && httpResp->binary_body && httpResp->binary_body_length > 0) {
         *respBody = (char *)usys_calloc(1, httpResp->binary_body_length + 1);
         if (*respBody) {
-            memcpy(*respBody, httpResp->binary_body, httpResp->binary_body_length);
+            memcpy(*respBody,
+                   httpResp->binary_body,
+                   httpResp->binary_body_length);
             (*respBody)[httpResp->binary_body_length] = '\0';
         }
     }
@@ -143,6 +134,7 @@ cleanup:
         ulfius_clean_request(httpReq);
         usys_free(httpReq);
     }
+
     if (httpResp) {
         ulfius_clean_response(httpResp);
         usys_free(httpResp);
@@ -179,11 +171,11 @@ static int wc_send_request(char *url,
         json = ulfius_get_json_body_response(httpResp, &jErr);
         if (json) {
             *buffer = json_dumps(json, 0);
-            ret     = STATUS_OK;
+            ret = STATUS_OK;
         }
     } else {
         *buffer = NULL;
-        ret     = STATUS_NOK;
+        ret = STATUS_NOK;
     }
 
     json_decref(json);
@@ -193,6 +185,7 @@ cleanup:
         ulfius_clean_request(httpReq);
         usys_free(httpReq);
     }
+
     if (httpResp) {
         ulfius_clean_response(httpResp);
         usys_free(httpResp);
@@ -209,12 +202,12 @@ static int wc_read_from_local_service(Config* config,
     char url[MAX_BUFFER] = {0};
 
     if (service == SERVICE_NODED) {
-        sprintf(url,"http://%s:%d/%s",
+        sprintf(url, "http://%s:%d/%s",
                 DEF_NODED_HOST,
                 config->nodedPort,
                 DEF_NODED_EP);
     } else if (service == SERVICE_STARTERD) {
-        sprintf(url,"http://%s:%d/%s",
+        sprintf(url, "http://%s:%d/%s",
                 DEF_STARTERD_HOST,
                 config->starterdPort,
                 DEF_STARTERD_EP);
@@ -276,17 +269,15 @@ static int get_capps_from_supervisord(Config *config, CappList **cappList) {
         memset(procName, 0, sizeof(procName));
         memset(procState, 0, sizeof(procState));
         pid = 0;
+        ukamaStatus = "Unknown";
 
-        /* Examples:
-         * meshd_latest RUNNING pid 456, uptime 0:10:12
-         * bootstrap_latest STOPPED Not started
-         */
         if (sscanf(line, "%127s %31s pid %d",
-                   procName, procState, &pid) < 2) {
+                   procName,
+                   procState,
+                   &pid) < 2) {
             continue;
         }
 
-        /* Only Ukama apps */
         if (strstr(procName, "_latest") == NULL) {
             continue;
         }
@@ -304,12 +295,6 @@ static int get_capps_from_supervisord(Config *config, CappList **cappList) {
             pid = 0;
         }
 
-        /*
-         * Naming convention:
-         * <app>_latest
-         * space = "system"
-         * tag   = "latest"
-         */
         add_capp_to_list(cappList,
                          "system",
                          procName,
@@ -355,8 +340,36 @@ static void wc_free_gps_data(GPSClientData *gps) {
 
     usys_free(gps->coordinates);
     usys_free(gps->gpsTime);
+
+    gps->available   = USYS_FALSE;
+    gps->gpsLock     = USYS_FALSE;
     gps->coordinates = NULL;
     gps->gpsTime     = NULL;
+}
+
+static void wc_free_capp_list(CappList *list) {
+
+    CappList *ptr = NULL;
+    CappList *next = NULL;
+
+    for (ptr = list; ptr; ptr = next) {
+        next = ptr->next;
+
+        if (ptr->capp) {
+            usys_free(ptr->capp->space);
+            usys_free(ptr->capp->name);
+            usys_free(ptr->capp->tag);
+
+            if (ptr->capp->runtime) {
+                usys_free(ptr->capp->runtime->status);
+                usys_free(ptr->capp->runtime);
+            }
+
+            usys_free(ptr->capp);
+        }
+
+        usys_free(ptr);
+    }
 }
 
 static int get_gps_data(GPSClientData *gps) {
@@ -372,18 +385,17 @@ static int get_gps_data(GPSClientData *gps) {
         return STATUS_NOK;
     }
 
+    gps->available   = USYS_TRUE;
     gps->gpsLock     = USYS_FALSE;
     gps->coordinates = NULL;
     gps->gpsTime     = NULL;
 
-    /* resolve local GPS service port */
     port = usys_find_service_port(SERVICE_GPS);
     if (port <= 0) {
         usys_log_error("Failed to resolve port for %s", SERVICE_GPS);
         return STATUS_NOK;
     }
 
-    /* lock: GET http://localhost:<port>/v1/lock  -> 200 empty if locked else 404 */
     snprintf(url, sizeof(url), "http://localhost:%d/v1/lock", port);
     ret = wc_send_request_raw(url, "GET", NULL, &status, &body);
     usys_free(body);
@@ -396,26 +408,26 @@ static int get_gps_data(GPSClientData *gps) {
 
     if (status != HttpStatus_OK) {
         gps->gpsLock = USYS_FALSE;
-        return STATUS_OK; /* not locked is not a client failure */
+        return STATUS_OK;
     }
 
     gps->gpsLock = USYS_TRUE;
 
-    /* coordinates: GET http://localhost:<port>/v1/coordinates -> 200 "lon,lat" else 404 */
     snprintf(url, sizeof(url), "http://localhost:%d/v1/coordinates", port);
     ret = wc_send_request_raw(url, "GET", NULL, &status, &body);
     if (ret == STATUS_OK && status == HttpStatus_OK && body && body[0] != '\0') {
         gps->coordinates = strdup(body);
     }
+
     usys_free(body);
     body = NULL;
 
-    /* time: GET http://localhost:<port>/v1/time -> 200 "<time>" else 404 */
     snprintf(url, sizeof(url), "http://localhost:%d/v1/time", port);
     ret = wc_send_request_raw(url, "GET", NULL, &status, &body);
     if (ret == STATUS_OK && status == HttpStatus_OK && body && body[0] != '\0') {
         gps->gpsTime = strdup(body);
     }
+
     usys_free(body);
     body = NULL;
 
@@ -440,8 +452,11 @@ int send_health_report(Config *config) {
     GPSClientData gps;
     memset(&gps, 0, sizeof(GPSClientData));
 
-    /* Get capps */
-    if (is_container_environment()) {
+    if (config == NULL || config->nodeID == NULL) {
+        return USYS_FALSE;
+    }
+
+    if (config->appManager == LOOKOUT_APP_MANAGER_SUPERVISORD) {
         status = get_capps_from_supervisord(config, &cappList);
         if (status != STATUS_OK) {
             usys_log_error("Unable to get capps from supervisord");
@@ -453,11 +468,14 @@ int send_health_report(Config *config) {
         }
     }
 
-    /* Collect resource usage only if we got capps */
     if (status == STATUS_OK) {
         for (ptr = cappList; ptr; ptr = ptr->next) {
+            if (ptr->capp == NULL || ptr->capp->runtime == NULL) {
+                continue;
+            }
+
             runtime = ptr->capp->runtime;
-            if (runtime == NULL || runtime->pid <= 0) {
+            if (runtime->pid <= 0) {
                 continue;
             }
 
@@ -467,31 +485,40 @@ int send_health_report(Config *config) {
         }
     }
 
-    /* GPS data (best-effort) */
-    if (get_gps_data(&gps) != STATUS_OK) {
-        gps.gpsLock = USYS_FALSE;
-        gps.coordinates = NULL;
-        gps.gpsTime = NULL;
+    gps.available = config->isTowerNode;
+
+    if (config->isTowerNode) {
+        if (get_gps_data(&gps) != STATUS_OK) {
+            gps.available = USYS_TRUE;
+            gps.gpsLock = USYS_FALSE;
+            gps.coordinates = NULL;
+            gps.gpsTime = NULL;
+        }
     }
 
     if (!json_serialize_health_report(&json,
                                       config->nodeID,
                                       cappList,
-                                      &gps)) {
+                                      &gps,
+                                      config->isTowerNode)) {
         usys_log_error("Error serializing health report. Ignoring");
         wc_free_gps_data(&gps);
+        wc_free_capp_list(cappList);
         return USYS_FALSE;
     }
 
     wc_free_gps_data(&gps);
 
     usys_find_ukama_service_address(&ukama);
-    sprintf(url,"%s/node/v1/health/nodes/%s/performance",
-            ukama, config->nodeID);
+    sprintf(url, "%s/node/v1/health/nodes/%s/performance",
+            ukama,
+            config->nodeID);
+
     report = json_dumps(json, 0);
 
     usys_log_debug("Sending to URL: %s the health report %s",
-                   url, report);
+                   url,
+                   report);
 
     if (wc_send_request(url, "POST", report, &buffer) == STATUS_NOK) {
         usys_log_error("failed to parse response from local service");
@@ -500,7 +527,10 @@ int send_health_report(Config *config) {
 
     json_decref(json);
     usys_free(report);
+    usys_free(buffer);
     usys_free(ukama);
+    wc_free_capp_list(cappList);
+
     return ret;
 }
 
@@ -514,7 +544,11 @@ void add_capp_to_list(CappList **list,
     CappList *newEntry = NULL;
     CappList *tail = NULL;
 
-    if (list == NULL || space == NULL || name == NULL || tag == NULL || status == NULL) {
+    if (list == NULL ||
+        space == NULL ||
+        name == NULL ||
+        tag == NULL ||
+        status == NULL) {
         return;
     }
 
@@ -549,13 +583,11 @@ void add_capp_to_list(CappList **list,
 
     newEntry->next = NULL;
 
-    /* First entry */
     if (*list == NULL) {
         *list = newEntry;
         return;
     }
 
-    /* Append to tail */
     tail = *list;
     while (tail->next != NULL) {
         tail = tail->next;

--- a/testing/node/apps/lookoutd.toml
+++ b/testing/node/apps/lookoutd.toml
@@ -1,21 +1,24 @@
 [build-from]
-        base="alpine"
-        version="latest"
+    base="alpine"
+    version="latest"
 
 [build-compile]
-	version="0.1"
-	static="false"
-	source="/nodes/ukamaOS/distro/system/lookoutd"
-	cmd="make"
-	bin_from="/nodes/ukamaOS/distro/system/lookoutd/lookout.d"
-	bin_to="/sbin"
+    version="0.1"
+    static="false"
+    source="/nodes/ukamaOS/distro/system/lookoutd"
+    cmd="make"
+    bin_from="/nodes/ukamaOS/distro/system/lookoutd/lookout.d"
+    bin_to="/sbin"
 
 [app-exec]
-	name="lookoutd"
-	version="latest"
-	bin="lookout.d"
-	path="/sbin"
-	autostart="false"
-        autorestart="true"
-        startretries=5
-	group="service"
+    name="lookoutd"
+    version="latest"
+    bin="lookout.d"
+    path="/sbin"
+    autostart="false"
+    autorestart="true"
+    startretries=5
+    group="service"
+
+[app-exec.env]
+    LOOKOUT_APP_MANAGER="starter"


### PR DESCRIPTION
This PR fixes #1273 

Fix lookoutd health reporting for starter-based nodes.

This PR updates lookoutd to use starter.d as the default app-status source, with optional LOOKOUT_APP_MANAGER=supervisor support for supervisor-based environments. It updates parsing to match the latest starter.d /v1/status response format using spaces[].apps[].

It also makes GPS and radio reporting node-aware. GPS and radio are only queried for Tower nodes; other node types now report clear not-available values instead of trying to contact services that do not exist. Debug mode behavior is unchanged: lookoutd still uses DEF_NODE_ID when ENV_LOOKOUT_DEBUG_MODE is set, otherwise it gets the node ID from node.d