### PR TITLE
Update lookout health report

### DIFF
--- a/nodes/ukamaOS/distro/system/lookoutd/docs/report
+++ b/nodes/ukamaOS/distro/system/lookoutd/docs/report
@@ -1,88 +1,423 @@
 {
-  "nodeID": "emu-cnode",
-  "timestamp": "1715274302",
-  "capps": [
+  "schemaVersion": "1.0",
+  "nodeId": "...",
+  "nodeType": "tower | amplifier | control | unknown",
+  "reportedAt": "...",
+  "capabilities": [],
+  "system": {},
+  "interfaces": {},
+  "apps": [],
+  "events": []
+}
+
+=== Capability mapping ===
+{
+  "tower": [
+    "power",
+    "cellular",
+    "radio",
+    "gps",
+    "backhaul"
+  ],
+  "amplifier": [
+    "power",
+    "radio",
+    "fem"
+  ],
+  "control": [
+    "power",
+    "switch",
+    "controller",
+    "backhaul"
+  ]
+}    
+    
+=== Generic ====
+{
+  "schemaVersion": "1.0",
+  "nodeId": "node-abc",
+  "nodeType": "tower",
+  "reportedAt": "2026-05-10T18:30:00Z",
+
+  "capabilities": [
+    "power",
+    "radio"
+  ],
+
+  "system": {
+    "uptimeSec": 86400,
+    "starter": {
+      "available": true,
+      "state": "ready",
+      "updateInProgress": false,
+      "switchRequested": false,
+      "terminateRequested": false,
+      "exitCode": 0
+    },
+    "power": {
+      "available": true,
+      "ok": true,
+      "board": "tower",
+      "reason": "",
+      "totalWatts": 42.5,
+      "temperatureC": 44.2
+    }
+  },
+
+  "interfaces": {},
+
+  "apps": [
+    {
+      "space": "services",
+      "name": "deviced",
+      "tag": "latest",
+      "version": "latest",
+      "state": "running",
+      "pid": 1234,
+      "resources": {
+        "cpuPercent": 3.2,
+        "memoryRssKb": 18432,
+        "diskReadBytes": 0,
+        "diskWriteBytes": 204800
+      }
+    }
+  ],
+
+  "events": []
+}
+
+=== Tower node ===
+{
+  "schemaVersion": "1.0",
+  "nodeId": "tnode-abc",
+  "nodeType": "tower",
+  "reportedAt": "2026-05-10T18:30:00Z",
+
+  "capabilities": [
+    "power",
+    "cellular",
+    "radio",
+    "gps",
+    "backhaul"
+  ],
+
+  "system": {
+    "uptimeSec": 86400,
+    "starter": {
+      "available": true,
+      "state": "ready",
+      "updateInProgress": false,
+      "switchRequested": false,
+      "terminateRequested": false,
+      "exitCode": 0
+    },
+    "power": {
+      "available": true,
+      "ok": true,
+      "board": "tower",
+      "reason": "",
+      "totalWatts": 42.5,
+      "temperatureC": 44.2
+    }
+  },
+
+  "interfaces": {
+    "cellular": {
+      "available": false,
+      "error": "cellular_status_not_supported"
+    },
+    "radio": {
+      "available": true,
+      "state": "on"
+    },
+    "gps": {
+      "available": true,
+      "lock": true,
+      "coordinates": "-114.0719,51.0447",
+      "time": "2026-05-10T18:29:55Z"
+    },
+    "backhaul": {
+      "available": true,
+      "state": "GOOD",
+      "linkGuess": "TERRESTRIAL_LIKE",
+      "confidence": 0.92
+    }
+  },
+
+  "apps": [
+    {
+      "space": "services",
+      "name": "deviced",
+      "tag": "latest",
+      "version": "latest",
+      "state": "running",
+      "pid": 1234,
+      "resources": {
+        "cpuPercent": 3.2,
+        "memoryRssKb": 18432,
+        "diskReadBytes": 0,
+        "diskWriteBytes": 204800
+      }
+    },
+    {
+      "space": "services",
+      "name": "gpsd",
+      "tag": "latest",
+      "version": "latest",
+      "state": "running",
+      "pid": 1235,
+      "resources": {
+        "cpuPercent": 1.1,
+        "memoryRssKb": 9200,
+        "diskReadBytes": 0,
+        "diskWriteBytes": 35000
+      }
+    }
+  ],
+
+  "events": []
+}
+
+=== Amplifier node ===
+{
+  "schemaVersion": "1.0",
+  "nodeId": "anode-abc",
+  "nodeType": "amplifier",
+  "reportedAt": "2026-05-10T18:30:00Z",
+
+  "capabilities": [
+    "power",
+    "radio",
+    "fem"
+  ],
+
+  "system": {
+    "uptimeSec": 86400,
+    "starter": {
+      "available": true,
+      "state": "ready",
+      "updateInProgress": false,
+      "switchRequested": false,
+      "terminateRequested": false,
+      "exitCode": 0
+    },
+    "power": {
+      "available": true,
+      "ok": true,
+      "board": "amplifier",
+      "reason": "",
+      "totalWatts": 61.8,
+      "temperatureC": 48.6
+    }
+  },
+
+  "interfaces": {
+    "radio": {
+      "available": true,
+      "state": "on"
+    },
+    "fem": {
+      "available": true,
+      "fems": [
+        {
+          "unit": 1,
+          "present": true,
+          "gpio": {
+            "txRfEnable": true,
+            "rxRfEnable": true,
+            "paVdsEnable": true,
+            "rfPalEnable": true,
+            "vds28vEnable": true,
+            "psuPgood": true
+          }
+        },
+        {
+          "unit": 2,
+          "present": true,
+          "gpio": {
+            "txRfEnable": true,
+            "rxRfEnable": true,
+            "paVdsEnable": true,
+            "rfPalEnable": true,
+            "vds28vEnable": true,
+            "psuPgood": true
+          }
+        }
+      ]
+    }
+  },
+
+  "apps": [
+    {
+      "space": "services",
+      "name": "femd",
+      "tag": "latest",
+      "version": "latest",
+      "state": "running",
+      "pid": 1236,
+      "resources": {
+        "cpuPercent": 1.4,
+        "memoryRssKb": 9800,
+        "diskReadBytes": 0,
+        "diskWriteBytes": 68000
+      }
+    }
+  ],
+
+  "events": []
+}
+
+=== Controller Node ===
+{
+  "schemaVersion": "1.0",
+  "nodeId": "cnode-abc",
+  "nodeType": "control",
+  "reportedAt": "2026-05-10T18:30:00Z",
+
+  "capabilities": [
+    "power",
+    "switch",
+    "controller",
+    "backhaul"
+  ],
+
+  "system": {
+    "uptimeSec": 86400,
+    "starter": {
+      "available": true,
+      "state": "ready",
+      "updateInProgress": false,
+      "switchRequested": false,
+      "terminateRequested": false,
+      "exitCode": 0
+    },
+    "power": {
+      "available": true,
+      "ok": true,
+      "board": "control",
+      "reason": "",
+      "totalWatts": 18.2,
+      "temperatureC": 41.0
+    }
+  },
+
+  "interfaces": {
+    "switch": {
+      "available": true,
+      "reachable": true,
+      "state": "ready",
+      "model": "Tycon TP-SW8GAT/BT",
+      "softwareVersion": "SW-1.0.0",
+      "portCount": 9,
+      "policy": {
+        "state": "loaded",
+        "hash": "abc123",
+        "source": "backend",
+        "error": ""
+      },
+      "ports": [
+        {
+          "id": 1,
+          "name": "port1",
+          "present": true,
+          "adminState": "up",
+          "linkState": "up",
+          "poeState": "on",
+          "poeOperational": true,
+          "speedBps": 1000000000,
+          "powerWatts": 12.5,
+          "fault": ""
+        },
+        {
+          "id": 2,
+          "name": "port2",
+          "present": true,
+          "adminState": "up",
+          "linkState": "up",
+          "poeState": "on",
+          "poeOperational": true,
+          "speedBps": 1000000000,
+          "powerWatts": 18.2,
+          "fault": ""
+        }
+      ]
+    },
+
+    "controller": {
+      "available": true,
+      "commOk": true,
+      "chargeState": "bulk",
+      "errorCode": 0,
+      "error": "",
+      "activeAlarmCount": 0,
+      "solar": {
+        "voltageV": 37.4,
+        "currentA": 4.8,
+        "powerW": 179.5
+      },
+      "battery": {
+        "voltageV": 25.6,
+        "currentA": 2.1,
+        "socPct": 82
+      },
+      "load": {
+        "outputOn": true,
+        "currentA": 3.8
+      }
+    },
+
+    "backhaul": {
+      "available": true,
+      "state": "GOOD",
+      "linkGuess": "TERRESTRIAL_LIKE",
+      "confidence": 0.92
+    }
+  },
+
+  "apps": [
     {
       "space": "services",
       "name": "switchd",
       "tag": "latest",
-      "status": "Active",
-      "resources": [
-        {
-          "name": "memory",
-          "value": "13000 bytes"
-        },
-        {
-          "name": "disk",
-          "value": "6000 bytes"
-        },
-        {
-          "name": "cpu",
-          "value": "0.10 %"
-        }
-      ]
+      "version": "latest",
+      "state": "running",
+      "pid": 1234,
+      "resources": {
+        "cpuPercent": 2.0,
+        "memoryRssKb": 15200,
+        "diskReadBytes": 0,
+        "diskWriteBytes": 99000
+      }
     },
     {
       "space": "services",
       "name": "controllerd",
       "tag": "latest",
-      "status": "Active",
-      "resources": [
-        {
-          "name": "memory",
-          "value": "12500 bytes"
-        },
-        {
-          "name": "disk",
-          "value": "5500 bytes"
-        },
-        {
-          "name": "cpu",
-          "value": "0.08 %"
-        }
-      ]
+      "version": "latest",
+      "state": "running",
+      "pid": 1237,
+      "resources": {
+        "cpuPercent": 1.7,
+        "memoryRssKb": 13400,
+        "diskReadBytes": 0,
+        "diskWriteBytes": 87000
+      }
+    },
+    {
+      "space": "services",
+      "name": "backhauld",
+      "tag": "latest",
+      "version": "latest",
+      "state": "running",
+      "pid": 1238,
+      "resources": {
+        "cpuPercent": 0.9,
+        "memoryRssKb": 11200,
+        "diskReadBytes": 0,
+        "diskWriteBytes": 42000
+      }
     }
   ],
-  "system": [
-    {
-      "name": "radio",
-      "value": "not-available"
-    },
-    {
-      "name": "coordinates",
-      "value": "-999.000000,-999.000000"
-    },
-    {
-      "name": "gpsLock",
-      "value": "not-available"
-    },
-    {
-      "name": "gpsTime",
-      "value": "not-available"
-    },
-    {
-      "name": "switch",
-      "value": "available"
-    },
-    {
-      "name": "switchPolicySiteID",
-      "value": "emu-site"
-    },
-    {
-      "name": "switchPolicy",
-      "value": "loaded"
-    },
-    {
-      "name": "switchPolicyHash",
-      "value": "fnv64:6a1b2c3d4e5f6789"
-    },
-    {
-      "name": "switchPolicySource",
-      "value": "local-file"
-    },
-    {
-      "name": "switchPolicyError",
-      "value": ""
-    }
-  ]
+
+  "events": []
 }

--- a/nodes/ukamaOS/distro/system/lookoutd/inc/config.h
+++ b/nodes/ukamaOS/distro/system/lookoutd/inc/config.h
@@ -1,11 +1,3 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- *
- * Copyright (c) 2023-present, Ukama Inc.
- */
-
 #ifndef CONFIG_H_
 #define CONFIG_H_
 
@@ -16,8 +8,13 @@ typedef enum {
     LOOKOUT_APP_MANAGER_SUPERVISORD
 } LookoutAppManager;
 
-/* Service configuration */
-/* Service configuration */
+typedef enum {
+    LOOKOUT_NODE_UNKNOWN = 0,
+    LOOKOUT_NODE_TOWER,
+    LOOKOUT_NODE_AMPLIFIER,
+    LOOKOUT_NODE_CONTROL
+} LookoutNodeType;
+
 typedef struct {
 
     int servicePort;
@@ -27,8 +24,11 @@ typedef struct {
     char *nodeID;
 
     LookoutAppManager appManager;
+    LookoutNodeType   nodeType;
+
     bool isTowerNode;
-    bool isCNode;
+    bool isAmplifierNode;
+    bool isControlNode;
 } Config;
 
 #endif /* CONFIG_H_ */

--- a/nodes/ukamaOS/distro/system/lookoutd/inc/jserdes.h
+++ b/nodes/ukamaOS/distro/system/lookoutd/inc/jserdes.h
@@ -11,6 +11,7 @@
 
 #include <jansson.h>
 
+#include "config.h"
 #include "lookout.h"
 #include "json_types.h"
 
@@ -19,19 +20,22 @@
 #define EMPTY_STRING  ""
 
 #define JSON_OK           STATUS_OK
-#define JSON_FAILURE      STATUS_NOTOK
+#define JSON_FAILURE      STATUS_NOK
 #define JSON_ENCODING_OK  JSON_OK
 #define JSON_DECODING_OK  JSON_OK
 
 void json_log(json_t *json);
 void json_free(JsonObj** json);
+
 bool json_deserialize_node_id(char **nodeID, json_t *json);
 bool json_deserialize_capps(CappList **cappList, JsonObj *json);
+bool json_deserialize_starter_status(StarterStatusData *starter,
+                                     JsonObj *json);
+
 bool json_serialize_health_report(JsonObj **json,
-                                  char *nodeID,
+                                  Config *config,
                                   CappList *list,
-                                  GPSClientData *gps,
-                                  SwitchPolicyStatusData *switchPolicy,
-                                  bool radioAvailable);
+                                  LookoutStatusData *status);
+
 #endif /* JSERDES_H_ */
 

--- a/nodes/ukamaOS/distro/system/lookoutd/inc/lookout.h
+++ b/nodes/ukamaOS/distro/system/lookoutd/inc/lookout.h
@@ -42,6 +42,16 @@
 #define LOOKOUT_GPS_COORD_NA      "-999.000000,-999.000000"
 #define LOOKOUT_GPS_TIME_NA       "not-available"
 
+#define LOOKOUT_SCHEMA_VERSION "1.0"
+
+#define LOOKOUT_SERVICE_POWER      "power"
+#define LOOKOUT_SERVICE_POWERD     "powerd"
+#define LOOKOUT_SERVICE_CONTROLLER "controllerd"
+#define LOOKOUT_SERVICE_BACKHAUL   "backhauld"
+#define LOOKOUT_SERVICE_FEM        "femd"
+#define LOOKOUT_SERVICE_GPS        "gps"
+#define LOOKOUT_SERVICE_SWITCH     "switchd"
+
 #define EP_BS              "/"
 #define REST_API_VERSION   "v1"
 #define URL_PREFIX         EP_BS REST_API_VERSION
@@ -58,19 +68,19 @@ typedef json_error_t        JsonErrObj;
 
 typedef struct _runtime {
 
-    char   *status; /* Current status 0: not executed, 1: running, 2: done */
-    pid_t  pid;     /* process ID */
-    int    memory;  /* memory usage, in bytes */
-    int    disk;    /* disk usage, in bytes */
-    double cpu;     /* CPU usage, in percentage */
+    char   *status;
+    pid_t  pid;
+    int    memory;
+    int    disk;
+    double cpu;
 } CappRuntime;
 
 typedef struct _capp {
 
-    char        *space;    /* space capp belongs */
-    char        *name;     /* Name of the cApp */
-    char        *tag;      /* cApp tag/version */
-    CappRuntime *runtime;  /* runtime of capp */
+    char        *space;
+    char        *name;
+    char        *tag;
+    CappRuntime *runtime;
 } Capp;
 
 typedef struct _cappList {
@@ -82,21 +92,81 @@ typedef struct _cappList {
 typedef struct {
 
     bool  available;
-    bool  gpsLock;
-    char *coordinates; /* "lon,lat" */
-    char *gpsTime;     /* string */
+    char *state;
+    bool  updateInProgress;
+    bool  switchRequested;
+    bool  terminateRequested;
+    int   exitCode;
+} StarterStatusData;
+
+typedef struct {
+
+    bool  available;
+    bool  ok;
+    char *board;
+    char *reason;
+    double totalWatts;
+    double temperatureC;
+} PowerStatusData;
+
+typedef struct {
+
+    bool  available;
+    bool  lock;
+    char *coordinates;
+    char *time;
 } GPSClientData;
 
 typedef struct {
 
-    bool  available;       /* This node should report switch status */
-    bool  switchAvailable; /* switch.d responded successfully */
+    bool available;
+    char *state;
+} RadioStatusData;
 
-    char *siteID;
-    char *policyState;
-    char *policyHash;
-    char *policySource;
-    char *policyError;
-} SwitchPolicyStatusData;
+typedef struct {
+
+    bool available;
+    char *service;
+    char *error;
+} CellularStatusData;
+
+typedef struct {
+
+    bool available;
+    JsonObj *status;
+    JsonObj *policy;
+    JsonObj *ports;
+} SwitchStatusData;
+
+typedef struct {
+
+    bool available;
+    JsonObj *status;
+} ControllerStatusData;
+
+typedef struct {
+
+    bool available;
+    JsonObj *status;
+} BackhaulStatusData;
+
+typedef struct {
+
+    bool available;
+    JsonObj *status;
+} FemStatusData;
+
+typedef struct {
+
+    StarterStatusData   starter;
+    PowerStatusData     power;
+    GPSClientData       gps;
+    RadioStatusData     radio;
+    CellularStatusData  cellular;
+    SwitchStatusData    sw;
+    ControllerStatusData controller;
+    BackhaulStatusData  backhaul;
+    FemStatusData       fem;
+} LookoutStatusData;
 
 #endif /* LOOKOUT_H_ */

--- a/nodes/ukamaOS/distro/system/lookoutd/src/jserdes.c
+++ b/nodes/ukamaOS/distro/system/lookoutd/src/jserdes.c
@@ -262,238 +262,216 @@ bool json_deserialize_capps(CappList **cappList, JsonObj *json) {
     return USYS_TRUE;
 }
 
-static void json_add_resources_to_capp_report(JsonObj **json,
-                                              CappRuntime *runtime) {
+static char *json_dup_string_or_null(JsonObj *json, const char *key) {
 
-    JsonObj *jArray = NULL;
-    JsonObj *jMemory = NULL;
-    JsonObj *jDisk = NULL;
-    JsonObj *jCpu = NULL;
+    JsonObj *entry = NULL;
+    const char *value = NULL;
 
-    char buffer[MAX_BUFFER] = {0};
-
-    json_object_set_new(*json, JTAG_RESOURCES, json_array());
-    jArray = json_object_get(*json, JTAG_RESOURCES);
-    if (jArray == NULL) return;
-
-    jMemory = json_object();
-    jDisk   = json_object();
-    jCpu    = json_object();
-
-    sprintf(buffer, "%d", runtime->memory);
-    json_object_set_new(jMemory,
-                        JTAG_NAME,
-                        json_string("memory"));
-    json_object_set_new(jMemory,
-                        JTAG_VALUE,
-                        json_string(buffer));
-
-    sprintf(buffer, "%d", runtime->disk);
-    json_object_set_new(jDisk,
-                        JTAG_NAME,
-                        json_string("disk"));
-    json_object_set_new(jDisk,
-                        JTAG_VALUE,
-                        json_string(buffer));
-
-    sprintf(buffer, "%f", runtime->cpu);
-    json_object_set_new(jCpu,
-                        JTAG_NAME,
-                        json_string("cpu"));
-    json_object_set_new(jCpu,
-                        JTAG_VALUE,
-                        json_string(buffer));
-
-    json_array_append_new(jArray, jMemory);
-    json_array_append_new(jArray, jDisk);
-    json_array_append_new(jArray, jCpu);
-}
-
-static void json_add_system_info_to_report(JsonObj **json,
-                                           bool radioAvailable) {
-
-    JsonObj *jArray = NULL;
-    JsonObj *jRadio = NULL;
-
-    jRadio = json_object();
-
-    json_object_set_new(*json, JTAG_SYSTEM, json_array());
-    jArray = json_object_get(*json, JTAG_SYSTEM);
-    if (jArray == NULL) return;
-
-    json_object_set_new(jRadio,
-                        JTAG_NAME,
-                        json_string("radio"));
-
-    if (radioAvailable == USYS_TRUE) {
-        json_object_set_new(jRadio,
-                            JTAG_VALUE,
-                            json_string(get_radio_status()));
-    } else {
-        json_object_set_new(jRadio,
-                            JTAG_VALUE,
-                            json_string(LOOKOUT_STATUS_NA));
+    if (json == NULL || key == NULL) {
+        return NULL;
     }
 
-    json_array_append_new(jArray, jRadio);
-}
-
-static void json_add_gps_info_to_report(JsonObj **json, GPSClientData *gps) {
-
-    JsonObj *jArray = NULL;
-    JsonObj *jEntry = NULL;
-
-    const char *lockStr = LOOKOUT_STATUS_NA;
-    const char *coord = LOOKOUT_GPS_COORD_NA;
-    const char *timeStr = LOOKOUT_GPS_TIME_NA;
-
-    if (json == NULL || *json == NULL || gps == NULL) return;
-
-    jArray = json_object_get(*json, JTAG_SYSTEM);
-    if (jArray == NULL || !json_is_array(jArray)) return;
-
-    if (gps->available == USYS_TRUE) {
-        lockStr = gps->gpsLock ? "true" : "false";
-
-        if (gps->coordinates && gps->coordinates[0] != '\0') {
-            coord = gps->coordinates;
-        }
-
-        if (gps->gpsTime && gps->gpsTime[0] != '\0') {
-            timeStr = gps->gpsTime;
-        }
+    entry = json_object_get(json, key);
+    if (!json_is_string(entry)) {
+        return NULL;
     }
 
-    jEntry = json_object();
-    json_object_set_new(jEntry, JTAG_NAME, json_string("coordinates"));
-    json_object_set_new(jEntry, JTAG_VALUE, json_string(coord));
-    json_array_append_new(jArray, jEntry);
+    value = json_string_value(entry);
+    if (value == NULL) {
+        return NULL;
+    }
 
-    jEntry = json_object();
-    json_object_set_new(jEntry, JTAG_NAME, json_string("gpsLock"));
-    json_object_set_new(jEntry, JTAG_VALUE, json_string(lockStr));
-    json_array_append_new(jArray, jEntry);
-
-    jEntry = json_object();
-    json_object_set_new(jEntry, JTAG_NAME, json_string("gpsTime"));
-    json_object_set_new(jEntry, JTAG_VALUE, json_string(timeStr));
-    json_array_append_new(jArray, jEntry);
+    return strdup(value);
 }
 
-static void json_add_system_entry(JsonObj *jArray,
-                                  const char *name,
-                                  const char *value) {
+static bool json_get_bool_default(JsonObj *json,
+                                  const char *key,
+                                  bool defVal) {
 
-    JsonObj *jEntry = NULL;
+    JsonObj *entry = NULL;
 
-    if (jArray == NULL || !json_is_array(jArray) ||
-        name == NULL || value == NULL) {
+    if (json == NULL || key == NULL) {
+        return defVal;
+    }
+
+    entry = json_object_get(json, key);
+    if (!json_is_boolean(entry)) {
+        return defVal;
+    }
+
+    return json_boolean_value(entry) ? true : false;
+}
+
+static int json_get_int_default(JsonObj *json,
+                                const char *key,
+                                int defVal) {
+
+    JsonObj *entry = NULL;
+
+    if (json == NULL || key == NULL) {
+        return defVal;
+    }
+
+    entry = json_object_get(json, key);
+    if (!json_is_integer(entry)) {
+        return defVal;
+    }
+
+    return (int)json_integer_value(entry);
+}
+
+bool json_deserialize_starter_status(StarterStatusData *starter,
+                                     JsonObj *json) {
+
+    JsonObj *jStarter = NULL;
+
+    if (starter == NULL || json == NULL) {
+        return USYS_FALSE;
+    }
+
+    memset(starter, 0, sizeof(StarterStatusData));
+
+    jStarter = json_object_get(json, "starterd");
+    if (!json_is_object(jStarter)) {
+        starter->available = USYS_FALSE;
+        return USYS_FALSE;
+    }
+
+    starter->available = USYS_TRUE;
+    starter->state = json_dup_string_or_null(jStarter, "state");
+    starter->updateInProgress =
+        json_get_bool_default(jStarter, "updateInProgress", false);
+    starter->switchRequested =
+        json_get_bool_default(jStarter, "switchRequested", false);
+    starter->terminateRequested =
+        json_get_bool_default(jStarter, "terminateRequested", false);
+    starter->exitCode =
+        json_get_int_default(jStarter, "exitCode", 0);
+
+    return USYS_TRUE;
+}
+
+static const char *node_type_to_string(LookoutNodeType nodeType) {
+
+    switch (nodeType) {
+    case LOOKOUT_NODE_TOWER:
+        return "tower";
+
+    case LOOKOUT_NODE_AMPLIFIER:
+        return "amplifier";
+
+    case LOOKOUT_NODE_CONTROL:
+        return "control";
+
+    default:
+        return "unknown";
+    }
+}
+
+static void json_add_capabilities(JsonObj *root, LookoutNodeType nodeType) {
+
+    JsonObj *array = NULL;
+
+    if (root == NULL) {
         return;
     }
 
-    jEntry = json_object();
-    if (jEntry == NULL) {
+    array = json_array();
+    if (array == NULL) {
         return;
     }
 
-    json_object_set_new(jEntry, JTAG_NAME, json_string(name));
-    json_object_set_new(jEntry, JTAG_VALUE, json_string(value));
-    json_array_append_new(jArray, jEntry);
+    switch (nodeType) {
+    case LOOKOUT_NODE_TOWER:
+        json_array_append_new(array, json_string("power"));
+        json_array_append_new(array, json_string("cellular"));
+        json_array_append_new(array, json_string("radio"));
+        json_array_append_new(array, json_string("gps"));
+        json_array_append_new(array, json_string("backhaul"));
+        break;
+
+    case LOOKOUT_NODE_AMPLIFIER:
+        json_array_append_new(array, json_string("power"));
+        json_array_append_new(array, json_string("radio"));
+        json_array_append_new(array, json_string("fem"));
+        break;
+
+    case LOOKOUT_NODE_CONTROL:
+        json_array_append_new(array, json_string("power"));
+        json_array_append_new(array, json_string("switch"));
+        json_array_append_new(array, json_string("controller"));
+        json_array_append_new(array, json_string("backhaul"));
+        break;
+
+    default:
+        break;
+    }
+
+    json_object_set_new(root, "capabilities", array);
 }
 
-static void json_add_switch_policy_info_to_report(JsonObj **json,
-                                                  SwitchPolicyStatusData *sp) {
+static long get_uptime_sec(void) {
 
-    JsonObj *jArray = NULL;
+    FILE *fp = NULL;
+    double uptime = 0.0;
 
-    const char *switchValue = LOOKOUT_STATUS_NA;
-    const char *siteID      = LOOKOUT_STATUS_NA;
-    const char *state       = LOOKOUT_STATUS_NA;
-    const char *hash        = LOOKOUT_STATUS_NA;
-    const char *source      = LOOKOUT_STATUS_NA;
-    const char *error       = "";
+    fp = fopen("/proc/uptime", "r");
+    if (fp == NULL) {
+        return 0;
+    }
 
-    if (json == NULL || *json == NULL || sp == NULL) return;
+    if (fscanf(fp, "%lf", &uptime) != 1) {
+        fclose(fp);
+        return 0;
+    }
 
-    if (sp->available != USYS_TRUE) {
+    fclose(fp);
+    return (long)uptime;
+}
+
+static void json_add_app_resources(JsonObj *jApp, CappRuntime *runtime) {
+
+    JsonObj *resources = NULL;
+
+    if (jApp == NULL || runtime == NULL) {
         return;
     }
 
-    jArray = json_object_get(*json, JTAG_SYSTEM);
-    if (jArray == NULL || !json_is_array(jArray)) return;
-
-    if (sp->switchAvailable == USYS_TRUE) {
-        switchValue = "available";
-
-        if (sp->siteID && sp->siteID[0] != '\0') {
-            siteID = sp->siteID;
-        }
-
-        if (sp->policyState && sp->policyState[0] != '\0') {
-            state = sp->policyState;
-        }
-
-        if (sp->policyHash && sp->policyHash[0] != '\0') {
-            hash = sp->policyHash;
-        }
-
-        if (sp->policySource && sp->policySource[0] != '\0') {
-            source = sp->policySource;
-        }
-
-        if (sp->policyError && sp->policyError[0] != '\0') {
-            error = sp->policyError;
-        }
-    } else {
-        switchValue = "unavailable";
-        state = "unknown";
-        hash = LOOKOUT_STATUS_NA;
-        source = LOOKOUT_STATUS_NA;
-        error = "switchd_unreachable";
+    resources = json_object();
+    if (resources == NULL) {
+        return;
     }
 
-    json_add_system_entry(jArray, "switch", switchValue);
-    json_add_system_entry(jArray, "switchPolicySiteID", siteID);
-    json_add_system_entry(jArray, "switchPolicy", state);
-    json_add_system_entry(jArray, "switchPolicyHash", hash);
-    json_add_system_entry(jArray, "switchPolicySource", source);
-    json_add_system_entry(jArray, "switchPolicyError", error);
+    json_object_set_new(resources,
+                        "cpuPercent",
+                        json_real(runtime->cpu));
+    json_object_set_new(resources,
+                        "memoryRssKb",
+                        json_integer(runtime->memory));
+    json_object_set_new(resources,
+                        "diskReadBytes",
+                        json_integer(0));
+    json_object_set_new(resources,
+                        "diskWriteBytes",
+                        json_integer(runtime->disk));
+
+    json_object_set_new(jApp, "resources", resources);
 }
 
-bool json_serialize_health_report(JsonObj **json,
-                                  char *nodeID,
-                                  CappList *list,
-                                  GPSClientData *gps,
-                                  SwitchPolicyStatusData *switchPolicy,
-                                  bool radioAvailable) {
+static void json_add_apps(JsonObj *root, CappList *list) {
 
-    JsonObj *jArray = NULL;
-    JsonObj *jCapp = NULL;
+    JsonObj *apps = NULL;
+    JsonObj *jApp = NULL;
     CappList *ptr = NULL;
     Capp *capp = NULL;
 
-    char buffer[MAX_BUFFER] = {0};
-    time_t currTime;
+    if (root == NULL) {
+        return;
+    }
 
-    *json = json_object();
-    if (*json == NULL) return USYS_FALSE;
-
-    json_object_set_new(*json,
-                        JTAG_NODE_ID,
-                        json_string(nodeID ? nodeID : ""));
-
-    time(&currTime);
-    sprintf(buffer, "%ld", (long)currTime);
-    json_object_set_new(*json,
-                        JTAG_TIMESTAMP,
-                        json_string(buffer));
-
-    json_object_set_new(*json, JTAG_CAPPS, json_array());
-    jArray = json_object_get(*json, JTAG_CAPPS);
-    if (jArray == NULL) {
-        json_decref(*json);
-        *json = NULL;
-        return USYS_FALSE;
+    apps = json_array();
+    if (apps == NULL) {
+        return;
     }
 
     for (ptr = list; ptr; ptr = ptr->next) {
@@ -502,34 +480,610 @@ bool json_serialize_health_report(JsonObj **json,
             continue;
         }
 
-        jCapp = json_object();
-        if (jCapp == NULL) {
-            json_decref(*json);
-            *json = NULL;
-            return USYS_FALSE;
+        jApp = json_object();
+        if (jApp == NULL) {
+            continue;
         }
 
-        json_object_set_new(jCapp,
-                            JTAG_SPACE,
+        json_object_set_new(jApp,
+                            "space",
                             json_string(capp->space ? capp->space : ""));
-        json_object_set_new(jCapp,
-                            JTAG_NAME,
+        json_object_set_new(jApp,
+                            "name",
                             json_string(capp->name ? capp->name : ""));
-        json_object_set_new(jCapp,
-                            JTAG_TAG,
+        json_object_set_new(jApp,
+                            "tag",
                             json_string(capp->tag ? capp->tag : ""));
-        json_object_set_new(jCapp,
-                            JTAG_STATUS,
+        json_object_set_new(jApp,
+                            "version",
+                            json_string(capp->tag ? capp->tag : ""));
+        json_object_set_new(jApp,
+                            "state",
                             json_string(capp->runtime->status ?
-                                        capp->runtime->status : "Unknown"));
+                                        capp->runtime->status : "unknown"));
+        json_object_set_new(jApp,
+                            "pid",
+                            json_integer(capp->runtime->pid));
 
-        json_add_resources_to_capp_report(&jCapp, capp->runtime);
-        json_array_append_new(jArray, jCapp);
+        json_add_app_resources(jApp, capp->runtime);
+        json_array_append_new(apps, jApp);
     }
 
-    json_add_system_info_to_report(json, radioAvailable);
-    json_add_gps_info_to_report(json, gps);
-    json_add_switch_policy_info_to_report(json, switchPolicy);
+    json_object_set_new(root, "apps", apps);
+}
+
+static void json_add_starter(JsonObj *system, StarterStatusData *starter) {
+
+    JsonObj *jStarter = NULL;
+
+    if (system == NULL || starter == NULL) {
+        return;
+    }
+
+    jStarter = json_object();
+    if (jStarter == NULL) {
+        return;
+    }
+
+    json_object_set_new(jStarter,
+                        "available",
+                        json_boolean(starter->available));
+    json_object_set_new(jStarter,
+                        "state",
+                        json_string(starter->state ?
+                                    starter->state : "unknown"));
+    json_object_set_new(jStarter,
+                        "updateInProgress",
+                        json_boolean(starter->updateInProgress));
+    json_object_set_new(jStarter,
+                        "switchRequested",
+                        json_boolean(starter->switchRequested));
+    json_object_set_new(jStarter,
+                        "terminateRequested",
+                        json_boolean(starter->terminateRequested));
+    json_object_set_new(jStarter,
+                        "exitCode",
+                        json_integer(starter->exitCode));
+
+    json_object_set_new(system, "starter", jStarter);
+}
+
+static void json_add_power(JsonObj *system, PowerStatusData *power) {
+
+    JsonObj *jPower = NULL;
+
+    if (system == NULL || power == NULL) {
+        return;
+    }
+
+    jPower = json_object();
+    if (jPower == NULL) {
+        return;
+    }
+
+    json_object_set_new(jPower,
+                        "available",
+                        json_boolean(power->available));
+
+    if (power->available == USYS_TRUE) {
+        json_object_set_new(jPower, "ok", json_boolean(power->ok));
+        json_object_set_new(jPower,
+                            "board",
+                            json_string(power->board ? power->board : ""));
+        json_object_set_new(jPower,
+                            "reason",
+                            json_string(power->reason ? power->reason : ""));
+        json_object_set_new(jPower,
+                            "totalWatts",
+                            json_real(power->totalWatts));
+        json_object_set_new(jPower,
+                            "temperatureC",
+                            json_real(power->temperatureC));
+    } else {
+        json_object_set_new(jPower,
+                            "error",
+                            json_string("power_service_unreachable"));
+    }
+
+    json_object_set_new(system, "power", jPower);
+}
+
+static void json_add_system(JsonObj *root, LookoutStatusData *status) {
+
+    JsonObj *system = NULL;
+
+    if (root == NULL || status == NULL) {
+        return;
+    }
+
+    system = json_object();
+    if (system == NULL) {
+        return;
+    }
+
+    json_object_set_new(system,
+                        "uptimeSec",
+                        json_integer(get_uptime_sec()));
+
+    json_add_starter(system, &status->starter);
+    json_add_power(system, &status->power);
+
+    json_object_set_new(root, "system", system);
+}
+
+static void json_add_cellular(JsonObj *interfaces,
+                              CellularStatusData *cellular) {
+
+    JsonObj *jCellular = NULL;
+
+    if (interfaces == NULL || cellular == NULL ||
+        cellular->available != USYS_TRUE) {
+        return;
+    }
+
+    jCellular = json_object();
+    if (jCellular == NULL) {
+        return;
+    }
+
+    json_object_set_new(jCellular, "available", json_false());
+    json_object_set_new(jCellular,
+                        "error",
+                        json_string(cellular->error ?
+                                    cellular->error :
+                                    "cellular_status_not_supported"));
+
+    json_object_set_new(interfaces, "cellular", jCellular);
+}
+
+static void json_add_radio(JsonObj *interfaces,
+                           RadioStatusData *radio) {
+
+    JsonObj *jRadio = NULL;
+
+    if (interfaces == NULL || radio == NULL ||
+        radio->available != USYS_TRUE) {
+        return;
+    }
+
+    jRadio = json_object();
+    if (jRadio == NULL) {
+        return;
+    }
+
+    json_object_set_new(jRadio, "available", json_true());
+    json_object_set_new(jRadio,
+                        "state",
+                        json_string(radio->state ? radio->state : "unknown"));
+
+    json_object_set_new(interfaces, "radio", jRadio);
+}
+
+static void json_add_gps(JsonObj *interfaces,
+                         GPSClientData *gps) {
+
+    JsonObj *jGps = NULL;
+
+    if (interfaces == NULL || gps == NULL) {
+        return;
+    }
+
+    if (gps->available != USYS_TRUE) {
+        return;
+    }
+
+    jGps = json_object();
+    if (jGps == NULL) {
+        return;
+    }
+
+    json_object_set_new(jGps, "available", json_true());
+    json_object_set_new(jGps, "lock", json_boolean(gps->lock));
+    json_object_set_new(jGps,
+                        "coordinates",
+                        json_string(gps->coordinates ?
+                                    gps->coordinates :
+                                    LOOKOUT_GPS_COORD_NA));
+    json_object_set_new(jGps,
+                        "time",
+                        json_string(gps->time ?
+                                    gps->time :
+                                    LOOKOUT_GPS_TIME_NA));
+
+    json_object_set_new(interfaces, "gps", jGps);
+}
+
+static JsonObj *copy_string_field(JsonObj *src, const char *key) {
+
+    JsonObj *entry = NULL;
+
+    if (src == NULL || key == NULL) {
+        return NULL;
+    }
+
+    entry = json_object_get(src, key);
+    if (!json_is_string(entry)) {
+        return NULL;
+    }
+
+    return json_string(json_string_value(entry));
+}
+
+static JsonObj *copy_bool_field(JsonObj *src, const char *key) {
+
+    JsonObj *entry = NULL;
+
+    if (src == NULL || key == NULL) {
+        return NULL;
+    }
+
+    entry = json_object_get(src, key);
+    if (!json_is_boolean(entry)) {
+        return NULL;
+    }
+
+    return json_boolean(json_boolean_value(entry));
+}
+
+static JsonObj *copy_int_field(JsonObj *src, const char *key) {
+
+    JsonObj *entry = NULL;
+
+    if (src == NULL || key == NULL) {
+        return NULL;
+    }
+
+    entry = json_object_get(src, key);
+    if (!json_is_integer(entry)) {
+        return NULL;
+    }
+
+    return json_integer(json_integer_value(entry));
+}
+
+static JsonObj *copy_num_field(JsonObj *src, const char *key) {
+
+    JsonObj *entry = NULL;
+
+    if (src == NULL || key == NULL) {
+        return NULL;
+    }
+
+    entry = json_object_get(src, key);
+    if (!json_is_number(entry)) {
+        return NULL;
+    }
+
+    return json_real(json_number_value(entry));
+}
+
+static void set_if(JsonObj *dst,
+                   const char *key,
+                   JsonObj *value) {
+
+    if (dst == NULL || key == NULL || value == NULL) {
+        return;
+    }
+
+    json_object_set_new(dst, key, value);
+}
+
+static void json_add_switch_ports(JsonObj *jSwitch, JsonObj *portsRaw) {
+
+    JsonObj *ports = NULL;
+    JsonObj *srcArray = NULL;
+    JsonObj *src = NULL;
+    JsonObj *dst = NULL;
+
+    int i = 0;
+    int count = 0;
+
+    if (jSwitch == NULL || portsRaw == NULL) {
+        return;
+    }
+
+    srcArray = portsRaw;
+    if (json_is_object(portsRaw)) {
+        srcArray = json_object_get(portsRaw, "ports");
+    }
+
+    if (!json_is_array(srcArray)) {
+        return;
+    }
+
+    ports = json_array();
+    if (ports == NULL) {
+        return;
+    }
+
+    count = json_array_size(srcArray);
+    for (i = 0; i < count; i++) {
+        src = json_array_get(srcArray, i);
+        if (!json_is_object(src)) {
+            continue;
+        }
+
+        dst = json_object();
+        if (dst == NULL) {
+            continue;
+        }
+
+        set_if(dst, "id", copy_int_field(src, "id"));
+        set_if(dst, "name", copy_string_field(src, "name"));
+        set_if(dst, "present", copy_bool_field(src, "present"));
+        set_if(dst, "adminState", copy_string_field(src, "adminState"));
+        set_if(dst, "linkState", copy_string_field(src, "linkState"));
+        set_if(dst, "poeState", copy_string_field(src, "poeState"));
+        set_if(dst, "poeOperational",
+               copy_bool_field(src, "poeOperational"));
+        set_if(dst, "speedBps", copy_int_field(src, "speedBps"));
+        set_if(dst, "powerWatts", copy_num_field(src, "powerWatts"));
+        set_if(dst, "fault", copy_string_field(src, "fault"));
+
+        json_array_append_new(ports, dst);
+    }
+
+    json_object_set_new(jSwitch, "ports", ports);
+}
+
+static void json_add_switch(JsonObj *interfaces,
+                            SwitchStatusData *sw) {
+
+    JsonObj *jSwitch = NULL;
+    JsonObj *jSwitchd = NULL;
+    JsonObj *jInfo = NULL;
+    JsonObj *policy = NULL;
+
+    if (interfaces == NULL || sw == NULL || sw->available != USYS_TRUE) {
+        return;
+    }
+
+    jSwitch = json_object();
+    if (jSwitch == NULL) {
+        return;
+    }
+
+    if (sw->status == NULL) {
+        json_object_set_new(jSwitch, "available", json_false());
+        json_object_set_new(jSwitch,
+                            "error",
+                            json_string("switch_service_unreachable"));
+        json_object_set_new(interfaces, "switch", jSwitch);
+        return;
+    }
+
+    json_object_set_new(jSwitch, "available", json_true());
+
+    jSwitchd = json_object_get(sw->status, "switchd");
+    jInfo = json_object_get(sw->status, "switch");
+
+    if (json_is_object(jSwitchd)) {
+        set_if(jSwitch, "state", copy_string_field(jSwitchd, "state"));
+        set_if(jSwitch,
+               "reachable",
+               copy_bool_field(jSwitchd, "reachable"));
+    }
+
+    if (json_is_object(jInfo)) {
+        set_if(jSwitch, "model", copy_string_field(jInfo, "model"));
+        set_if(jSwitch,
+               "softwareVersion",
+               copy_string_field(jInfo, "softwareVersion"));
+        set_if(jSwitch, "portCount", copy_int_field(jInfo, "portCount"));
+    }
+
+    policy = json_object();
+    if (policy) {
+        if (sw->policy) {
+            set_if(policy, "state", copy_string_field(sw->policy, "state"));
+            set_if(policy, "hash", copy_string_field(sw->policy, "hash"));
+            set_if(policy, "source", copy_string_field(sw->policy, "source"));
+            set_if(policy, "error", copy_string_field(sw->policy, "error"));
+        }
+
+        json_object_set_new(jSwitch, "policy", policy);
+    }
+
+    json_add_switch_ports(jSwitch, sw->ports);
+
+    json_object_set_new(interfaces, "switch", jSwitch);
+}
+
+static void json_add_controller(JsonObj *interfaces,
+                                ControllerStatusData *controller) {
+
+    JsonObj *jController = NULL;
+    JsonObj *src = NULL;
+    JsonObj *solar = NULL;
+    JsonObj *battery = NULL;
+    JsonObj *load = NULL;
+    JsonObj *ctrl = NULL;
+
+    if (interfaces == NULL || controller == NULL ||
+        controller->available != USYS_TRUE) {
+        return;
+    }
+
+    jController = json_object();
+    if (jController == NULL) {
+        return;
+    }
+
+    src = controller->status;
+    if (src == NULL) {
+        json_object_set_new(jController, "available", json_false());
+        json_object_set_new(jController,
+                            "error",
+                            json_string("controller_service_unreachable"));
+        json_object_set_new(interfaces, "controller", jController);
+        return;
+    }
+
+    json_object_set_new(jController, "available", json_true());
+
+    set_if(jController, "commOk", copy_bool_field(src, "commOk"));
+    set_if(jController, "chargeState", copy_string_field(src, "chargeState"));
+    set_if(jController, "errorCode", copy_int_field(src, "errorCode"));
+    set_if(jController, "error", copy_string_field(src, "error"));
+    set_if(jController,
+           "activeAlarmCount",
+           copy_int_field(src, "activeAlarmCount"));
+
+    solar = json_object_get(src, "solar");
+    if (json_is_object(solar)) {
+        json_object_set(jController, "solar", solar);
+    }
+
+    battery = json_object_get(src, "battery");
+    if (json_is_object(battery)) {
+        json_object_set(jController, "battery", battery);
+    }
+
+    ctrl = json_object_get(src, "controller");
+    if (json_is_object(ctrl)) {
+        load = json_object();
+        if (load) {
+            set_if(load, "outputOn",
+                   copy_bool_field(ctrl, "loadOutputOn"));
+            set_if(load, "currentA",
+                   copy_num_field(ctrl, "loadCurrentA"));
+            json_object_set_new(jController, "load", load);
+        }
+    }
+
+    json_object_set_new(interfaces, "controller", jController);
+}
+
+static void json_add_backhaul(JsonObj *interfaces,
+                              BackhaulStatusData *backhaul) {
+
+    JsonObj *jBackhaul = NULL;
+    JsonObj *src = NULL;
+
+    if (interfaces == NULL || backhaul == NULL ||
+        backhaul->available != USYS_TRUE) {
+        return;
+    }
+
+    jBackhaul = json_object();
+    if (jBackhaul == NULL) {
+        return;
+    }
+
+    src = backhaul->status;
+    if (src == NULL) {
+        json_object_set_new(jBackhaul, "available", json_false());
+        json_object_set_new(jBackhaul,
+                            "error",
+                            json_string("backhaul_service_unreachable"));
+        json_object_set_new(interfaces, "backhaul", jBackhaul);
+        return;
+    }
+
+    json_object_set_new(jBackhaul, "available", json_true());
+    set_if(jBackhaul, "state", copy_string_field(src, "backhaulState"));
+    set_if(jBackhaul, "linkGuess", copy_string_field(src, "linkGuess"));
+    set_if(jBackhaul, "confidence", copy_num_field(src, "confidence"));
+
+    json_object_set_new(interfaces, "backhaul", jBackhaul);
+}
+
+static void json_add_fem(JsonObj *interfaces,
+                         FemStatusData *fem) {
+
+    JsonObj *jFem = NULL;
+    JsonObj *fems = NULL;
+
+    if (interfaces == NULL || fem == NULL ||
+        fem->available != USYS_TRUE) {
+        return;
+    }
+
+    jFem = json_object();
+    if (jFem == NULL) {
+        return;
+    }
+
+    if (fem->status == NULL) {
+        json_object_set_new(jFem, "available", json_false());
+        json_object_set_new(jFem,
+                            "error",
+                            json_string("fem_service_unreachable"));
+        json_object_set_new(interfaces, "fem", jFem);
+        return;
+    }
+
+    json_object_set_new(jFem, "available", json_true());
+
+    fems = json_object_get(fem->status, "fems");
+    if (json_is_array(fems)) {
+        json_object_set(jFem, "fems", fems);
+    }
+
+    json_object_set_new(interfaces, "fem", jFem);
+}
+
+static void json_add_interfaces(JsonObj *root,
+                                LookoutStatusData *status) {
+
+    JsonObj *interfaces = NULL;
+
+    if (root == NULL || status == NULL) {
+        return;
+    }
+
+    interfaces = json_object();
+    if (interfaces == NULL) {
+        return;
+    }
+
+    json_add_cellular(interfaces, &status->cellular);
+    json_add_radio(interfaces, &status->radio);
+    json_add_gps(interfaces, &status->gps);
+    json_add_switch(interfaces, &status->sw);
+    json_add_controller(interfaces, &status->controller);
+    json_add_backhaul(interfaces, &status->backhaul);
+    json_add_fem(interfaces, &status->fem);
+
+    json_object_set_new(root, "interfaces", interfaces);
+}
+
+bool json_serialize_health_report(JsonObj **json,
+                                  Config *config,
+                                  CappList *list,
+                                  LookoutStatusData *status) {
+
+    char buffer[MAX_BUFFER] = {0};
+    time_t currTime;
+
+    if (json == NULL || config == NULL || status == NULL) {
+        return USYS_FALSE;
+    }
+
+    *json = json_object();
+    if (*json == NULL) {
+        return USYS_FALSE;
+    }
+
+    json_object_set_new(*json,
+                        "schemaVersion",
+                        json_string(LOOKOUT_SCHEMA_VERSION));
+    json_object_set_new(*json,
+                        "nodeId",
+                        json_string(config->nodeID ? config->nodeID : ""));
+    json_object_set_new(*json,
+                        "nodeType",
+                        json_string(node_type_to_string(config->nodeType)));
+
+    time(&currTime);
+    snprintf(buffer, sizeof(buffer), "%ld", (long)currTime);
+    json_object_set_new(*json, "reportedAt", json_string(buffer));
+
+    json_add_capabilities(*json, config->nodeType);
+    json_add_system(*json, status);
+    json_add_interfaces(*json, status);
+    json_add_apps(*json, list);
+    json_object_set_new(*json, "events", json_array());
 
     return USYS_TRUE;
 }

--- a/nodes/ukamaOS/distro/system/lookoutd/src/main.c
+++ b/nodes/ukamaOS/distro/system/lookoutd/src/main.c
@@ -50,38 +50,54 @@ static bool str_eq(const char *a, const char *b) {
     return strcmp(a, b) == 0;
 }
 
-static bool node_id_is_tower(const char *nodeID) {
+static bool str_contains(const char *s, const char *needle) {
 
-    if (nodeID == NULL || nodeID[0] == '\0') {
+    if (s == NULL || needle == NULL) {
         return false;
     }
 
-    if (strstr(nodeID, "tnode") != NULL) {
-        return true;
-    }
-
-    if (strstr(nodeID, "tower") != NULL) {
-        return true;
-    }
-
-    return false;
+    return strstr(s, needle) != NULL;
 }
 
-static bool node_id_is_cnode(const char *nodeID) {
+static LookoutNodeType detect_node_type(const char *nodeID) {
 
     if (nodeID == NULL || nodeID[0] == '\0') {
-        return false;
+        return LOOKOUT_NODE_UNKNOWN;
     }
 
-    if (strstr(nodeID, "cnode") != NULL) {
-        return true;
+    if (str_contains(nodeID, "tnode") ||
+        str_contains(nodeID, "tower")) {
+        return LOOKOUT_NODE_TOWER;
     }
 
-    if (strstr(nodeID, "control") != NULL) {
-        return true;
+    if (str_contains(nodeID, "anode") ||
+        str_contains(nodeID, "amplifier")) {
+        return LOOKOUT_NODE_AMPLIFIER;
     }
 
-    return false;
+    if (str_contains(nodeID, "cnode") ||
+        str_contains(nodeID, "control")) {
+        return LOOKOUT_NODE_CONTROL;
+    }
+
+    return LOOKOUT_NODE_UNKNOWN;
+}
+
+static const char *node_type_to_string(LookoutNodeType nodeType) {
+
+    switch (nodeType) {
+    case LOOKOUT_NODE_TOWER:
+        return "tower";
+
+    case LOOKOUT_NODE_AMPLIFIER:
+        return "amplifier";
+
+    case LOOKOUT_NODE_CONTROL:
+        return "control";
+
+    default:
+        return "unknown";
+    }
 }
 
 static void configure_app_manager(Config *config) {
@@ -168,9 +184,11 @@ int main(int argc, char **argv) {
     serviceConfig.servicePort  = usys_find_service_port(SERVICE_NAME);
     serviceConfig.nodedPort    = usys_find_service_port(SERVICE_NODE);
     serviceConfig.starterdPort = usys_find_service_port(SERVICE_STARTER);
-    serviceConfig.nodeID       = NULL;
-    serviceConfig.isTowerNode  = false;
-    serviceConfig.isCNode      = false;
+
+    serviceConfig.nodeType        = LOOKOUT_NODE_UNKNOWN;
+    serviceConfig.isTowerNode     = false;
+    serviceConfig.isAmplifierNode = false;
+    serviceConfig.isControlNode   = false;
 
     if (!usys_find_service_port(SERVICE_UKAMA)) {
         usys_log_error("Unable to determine the port for Ukama");
@@ -205,13 +223,19 @@ int main(int argc, char **argv) {
         }
     }
 
-    serviceConfig.isTowerNode = node_id_is_tower(serviceConfig.nodeID);
-    serviceConfig.isCNode     = node_id_is_cnode(serviceConfig.nodeID);
+    serviceConfig.nodeType = detect_node_type(serviceConfig.nodeID);
+
+    serviceConfig.isTowerNode =
+        serviceConfig.nodeType == LOOKOUT_NODE_TOWER;
+    serviceConfig.isAmplifierNode =
+        serviceConfig.nodeType == LOOKOUT_NODE_AMPLIFIER;
+    serviceConfig.isControlNode =
+        serviceConfig.nodeType == LOOKOUT_NODE_CONTROL;
+
     usys_log_info("%s: nodeID=%s nodeType=%s appManager=%s",
                   SERVICE_NAME,
                   serviceConfig.nodeID,
-                  serviceConfig.isTowerNode ? "tower" :
-                  (serviceConfig.isCNode ? "cnode" : "non-tower"),
+                  node_type_to_string(serviceConfig.nodeType),
                   serviceConfig.appManager == LOOKOUT_APP_MANAGER_STARTERD ?
                   "starter" : "supervisor");
 

--- a/nodes/ukamaOS/distro/system/lookoutd/src/main.c
+++ b/nodes/ukamaOS/distro/system/lookoutd/src/main.c
@@ -138,11 +138,13 @@ void usage() {
 
 int main(int argc, char **argv) {
 
-    int opt, optIdx;
+    int opt, optIdx, ret=-1;
     char *debug = DEF_LOG_LEVEL;
 
     UInst  serviceInst;
     Config serviceConfig = {0};
+
+    memset(&serviceInst, 0, sizeof(UInst));
 
     usys_log_set_service(SERVICE_NAME);
 
@@ -192,18 +194,18 @@ int main(int argc, char **argv) {
 
     if (!usys_find_service_port(SERVICE_UKAMA)) {
         usys_log_error("Unable to determine the port for Ukama");
-        usys_exit(1);
+        goto done;
     }
 
     if (!serviceConfig.servicePort || !serviceConfig.nodedPort) {
         usys_log_error("Unable to determine the port for required services");
-        usys_exit(1);
+        goto done;
     }
 
     if (serviceConfig.appManager == LOOKOUT_APP_MANAGER_STARTERD &&
         !serviceConfig.starterdPort) {
         usys_log_error("Unable to determine the port for starter.d");
-        usys_exit(1);
+        goto done;
     }
 
     usys_log_debug("Starting %s ... ", SERVICE_NAME);
@@ -242,7 +244,7 @@ int main(int argc, char **argv) {
     if (start_web_services(&serviceConfig, &serviceInst) != USYS_TRUE) {
         usys_log_error("%s: unable to start webservice. Exiting.",
                        SERVICE_NAME);
-        exit(1);
+        goto done;
     }
 
     while (USYS_TRUE) {
@@ -253,13 +255,14 @@ int main(int argc, char **argv) {
         sleep(DEF_REPORT_INTERVAL);
     }
 
-done:
     ulfius_stop_framework(&serviceInst);
     ulfius_clean_instance(&serviceInst);
 
+    ret = 0;
+done:
     usys_free(serviceConfig.nodeID);
 
     usys_log_debug("Exiting %s ...", SERVICE_NAME);
 
-    return USYS_TRUE;
+    return ret;
 }

--- a/nodes/ukamaOS/distro/system/lookoutd/src/web_client.c
+++ b/nodes/ukamaOS/distro/system/lookoutd/src/web_client.c
@@ -309,61 +309,140 @@ static int get_capps_from_supervisord(Config *config, CappList **cappList) {
     return STATUS_OK;
 }
 
-static int get_capps_from_starterd(Config *config, CappList **cappList) {
+static int wc_find_service_port3(const char *a,
+                                 const char *b,
+                                 const char *c) {
+
+    int port = 0;
+
+    if (a) {
+        port = usys_find_service_port((char *)a);
+        if (port > 0) return port;
+    }
+
+    if (b) {
+        port = usys_find_service_port((char *)b);
+        if (port > 0) return port;
+    }
+
+    if (c) {
+        port = usys_find_service_port((char *)c);
+        if (port > 0) return port;
+    }
+
+    return 0;
+}
+
+static int wc_get_json_from_service(int port,
+                                    const char *path,
+                                    JsonObj **out) {
+
+    int ret = STATUS_NOK;
+    long status = 0;
+
+    char url[MAX_BUFFER] = {0};
+    char *body = NULL;
+
+    JsonErrObj jErr;
+
+    if (out == NULL || port <= 0 || path == NULL) {
+        return STATUS_NOK;
+    }
+
+    *out = NULL;
+
+    snprintf(url, sizeof(url), "http://localhost:%d%s", port, path);
+
+    ret = wc_send_request_raw(url, "GET", NULL, &status, &body);
+    if (ret != STATUS_OK || status != HttpStatus_OK || body == NULL) {
+        usys_log_error("Failed to read %s", url);
+        usys_free(body);
+        return STATUS_NOK;
+    }
+
+    memset(&jErr, 0, sizeof(JsonErrObj));
+    *out = json_loads(body, JSON_DECODE_ANY, &jErr);
+    usys_free(body);
+
+    if (*out == NULL) {
+        usys_log_error("Failed to parse response from %s", url);
+        return STATUS_NOK;
+    }
+
+    return STATUS_OK;
+}
+
+static bool wc_json_bool(JsonObj *json, const char *key, bool defVal) {
+
+    JsonObj *entry = NULL;
+
+    if (json == NULL || key == NULL) {
+        return defVal;
+    }
+
+    entry = json_object_get(json, key);
+    if (!json_is_boolean(entry)) {
+        return defVal;
+    }
+
+    return json_boolean_value(entry) ? true : false;
+}
+
+static double wc_json_num(JsonObj *json, const char *key, double defVal) {
+
+    JsonObj *entry = NULL;
+
+    if (json == NULL || key == NULL) {
+        return defVal;
+    }
+
+    entry = json_object_get(json, key);
+    if (!json_is_number(entry)) {
+        return defVal;
+    }
+
+    return json_number_value(entry);
+}
+
+static int get_capps_from_starterd(Config *config,
+                                   CappList **cappList,
+                                   StarterStatusData *starter) {
 
     int     ret     = STATUS_OK;
     char    *buffer = NULL;
     JsonObj *json   = NULL;
 
+    if (starter) {
+        memset(starter, 0, sizeof(StarterStatusData));
+    }
+
     if (wc_read_from_local_service(config, SERVICE_STARTERD, &buffer)) {
-        usys_log_error("Error reading capps from starter.d");
+        usys_log_error("Error reading status from starter.d");
         return STATUS_NOK;
     }
 
-    usys_log_debug("%s: capps: %s", SERVICE_NAME, buffer);
+    usys_log_debug("%s: starter status: %s", SERVICE_NAME, buffer);
 
     json = json_loads(buffer, JSON_DECODE_ANY, NULL);
+    if (json == NULL) {
+        usys_log_error("Failed to parse starter.d status");
+        usys_free(buffer);
+        return STATUS_NOK;
+    }
+
     if (json_deserialize_capps(cappList, json) == USYS_FALSE) {
-        usys_log_error("Failed to parse capps response from starterd");
+        usys_log_error("Failed to parse apps response from starter.d");
         ret = STATUS_NOK;
+    }
+
+    if (starter) {
+        json_deserialize_starter_status(starter, json);
     }
 
     json_decref(json);
     usys_free(buffer);
 
     return ret;
-}
-
-static void wc_free_gps_data(GPSClientData *gps) {
-
-    if (!gps) return;
-
-    usys_free(gps->coordinates);
-    usys_free(gps->gpsTime);
-
-    gps->available   = USYS_FALSE;
-    gps->gpsLock     = USYS_FALSE;
-    gps->coordinates = NULL;
-    gps->gpsTime     = NULL;
-}
-
-static void wc_free_switch_policy_data(SwitchPolicyStatusData *switchPolicy) {
-
-    if (!switchPolicy) return;
-
-    usys_free(switchPolicy->siteID);
-    usys_free(switchPolicy->policyState);
-    usys_free(switchPolicy->policyHash);
-    usys_free(switchPolicy->policySource);
-    usys_free(switchPolicy->policyError);
-
-    switchPolicy->available       = USYS_FALSE;
-    switchPolicy->switchAvailable = USYS_FALSE;
-    switchPolicy->siteID          = NULL;
-    switchPolicy->policyState     = NULL;
-    switchPolicy->policyHash      = NULL;
-    switchPolicy->policySource    = NULL;
-    switchPolicy->policyError     = NULL;
 }
 
 static void wc_free_capp_list(CappList *list) {
@@ -391,69 +470,7 @@ static void wc_free_capp_list(CappList *list) {
     }
 }
 
-static int get_gps_data(GPSClientData *gps) {
-
-    int  ret = STATUS_NOK;
-    int  port = 0;
-    long status = 0;
-
-    char url[MAX_BUFFER] = {0};
-    char *body = NULL;
-
-    if (gps == NULL) {
-        return STATUS_NOK;
-    }
-
-    gps->available   = USYS_TRUE;
-    gps->gpsLock     = USYS_FALSE;
-    gps->coordinates = NULL;
-    gps->gpsTime     = NULL;
-
-    port = usys_find_service_port(SERVICE_GPS);
-    if (port <= 0) {
-        usys_log_error("Failed to resolve port for %s", SERVICE_GPS);
-        return STATUS_NOK;
-    }
-
-    snprintf(url, sizeof(url), "http://localhost:%d/v1/lock", port);
-    ret = wc_send_request_raw(url, "GET", NULL, &status, &body);
-    usys_free(body);
-    body = NULL;
-
-    if (ret != STATUS_OK) {
-        usys_log_error("Failed to read gps lock from %s", url);
-        return STATUS_NOK;
-    }
-
-    if (status != HttpStatus_OK) {
-        gps->gpsLock = USYS_FALSE;
-        return STATUS_OK;
-    }
-
-    gps->gpsLock = USYS_TRUE;
-
-    snprintf(url, sizeof(url), "http://localhost:%d/v1/coordinates", port);
-    ret = wc_send_request_raw(url, "GET", NULL, &status, &body);
-    if (ret == STATUS_OK && status == HttpStatus_OK && body && body[0] != '\0') {
-        gps->coordinates = strdup(body);
-    }
-
-    usys_free(body);
-    body = NULL;
-
-    snprintf(url, sizeof(url), "http://localhost:%d/v1/time", port);
-    ret = wc_send_request_raw(url, "GET", NULL, &status, &body);
-    if (ret == STATUS_OK && status == HttpStatus_OK && body && body[0] != '\0') {
-        gps->gpsTime = strdup(body);
-    }
-
-    usys_free(body);
-    body = NULL;
-
-    return STATUS_OK;
-}
-
-static char *json_dup_string(JsonObj *json, const char *key) {
+static char *wc_json_dup_string(JsonObj *json, const char *key) {
 
     JsonObj *entry = NULL;
     const char *value = NULL;
@@ -475,7 +492,99 @@ static char *json_dup_string(JsonObj *json, const char *key) {
     return strdup(value);
 }
 
-static int get_switch_policy_data(SwitchPolicyStatusData *switchPolicy) {
+static void wc_free_starter_data(StarterStatusData *starter) {
+
+    if (!starter) return;
+
+    usys_free(starter->state);
+    memset(starter, 0, sizeof(StarterStatusData));
+}
+
+static void wc_free_power_data(PowerStatusData *power) {
+
+    if (!power) return;
+
+    usys_free(power->board);
+    usys_free(power->reason);
+    memset(power, 0, sizeof(PowerStatusData));
+}
+
+static void wc_free_gps_data(GPSClientData *gps) {
+
+    if (!gps) return;
+
+    usys_free(gps->coordinates);
+    usys_free(gps->time);
+    memset(gps, 0, sizeof(GPSClientData));
+}
+
+static void wc_free_radio_data(RadioStatusData *radio) {
+
+    if (!radio) return;
+
+    usys_free(radio->state);
+    memset(radio, 0, sizeof(RadioStatusData));
+}
+
+static void wc_free_cellular_data(CellularStatusData *cellular) {
+
+    if (!cellular) return;
+
+    usys_free(cellular->service);
+    usys_free(cellular->error);
+    memset(cellular, 0, sizeof(CellularStatusData));
+}
+
+static void wc_free_switch_data(SwitchStatusData *sw) {
+
+    if (!sw) return;
+
+    json_decref(sw->status);
+    json_decref(sw->policy);
+    json_decref(sw->ports);
+    memset(sw, 0, sizeof(SwitchStatusData));
+}
+
+static void wc_free_controller_data(ControllerStatusData *controller) {
+
+    if (!controller) return;
+
+    json_decref(controller->status);
+    memset(controller, 0, sizeof(ControllerStatusData));
+}
+
+static void wc_free_backhaul_data(BackhaulStatusData *backhaul) {
+
+    if (!backhaul) return;
+
+    json_decref(backhaul->status);
+    memset(backhaul, 0, sizeof(BackhaulStatusData));
+}
+
+static void wc_free_fem_data(FemStatusData *fem) {
+
+    if (!fem) return;
+
+    json_decref(fem->status);
+    memset(fem, 0, sizeof(FemStatusData));
+}
+
+static void wc_free_status_data(LookoutStatusData *status) {
+
+    if (!status) return;
+
+    wc_free_starter_data(&status->starter);
+    wc_free_power_data(&status->power);
+    wc_free_gps_data(&status->gps);
+    wc_free_radio_data(&status->radio);
+    wc_free_cellular_data(&status->cellular);
+    wc_free_switch_data(&status->sw);
+    wc_free_controller_data(&status->controller);
+    wc_free_backhaul_data(&status->backhaul);
+    wc_free_fem_data(&status->fem);
+}
+
+static int get_gps_data(GPSClientData *gps) {
 
     int  ret = STATUS_NOK;
     int  port = 0;
@@ -484,55 +593,195 @@ static int get_switch_policy_data(SwitchPolicyStatusData *switchPolicy) {
     char url[MAX_BUFFER] = {0};
     char *body = NULL;
 
-    JsonObj *json = NULL;
-    JsonErrObj jErr;
-
-    if (switchPolicy == NULL) {
+    if (gps == NULL) {
         return STATUS_NOK;
     }
 
-    switchPolicy->available       = USYS_TRUE;
-    switchPolicy->switchAvailable = USYS_FALSE;
-    switchPolicy->siteID          = NULL;
-    switchPolicy->policyState     = NULL;
-    switchPolicy->policyHash      = NULL;
-    switchPolicy->policySource    = NULL;
-    switchPolicy->policyError     = NULL;
+    memset(gps, 0, sizeof(GPSClientData));
+    gps->available = USYS_TRUE;
+    gps->lock = USYS_FALSE;
 
-    port = usys_find_service_port(SERVICE_SWITCH);
+    port = wc_find_service_port3(LOOKOUT_SERVICE_GPS,
+                                 "gpsd",
+                                 "gps.d");
     if (port <= 0) {
-        usys_log_error("Failed to resolve port for %s", SERVICE_SWITCH);
+        usys_log_error("Failed to resolve gps service port");
         return STATUS_NOK;
     }
 
-    snprintf(url, sizeof(url), "http://localhost:%d/v1/ports/policy", port);
-
+    snprintf(url, sizeof(url), "http://localhost:%d/v1/lock", port);
     ret = wc_send_request_raw(url, "GET", NULL, &status, &body);
-    if (ret != STATUS_OK || status != HttpStatus_OK || body == NULL) {
-        usys_log_error("Failed to read switch policy from %s", url);
-        usys_free(body);
-        return STATUS_NOK;
-    }
-
-    memset(&jErr, 0, sizeof(JsonErrObj));
-    json = json_loads(body, JSON_DECODE_ANY, &jErr);
     usys_free(body);
     body = NULL;
 
-    if (json == NULL) {
-        usys_log_error("Failed to parse switch policy response");
+    if (ret != STATUS_OK) {
+        usys_log_error("Failed to read gps lock from %s", url);
         return STATUS_NOK;
     }
 
-    switchPolicy->switchAvailable = USYS_TRUE;
-    switchPolicy->siteID          = json_dup_string(json, "site_id");
-    switchPolicy->policyState     = json_dup_string(json, "state");
-    switchPolicy->policyHash      = json_dup_string(json, "hash");
-    switchPolicy->policySource    = json_dup_string(json, "source");
-    switchPolicy->policyError     = json_dup_string(json, "error");
+    gps->lock = status == HttpStatus_OK ? USYS_TRUE : USYS_FALSE;
+
+    snprintf(url, sizeof(url), "http://localhost:%d/v1/coordinates", port);
+    ret = wc_send_request_raw(url, "GET", NULL, &status, &body);
+    if (ret == STATUS_OK && status == HttpStatus_OK &&
+        body && body[0] != '\0') {
+        gps->coordinates = strdup(body);
+    }
+
+    usys_free(body);
+    body = NULL;
+
+    snprintf(url, sizeof(url), "http://localhost:%d/v1/time", port);
+    ret = wc_send_request_raw(url, "GET", NULL, &status, &body);
+    if (ret == STATUS_OK && status == HttpStatus_OK &&
+        body && body[0] != '\0') {
+        gps->time = strdup(body);
+    }
+
+    usys_free(body);
+    body = NULL;
+
+    return STATUS_OK;
+}
+
+static void collect_radio_data(RadioStatusData *radio) {
+
+    extern char *get_radio_status(void);
+
+    if (!radio) return;
+
+    memset(radio, 0, sizeof(RadioStatusData));
+
+    radio->available = USYS_TRUE;
+    radio->state = strdup(get_radio_status());
+}
+
+static void collect_cellular_data(CellularStatusData *cellular) {
+
+    if (!cellular) return;
+
+    memset(cellular, 0, sizeof(CellularStatusData));
+
+    cellular->available = USYS_TRUE;
+    cellular->service = NULL;
+    cellular->error = strdup("cellular_status_not_supported");
+}
+
+static void collect_power_data(PowerStatusData *power) {
+
+    int port = 0;
+    JsonObj *json = NULL;
+    JsonObj *lm75 = NULL;
+    JsonObj *lm25066 = NULL;
+
+    if (!power) return;
+
+    memset(power, 0, sizeof(PowerStatusData));
+
+    port = wc_find_service_port3(LOOKOUT_SERVICE_POWER,
+                                 LOOKOUT_SERVICE_POWERD,
+                                 "power.d");
+    if (port <= 0 ||
+        wc_get_json_from_service(port, "/v1/status", &json) != STATUS_OK) {
+        power->available = USYS_FALSE;
+        return;
+    }
+
+    power->available = USYS_TRUE;
+    power->ok = wc_json_bool(json, "ok", false);
+    power->board = wc_json_dup_string(json, "board");
+    power->reason = wc_json_dup_string(json, "reason");
+    power->totalWatts = wc_json_num(json, "totalWatts", 0.0);
+
+    lm75 = json_object_get(json, "lm75");
+    if (json_is_object(lm75)) {
+        power->temperatureC = wc_json_num(lm75, "boardTempC", 0.0);
+    } else {
+        lm25066 = json_object_get(json, "lm25066");
+        if (json_is_object(lm25066)) {
+            power->temperatureC = wc_json_num(lm25066, "hsTempC", 0.0);
+        }
+    }
 
     json_decref(json);
-    return STATUS_OK;
+}
+
+static void collect_switch_data(SwitchStatusData *sw) {
+
+    int port = 0;
+
+    if (!sw) return;
+
+    memset(sw, 0, sizeof(SwitchStatusData));
+    sw->available = USYS_TRUE;
+
+    port = wc_find_service_port3(LOOKOUT_SERVICE_SWITCH,
+                                 "switch",
+                                 "switch.d");
+    if (port <= 0) {
+        return;
+    }
+
+    wc_get_json_from_service(port, "/v1/status", &sw->status);
+    wc_get_json_from_service(port, "/v1/ports/policy", &sw->policy);
+    wc_get_json_from_service(port, "/v1/ports", &sw->ports);
+}
+
+static void collect_controller_data(ControllerStatusData *controller) {
+
+    int port = 0;
+
+    if (!controller) return;
+
+    memset(controller, 0, sizeof(ControllerStatusData));
+    controller->available = USYS_TRUE;
+
+    port = wc_find_service_port3(LOOKOUT_SERVICE_CONTROLLER,
+                                 "controller",
+                                 "controller.d");
+    if (port <= 0) {
+        return;
+    }
+
+    wc_get_json_from_service(port, "/v1/status", &controller->status);
+}
+
+static void collect_backhaul_data(BackhaulStatusData *backhaul) {
+
+    int port = 0;
+
+    if (!backhaul) return;
+
+    memset(backhaul, 0, sizeof(BackhaulStatusData));
+    backhaul->available = USYS_TRUE;
+
+    port = wc_find_service_port3(LOOKOUT_SERVICE_BACKHAUL,
+                                 "backhaul",
+                                 "backhaul.d");
+    if (port <= 0) {
+        return;
+    }
+
+    wc_get_json_from_service(port, "/v1/status", &backhaul->status);
+}
+
+static void collect_fem_data(FemStatusData *fem) {
+
+    int port = 0;
+
+    if (!fem) return;
+
+    memset(fem, 0, sizeof(FemStatusData));
+    fem->available = USYS_TRUE;
+
+    port = wc_find_service_port3(LOOKOUT_SERVICE_FEM,
+                                 "fem",
+                                 "fem.d");
+    if (port <= 0) {
+        return;
+    }
+
+    wc_get_json_from_service(port, "/v1/fems", &fem->status);
 }
 
 int send_health_report(Config *config) {
@@ -542,6 +791,8 @@ int send_health_report(Config *config) {
     CappRuntime *runtime  = NULL;
     JsonObj     *json     = NULL;
 
+    LookoutStatusData statusData;
+
     char url[MAX_BUFFER] = {0};
     char *ukama  = NULL;
     char *buffer = NULL;
@@ -550,11 +801,7 @@ int send_health_report(Config *config) {
     int ret    = USYS_TRUE;
     int status = STATUS_NOK;
 
-    GPSClientData gps;
-    memset(&gps, 0, sizeof(GPSClientData));
-
-    SwitchPolicyStatusData switchPolicy;
-    memset(&switchPolicy, 0, sizeof(SwitchPolicyStatusData));
+    memset(&statusData, 0, sizeof(LookoutStatusData));
 
     if (config == NULL || config->nodeID == NULL) {
         return USYS_FALSE;
@@ -563,12 +810,14 @@ int send_health_report(Config *config) {
     if (config->appManager == LOOKOUT_APP_MANAGER_SUPERVISORD) {
         status = get_capps_from_supervisord(config, &cappList);
         if (status != STATUS_OK) {
-            usys_log_error("Unable to get capps from supervisord");
+            usys_log_error("Unable to get apps from supervisord");
         }
     } else {
-        status = get_capps_from_starterd(config, &cappList);
+        status = get_capps_from_starterd(config,
+                                         &cappList,
+                                         &statusData.starter);
         if (status != STATUS_OK) {
-            usys_log_error("Unable to get capps from starterd");
+            usys_log_error("Unable to get apps from starter.d");
         }
     }
 
@@ -589,44 +838,40 @@ int send_health_report(Config *config) {
         }
     }
 
-    gps.available = config->isTowerNode;
-    if (config->isTowerNode) {
-        if (get_gps_data(&gps) != STATUS_OK) {
-            gps.available = USYS_TRUE;
-            gps.gpsLock = USYS_FALSE;
-            gps.coordinates = NULL;
-            gps.gpsTime = NULL;
+    collect_power_data(&statusData.power);
+
+    if (config->nodeType == LOOKOUT_NODE_TOWER) {
+        collect_cellular_data(&statusData.cellular);
+        collect_radio_data(&statusData.radio);
+
+        if (get_gps_data(&statusData.gps) != STATUS_OK) {
+            statusData.gps.available = USYS_TRUE;
+            statusData.gps.lock = USYS_FALSE;
         }
+
+        collect_backhaul_data(&statusData.backhaul);
     }
 
-    switchPolicy.available = config->isCNode;
-    if (config->isCNode) {
-        if (get_switch_policy_data(&switchPolicy) != STATUS_OK) {
-            switchPolicy.available       = USYS_TRUE;
-            switchPolicy.switchAvailable = USYS_FALSE;
-            switchPolicy.siteID          = NULL;
-            switchPolicy.policyState     = NULL;
-            switchPolicy.policyHash      = NULL;
-            switchPolicy.policySource    = NULL;
-            switchPolicy.policyError     = NULL;
-        }
+    if (config->nodeType == LOOKOUT_NODE_AMPLIFIER) {
+        collect_radio_data(&statusData.radio);
+        collect_fem_data(&statusData.fem);
+    }
+
+    if (config->nodeType == LOOKOUT_NODE_CONTROL) {
+        collect_switch_data(&statusData.sw);
+        collect_controller_data(&statusData.controller);
+        collect_backhaul_data(&statusData.backhaul);
     }
 
     if (!json_serialize_health_report(&json,
-                                      config->nodeID,
+                                      config,
                                       cappList,
-                                      &gps,
-                                      &switchPolicy,
-                                      config->isTowerNode)) {
-        usys_log_error("Error serializing health report. Ignoring");
-        wc_free_gps_data(&gps);
-        wc_free_switch_policy_data(&switchPolicy);
+                                      &statusData)) {
+        usys_log_error("Error serializing node status report");
+        wc_free_status_data(&statusData);
         wc_free_capp_list(cappList);
         return USYS_FALSE;
     }
-
-    wc_free_gps_data(&gps);
-    wc_free_switch_policy_data(&switchPolicy);
 
     usys_find_ukama_service_address(&ukama);
     sprintf(url, "%s/node/v1/health/nodes/%s/performance",
@@ -635,12 +880,12 @@ int send_health_report(Config *config) {
 
     report = json_dumps(json, 0);
 
-    usys_log_debug("Sending to URL: %s the health report %s",
+    usys_log_debug("Sending to URL: %s the node status report %s",
                    url,
                    report);
 
     if (wc_send_request(url, "POST", report, &buffer) == STATUS_NOK) {
-        usys_log_error("failed to parse response from local service");
+        usys_log_error("failed to send node status report");
         ret = USYS_FALSE;
     }
 
@@ -648,6 +893,7 @@ int send_health_report(Config *config) {
     usys_free(report);
     usys_free(buffer);
     usys_free(ukama);
+    wc_free_status_data(&statusData);
     wc_free_capp_list(cappList);
 
     return ret;

--- a/nodes/ukamaOS/distro/system/lookoutd/src/web_client.c
+++ b/nodes/ukamaOS/distro/system/lookoutd/src/web_client.c
@@ -881,8 +881,7 @@ int send_health_report(Config *config) {
     report = json_dumps(json, 0);
 
     usys_log_debug("Sending to URL: %s the node status report %s",
-                   url,
-                   report);
+                   url, report);
 
     if (wc_send_request(url, "POST", report, &buffer) == STATUS_NOK) {
         usys_log_error("failed to send node status report");

--- a/nodes/ukamaOS/distro/system/meshd/src/callback.c
+++ b/nodes/ukamaOS/distro/system/meshd/src/callback.c
@@ -146,9 +146,7 @@ int callback_forward_service(const URequest *request,
                                         HttpStatus_BadRequest,
                                         HttpStatusStr(HttpStatus_BadRequest));
         return U_CALLBACK_CONTINUE;
-    } else {
-        usys_log_debug("Forward request JSON: %s", requestStr);
-    }
+    } 
 
     map = add_map_to_table(&ClientTable, service, sourcePort, idStr);
     if (map == NULL) {

--- a/nodes/ukamaOS/distro/system/meshd/src/data.c
+++ b/nodes/ukamaOS/distro/system/meshd/src/data.c
@@ -243,7 +243,6 @@ STATIC int send_data_to_local_service(URequest *data,
         *httpStatus = (int)code;
 
         if (response.size && response.buffer) {
-            usys_log_debug("Response received from server: %s", response.buffer);
             *retStr = strdup(response.buffer);
         } else {
             *retStr = strdup("");
@@ -269,10 +268,6 @@ void process_incoming_websocket_response(Message *message, void *data) {
         usys_log_error("process_incoming_websocket_response: invalid message");
         return;
     }
-
-    usys_log_info("Response to local service Code: %d Data: %s",
-                  message->code,
-                  message->data ? message->data : "");
 
     item = is_existing_item(ClientTable, message->seqNo);
     if (item == NULL) {
@@ -316,9 +311,6 @@ int process_incoming_websocket_message(Message *message, Config *config) {
                                      &responseLocal);
 
     if (ret) {
-        usys_log_info("Received response from local server Code: %d Response: %s",
-                      httpStatus, responseLocal ? responseLocal : "(null)");
-
         serialize_local_service_response(&responseRemote,
                                          message,
                                          httpStatus,
@@ -335,7 +327,6 @@ int process_incoming_websocket_message(Message *message, Config *config) {
     }
 
     if (responseRemote) {
-        usys_log_info("Adding response to websocket queue: %s", responseRemote);
         add_work_to_queue(&Transmit, responseRemote, NULL, 0, NULL, 0);
     }
 

--- a/nodes/ukamaOS/distro/system/meshd/src/data.c
+++ b/nodes/ukamaOS/distro/system/meshd/src/data.c
@@ -270,9 +270,9 @@ void process_incoming_websocket_response(Message *message, void *data) {
         return;
     }
 
-    usys_log_debug("Response to local service Code: %d Data: %s",
-                   message->code,
-                   message->data ? message->data : "");
+    usys_log_info("Response to local service Code: %d Data: %s",
+                  message->code,
+                  message->data ? message->data : "");
 
     item = is_existing_item(ClientTable, message->seqNo);
     if (item == NULL) {
@@ -316,8 +316,8 @@ int process_incoming_websocket_message(Message *message, Config *config) {
                                      &responseLocal);
 
     if (ret) {
-        usys_log_debug("Received response from local server Code: %d Response: %s",
-                       httpStatus, responseLocal ? responseLocal : "(null)");
+        usys_log_info("Received response from local server Code: %d Response: %s",
+                      httpStatus, responseLocal ? responseLocal : "(null)");
 
         serialize_local_service_response(&responseRemote,
                                          message,
@@ -335,7 +335,7 @@ int process_incoming_websocket_message(Message *message, Config *config) {
     }
 
     if (responseRemote) {
-        usys_log_debug("Adding response to websocket queue: %s", responseRemote);
+        usys_log_info("Adding response to websocket queue: %s", responseRemote);
         add_work_to_queue(&Transmit, responseRemote, NULL, 0, NULL, 0);
     }
 

--- a/nodes/ukamaOS/distro/system/meshd/src/main.c
+++ b/nodes/ukamaOS/distro/system/meshd/src/main.c
@@ -158,6 +158,8 @@ int main (int argc, char *argv[]) {
     state->webInst = &webInst;
     state->handler = &websocketHandler;
 
+	set_log_level("DEBUG");	
+
     catch_sigterm();
 
 	/* Prase command line args. */

--- a/nodes/ukamaOS/distro/system/meshd/src/work.c
+++ b/nodes/ukamaOS/distro/system/meshd/src/work.c
@@ -99,7 +99,6 @@ int add_work_to_queue(WorkList **list, char *data, thread_func_t pre,
 
 	/* Unlock */
 	pthread_mutex_unlock(&((*list)->mutex));
-    usys_log_info("Work added on the queue. Len: %d Data: %s", strlen(data), data);
 
 	return TRUE;
 }

--- a/nodes/ukamaOS/distro/system/meshd/src/work.c
+++ b/nodes/ukamaOS/distro/system/meshd/src/work.c
@@ -12,7 +12,6 @@
 #include "usys_log.h"
 
 #include "work.h"
-
 #include "static.h"
 
 void init_work_list(WorkList **list) {
@@ -100,7 +99,7 @@ int add_work_to_queue(WorkList **list, char *data, thread_func_t pre,
 
 	/* Unlock */
 	pthread_mutex_unlock(&((*list)->mutex));
-    usys_log_debug("Work added on the queue. Len: %d Data: %s", strlen(data), data);
+    usys_log_info("Work added on the queue. Len: %d Data: %s", strlen(data), data);
 
 	return TRUE;
 }


### PR DESCRIPTION
Fix #1297 , refactor the health report structure for all 3 node types.

{
  "schemaVersion": "1.0",
  "nodeId": "uk-sa2602-cnode-v0-344c",
  "nodeType": "control",
  "reportedAt": "1778471096",
  "capabilities": [
    "power",
    "switch",
    "controller",
    "backhaul"
  ],
  "system": {
    "uptimeSec": 259882,
    "starter": {
      "available": true,
      "state": "unknown",
      "updateInProgress": false,
      "switchRequested": false,
      "terminateRequested": false,
      "exitCode": 0
    },
    "power": {
      "available": false,
      "error": "power_service_unreachable"
    }
  },
  "interfaces": {
    "switch": {
      "available": true,
      "policy": {},
      "ports": [
        {
          "id": 1,
          "name": "tnode-poe",
          "present": true,
          "adminState": "up",
          "linkState": "up",
          "poeState": "on",
          "poeOperational": true,
          "speedBps": 1000000000,
          "powerWatts": 12.0,
          "fault": ""
        },
        {
          "id": 2,
          "name": "cnode-poe",
          "present": true,
          "adminState": "up",
          "linkState": "up",
          "poeState": "on",
          "poeOperational": true,
          "speedBps": 1000000000,
          "powerWatts": 7.0,
          "fault": ""
        },
        {
          "id": 3,
          "name": "anode-poe",
          "present": true,
          "adminState": "up",
          "linkState": "up",
          "poeState": "on",
          "poeOperational": true,
          "speedBps": 1000000000,
          "powerWatts": 8.0,
          "fault": ""
        },
        {
          "id": 4,
          "name": "spare-poe",
          "present": true,
          "adminState": "up",
          "linkState": "down",
          "poeState": "off",
          "poeOperational": false,
          "speedBps": 0,
          "powerWatts": 0.0,
          "fault": ""
        },
        {
          "id": 5,
          "name": "port5",
          "present": true,
          "adminState": "up",
          "linkState": "down",
          "poeState": "off",
          "poeOperational": false,
          "speedBps": 0,
          "powerWatts": 0.0,
          "fault": ""
        },
        {
          "id": 6,
          "name": "port6",
          "present": true,
          "adminState": "up",
          "linkState": "down",
          "poeState": "off",
          "poeOperational": false,
          "speedBps": 0,
          "powerWatts": 0.0,
          "fault": ""
        },
        {
          "id": 7,
          "name": "port7",
          "present": true,
          "adminState": "up",
          "linkState": "down",
          "poeState": "off",
          "poeOperational": false,
          "speedBps": 0,
          "powerWatts": 0.0,
          "fault": ""
        },
        {
          "id": 8,
          "name": "port8",
          "present": true,
          "adminState": "up",
          "linkState": "down",
          "poeState": "off",
          "poeOperational": false,
          "speedBps": 0,
          "powerWatts": 0.0,
          "fault": ""
        },
        {
          "id": 9,
          "name": "uplink-sfp",
          "present": true,
          "adminState": "up",
          "linkState": "up",
          "poeState": "off",
          "poeOperational": false,
          "speedBps": 1000000000,
          "powerWatts": 0.0,
          "fault": ""
        },
        {
          "id": 10,
          "name": "port10",
          "present": true,
          "adminState": "up",
          "linkState": "down",
          "poeState": "off",
          "poeOperational": false,
          "speedBps": 0,
          "powerWatts": 0.0,
          "fault": ""
        }
      ]
    },
    "controller": {
      "available": true,
      "solar": {
        "voltage_v": 65.372,
        "current_a": 8.168634889555161,
        "power_w": 534.0,
        "yield_today_kwh": 12.5145,
        "yield_total_kwh": 0.0305
      },
      "battery": {
        "voltage_v": 53.014,
        "current_a": 10.073
      },
      "load": {}
    },
    "backhaul": {
      "available": true,
      "state": "DOWN",
      "linkGuess": "UNKNOWN",
      "confidence": 0.9
    }
  },
  "apps": [
    {
      "space": "boot",
      "name": "noded",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 12,
      "resources": {
        "cpuPercent": 0.0,
        "memoryRssKb": 9256,
        "diskReadBytes": 0,
        "diskWriteBytes": 32768
      }
    },
    {
      "space": "boot",
      "name": "bootstrap",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 20,
      "resources": {
        "cpuPercent": 0.0,
        "memoryRssKb": 11104,
        "diskReadBytes": 0,
        "diskWriteBytes": 16384
      }
    },
    {
      "space": "boot",
      "name": "meshd",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 30,
      "resources": {
        "cpuPercent": 5.0,
        "memoryRssKb": 12100,
        "diskReadBytes": 0,
        "diskWriteBytes": 8192
      }
    },
    {
      "space": "boot",
      "name": "controlleremu",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 42,
      "resources": {
        "cpuPercent": 8.0,
        "memoryRssKb": 21512,
        "diskReadBytes": 0,
        "diskWriteBytes": 4096
      }
    },
    {
      "space": "boot",
      "name": "switchemu",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 49,
      "resources": {
        "cpuPercent": 77.0,
        "memoryRssKb": 7980,
        "diskReadBytes": 0,
        "diskWriteBytes": 0
      }
    },
    {
      "space": "services",
      "name": "backhaul",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 58,
      "resources": {
        "cpuPercent": 2.0,
        "memoryRssKb": 11588,
        "diskReadBytes": 0,
        "diskWriteBytes": 16384
      }
    },
    {
      "space": "services",
      "name": "rlog",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 65,
      "resources": {
        "cpuPercent": 9.0,
        "memoryRssKb": 11516,
        "diskReadBytes": 0,
        "diskWriteBytes": 4096
      }
    },
    {
      "space": "services",
      "name": "deviced",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 73,
      "resources": {
        "cpuPercent": 0.0,
        "memoryRssKb": 11032,
        "diskReadBytes": 0,
        "diskWriteBytes": 0
      }
    },
    {
      "space": "services",
      "name": "wimcd",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 80,
      "resources": {
        "cpuPercent": 544.0,
        "memoryRssKb": 12688,
        "diskReadBytes": 0,
        "diskWriteBytes": 188416
      }
    },
    {
      "space": "services",
      "name": "switch",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 99,
      "resources": {
        "cpuPercent": 20.0,
        "memoryRssKb": 8984,
        "diskReadBytes": 0,
        "diskWriteBytes": 4096
      }
    },
    {
      "space": "services",
      "name": "aggregator",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 115,
      "resources": {
        "cpuPercent": 3.0,
        "memoryRssKb": 11340,
        "diskReadBytes": 0,
        "diskWriteBytes": 0
      }
    },
    {
      "space": "services",
      "name": "controller",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 131,
      "resources": {
        "cpuPercent": 2.0,
        "memoryRssKb": 8672,
        "diskReadBytes": 0,
        "diskWriteBytes": 0
      }
    },
    {
      "space": "services",
      "name": "lookoutd",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 146,
      "resources": {
        "cpuPercent": 1.0,
        "memoryRssKb": 11204,
        "diskReadBytes": 0,
        "diskWriteBytes": 16384
      }
    },
    {
      "space": "services",
      "name": "configd",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 168,
      "resources": {
        "cpuPercent": 3.0,
        "memoryRssKb": 11240,
        "diskReadBytes": 0,
        "diskWriteBytes": 0
      }
    },
    {
      "space": "services",
      "name": "metricsd",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 197,
      "resources": {
        "cpuPercent": 7.0,
        "memoryRssKb": 12864,
        "diskReadBytes": 0,
        "diskWriteBytes": 49152
      }
    },
    {
      "space": "services",
      "name": "notifyd",
      "tag": "old_arch-f1d946ddd",
      "version": "old_arch-f1d946ddd",
      "state": "Active",
      "pid": 215,
      "resources": {
        "cpuPercent": 3.0,
        "memoryRssKb": 11432,
        "diskReadBytes": 0,
        "diskWriteBytes": 0
      }
    }
  ],
  "events": []
}