### PR TITLE
Support multiple hubs address and match backend update contract with starter

### DIFF
--- a/nodes/ukamaOS/distro/system/starterd/src/supervisor.c
+++ b/nodes/ukamaOS/distro/system/starterd/src/supervisor.c
@@ -474,11 +474,11 @@ static bool update_self(Supervisor *s,
     return true;
 }
 
-static bool update_app(Supervisor *s,
-                       const char *space,
-                       const char *name,
-                       const char *tag,
-                       const char *hub) {
+static bool update_one_app(Supervisor *s,
+                           const char *space,
+                           const char *name,
+                           const char *tag,
+                           const char *hub) {
 
     App *a;
     char *oldTag;
@@ -564,6 +564,46 @@ static bool update_app(Supervisor *s,
     free(oldTag);
     free(oldLastGood);
     return true;
+}
+
+static bool update_app(Supervisor *s,
+                       const char *space,
+                       const char *name,
+                       const char *tag,
+                       const char *hub) {
+
+    Space *sp =  NULL;
+    bool matched;
+    bool ok;
+
+    if (!s || !name || !tag) {
+        return false;
+    }
+
+    if (space) {
+        return update_one_app(s, space, name, tag, hub);
+    }
+
+    matched = false;
+    ok = true;
+
+    sp = s->spaceList;
+    while (sp) {
+        if (sp->name && app_find(s->spaceList, sp->name, name)) {
+            matched = true;
+            if (!update_one_app(s, sp->name, name, tag, hub)) {
+                ok = false;
+            }
+        }
+        sp = sp->next;
+    }
+
+    if (!matched) {
+        usys_log_error("update: app not found in any space: %s", name);
+        return false;
+    }
+
+    return ok;
 }
 
 static void* supervisor_thread(void *arg) {

--- a/nodes/ukamaOS/distro/system/starterd/src/web_client.c
+++ b/nodes/ukamaOS/distro/system/starterd/src/web_client.c
@@ -569,10 +569,27 @@ bool wc_fetch_package(Config *config,
             goto done;
         }
 
-        jhub = json_string(hub);
-        if (jhub == NULL) {
-            usys_log_error("wimc: failed creating hub json string");
-            goto done;
+        if (hub[0] == '[') {
+            json_error_t jerr;
+
+            memset(&jerr, 0, sizeof(jerr));
+
+            jhub = json_loads(hub, 0, &jerr);
+            if (jhub == NULL || !json_is_array(jhub)) {
+                if (jhub != NULL) {
+                    json_decref(jhub);
+                    jhub = NULL;
+                }
+
+                usys_log_error("wimc: invalid hub array payload");
+                goto done;
+            }
+        } else {
+            jhub = json_string(hub);
+            if (jhub == NULL) {
+                usys_log_error("wimc: failed creating hub json string");
+                goto done;
+            }
         }
 
         if (json_object_set_new(jreq, "hub", jhub) != 0) {

--- a/nodes/ukamaOS/distro/system/starterd/src/web_service.c
+++ b/nodes/ukamaOS/distro/system/starterd/src/web_service.c
@@ -144,10 +144,14 @@ static bool ws_parse_update(json_t *j,
                             char **hubOut) {
 
     json_t *v;
+    json_t *item;
     const char *space;
     const char *name;
     const char *tag;
     const char *hub;
+    char *hubPayload;
+    size_t i;
+    size_t count;
 
     if (spaceOut) *spaceOut = NULL;
     if (nameOut)  *nameOut  = NULL;
@@ -167,17 +171,80 @@ static bool ws_parse_update(json_t *j,
     v = json_object_get(j, "tag");
     tag = json_is_string(v) ? json_string_value(v) : NULL;
 
-    v = json_object_get(j, "hub");
-    hub = json_is_string(v) ? json_string_value(v) : NULL;
-
     if (!space || !name || !tag) {
         return false;
     }
 
-    if (spaceOut)                *spaceOut = strdup(space);
-    if (nameOut)                 *nameOut  = strdup(name);
-    if (tagOut)                  *tagOut   = strdup(tag);
-    if (hubOut && hub && *hub)   *hubOut   = strdup(hub);
+    hubPayload = NULL;
+
+    v = json_object_get(j, "hub");
+    if (json_is_string(v)) {
+        hub = json_string_value(v);
+        if (hub && *hub) {
+            hubPayload = strdup(hub);
+            if (!hubPayload) {
+                return false;
+            }
+        }
+    } else if (json_is_array(v)) {
+        count = json_array_size(v);
+
+        if (count == 0 || count > 8) {
+            return false;
+        }
+
+        json_array_foreach(v, i, item) {
+            hub = json_is_string(item) ? json_string_value(item) : NULL;
+            if (!hub || !*hub) {
+                return false;
+            }
+        }
+
+        hubPayload = json_dumps(v, JSON_COMPACT);
+        if (!hubPayload) {
+            return false;
+        }
+    } else if (v != NULL) {
+        return false;
+    }
+
+    if (spaceOut) {
+        *spaceOut = strdup(space);
+        if (!*spaceOut) {
+            free(hubPayload);
+            return false;
+        }
+    }
+
+    if (nameOut) {
+        *nameOut = strdup(name);
+        if (!*nameOut) {
+            free(hubPayload);
+            free(spaceOut ? *spaceOut : NULL);
+            if (spaceOut) *spaceOut = NULL;
+            return false;
+        }
+    }
+
+    if (tagOut) {
+        *tagOut = strdup(tag);
+        if (!*tagOut) {
+            free(hubPayload);
+            free(spaceOut ? *spaceOut : NULL);
+            free(nameOut ?  *nameOut : NULL);
+            
+            if (spaceOut) *spaceOut = NULL;
+            if (nameOut)  *nameOut  = NULL;
+
+            return false;
+        }
+    }
+
+    if (hubOut) {
+        *hubOut = hubPayload;
+    } else {
+        free(hubPayload);
+    }
 
     return true;
 }

--- a/nodes/ukamaOS/distro/system/starterd/src/web_service.c
+++ b/nodes/ukamaOS/distro/system/starterd/src/web_service.c
@@ -63,6 +63,32 @@ static bool ws_app_exists(StarterContext *ctx,
     return true;
 }
 
+static bool ws_update_target_exists(StarterContext *ctx,
+                                    const char *space,
+                                    const char *name) {
+
+    Space *sp = NULL;
+
+    if (!ctx || !ctx->spaceList || !name) {
+        return false;
+    }
+
+    if (space) {
+        return ws_app_exists(ctx, space, name);
+    }
+
+    sp = ctx->spaceList;
+    while (sp) {
+        if (sp->name && app_find(ctx->spaceList, sp->name, name)) {
+            return true;
+        }
+        sp = sp->next;
+    }
+
+    usys_log_error("web: app not found in any space: name=%s", name);
+    return false;
+}
+
 static int ws_ping_cb(const struct _u_request *req,
                       struct _u_response *resp,
                       void *userData) {
@@ -162,8 +188,17 @@ static bool ws_parse_update(json_t *j,
         return false;
     }
 
+    space = NULL;
+
     v = json_object_get(j, "space");
-    space = json_is_string(v) ? json_string_value(v) : NULL;
+    if (json_is_string(v)) {
+        space = json_string_value(v);
+        if (!space || !*space) {
+            return false;
+        }
+    } else if (v != NULL) {
+        return false;
+    }
 
     v = json_object_get(j, "name");
     name = json_is_string(v) ? json_string_value(v) : NULL;
@@ -171,7 +206,7 @@ static bool ws_parse_update(json_t *j,
     v = json_object_get(j, "tag");
     tag = json_is_string(v) ? json_string_value(v) : NULL;
 
-    if (!space || !name || !tag) {
+    if (!name || !*name || !tag || !*tag) {
         return false;
     }
 
@@ -208,7 +243,7 @@ static bool ws_parse_update(json_t *j,
         return false;
     }
 
-    if (spaceOut) {
+    if (spaceOut && space) {
         *spaceOut = strdup(space);
         if (!*spaceOut) {
             free(hubPayload);
@@ -232,7 +267,7 @@ static bool ws_parse_update(json_t *j,
             free(hubPayload);
             free(spaceOut ? *spaceOut : NULL);
             free(nameOut ?  *nameOut : NULL);
-            
+
             if (spaceOut) *spaceOut = NULL;
             if (nameOut)  *nameOut  = NULL;
 
@@ -304,7 +339,7 @@ static int ws_update_cb(const struct _u_request *req,
                              HttpStatusStr(HttpStatus_BadRequest));
     }
 
-    if (!ws_app_exists(ctx, space, name)) {
+    if (!ws_update_target_exists(ctx, space, name)) {
         json_decref(j);
         free(space);
         free(name);

--- a/nodes/ukamaOS/distro/system/wimcd/common/utils.c
+++ b/nodes/ukamaOS/distro/system/wimcd/common/utils.c
@@ -6,10 +6,6 @@
  * Copyright (c) 2021-present, Ukama Inc.
  */
 
-/*
- * Misc utility functions
- */
-
 #include <stdio.h>
 #include <string.h>
 
@@ -110,4 +106,6 @@ TransferState convert_str_to_tx_state(char *state) {
   }  else if (strcmp(state, AGENT_TX_STATE_ERR_STR)==0) {
     return ERR;
   }
+
+  return ERR;
 }

--- a/nodes/ukamaOS/distro/system/wimcd/inc/wimc.h
+++ b/nodes/ukamaOS/distro/system/wimcd/inc/wimc.h
@@ -73,6 +73,7 @@
 #define WIMC_MAX_ARGS_LEN   1024
 #define WIMC_MAX_URL_LEN    1024
 #define WIMC_MAX_ERR_STR    1024
+#define WIMC_MAX_HUBS       8
 
 #define WIMC_ACTION_FETCH_STR  "fetch"
 #define WIMC_ACTION_UPDATE_STR "update"

--- a/nodes/ukamaOS/distro/system/wimcd/src/callback.c
+++ b/nodes/ukamaOS/distro/system/wimcd/src/callback.c
@@ -105,6 +105,7 @@ static bool parse_hub_overrides(const URequest *request, HubList *list) {
 
     json = NULL;
     jhub = NULL;
+    item = NULL;
     hub = NULL;
     ret = true;
 
@@ -114,14 +115,16 @@ static bool parse_hub_overrides(const URequest *request, HubList *list) {
 
     memset(list, 0, sizeof(HubList));
 
-    if (!request || !request->binary_body || request->binary_body_length == 0) {
+    if (request == NULL ||
+        request->binary_body == NULL ||
+        request->binary_body_length == 0) {
         return true;
     }
 
     memset(&jerr, 0, sizeof(jerr));
 
     json = ulfius_get_json_body_request(request, &jerr);
-    if (!json) {
+    if (json == NULL) {
         return true;
     }
 
@@ -133,8 +136,9 @@ static bool parse_hub_overrides(const URequest *request, HubList *list) {
 
     if (json_is_string(jhub)) {
         hub = json_string_value(jhub);
-        if (hub && *hub && !hub_list_add(list, hub)) {
-            ret = false;
+
+        if (hub != NULL && *hub != '\0') {
+            ret = hub_list_add(list, hub);
         }
 
         json_decref(json);
@@ -142,13 +146,15 @@ static bool parse_hub_overrides(const URequest *request, HubList *list) {
     }
 
     if (json_is_array(jhub)) {
-        if (json_array_size(jhub) > WIMC_MAX_HUBS) {
+        if (json_array_size(jhub) == 0 ||
+            json_array_size(jhub) > WIMC_MAX_HUBS) {
             json_decref(json);
             return false;
         }
 
         json_array_foreach(jhub, i, item) {
             hub = json_is_string(item) ? json_string_value(item) : NULL;
+
             if (hub == NULL || *hub == '\0') {
                 ret = false;
                 break;
@@ -165,6 +171,104 @@ static bool parse_hub_overrides(const URequest *request, HubList *list) {
     }
 
     json_decref(json);
+
+    return false;
+}
+
+static bool get_artifacts_info_from_any_hub(Artifact *artifact,
+                                            Config *config,
+                                            HubList *hubList,
+                                            const char *defaultHubURL,
+                                            char *name,
+                                            char *tag,
+                                            char *selectedHub,
+                                            size_t selectedHubSize,
+                                            int *status) {
+
+    int i;
+    int httpStatus;
+    const char *hubURL;
+
+    if (artifact == NULL ||
+        config == NULL ||
+        name == NULL ||
+        tag == NULL ||
+        selectedHub == NULL ||
+        selectedHubSize == 0) {
+        if (status != NULL) {
+            *status = HttpStatus_InternalServerError;
+        }
+        return false;
+    }
+
+    selectedHub[0] = '\0';
+
+    if (status != NULL) {
+        *status = HttpStatus_InternalServerError;
+    }
+
+    if (hubList != NULL && hubList->count > 0) {
+        for (i = 0; i < hubList->count; i++) {
+            hubURL = hubList->items[i];
+
+            if (hubURL == NULL || *hubURL == '\0') {
+                continue;
+            }
+
+            httpStatus = 0;
+
+            usys_log_debug("Trying hub %s for %s:%s",
+                           hubURL, name, tag);
+
+            if (get_artifacts_info_from_hub(artifact, config, hubURL,
+                                            name, tag, &httpStatus)) {
+                snprintf(selectedHub, selectedHubSize, "%s", hubURL);
+
+                if (status != NULL) {
+                    *status = HttpStatus_OK;
+                }
+
+                usys_log_debug("Selected hub %s for %s:%s",
+                               selectedHub, name, tag);
+
+                return true;
+            }
+
+            usys_log_error("Hub failed %s for %s:%s http=%d",
+                           hubURL, name, tag, httpStatus);
+
+            if (status != NULL && httpStatus != 0) {
+                *status = httpStatus;
+            }
+        }
+
+        return false;
+    }
+
+    if (defaultHubURL == NULL || *defaultHubURL == '\0') {
+        if (status != NULL) {
+            *status = HttpStatus_BadRequest;
+        }
+        return false;
+    }
+
+    httpStatus = 0;
+
+    if (get_artifacts_info_from_hub(artifact, config, defaultHubURL,
+                                    name, tag, &httpStatus)) {
+        snprintf(selectedHub, selectedHubSize, "%s", defaultHubURL);
+
+        if (status != NULL) {
+            *status = HttpStatus_OK;
+        }
+
+        return true;
+    }
+
+    if (status != NULL) {
+        *status = httpStatus;
+    }
+
     return false;
 }
 
@@ -459,144 +563,67 @@ int web_service_cb_get_app_status(const URequest *request,
     return U_CALLBACK_CONTINUE;
 }
 
-static bool get_artifacts_info_from_any_hub(Artifact *artifact,
-                                            Config *config,
-                                            HubList *hubList,
-                                            const char *defaultHubURL,
-                                            char *name,
-                                            char *tag,
-                                            char *selectedHub,
-                                            size_t selectedHubSize,
-                                            int *status) {
-
-    int i;
-    int httpStatus;
-    const char *hubURL;
-
-    if (artifact == NULL || config == NULL || name == NULL || tag == NULL ||
-        selectedHub == NULL || selectedHubSize == 0) {
-        if (status != NULL) {
-            *status = HttpStatus_InternalServerError;
-        }
-        return false;
-    }
-
-    selectedHub[0] = '\0';
-
-    if (status != NULL) {
-        *status = HttpStatus_InternalServerError;
-    }
-
-    if (hubList != NULL && hubList->count > 0) {
-        for (i = 0; i < hubList->count; i++) {
-            hubURL = hubList->items[i];
-
-            if (hubURL == NULL || *hubURL == '\0') {
-                continue;
-            }
-
-            httpStatus = 0;
-
-            usys_log_debug("Trying hub %s for %s:%s", hubURL, name, tag);
-
-            if (get_artifacts_info_from_hub(artifact, config, hubURL,
-                                            name, tag, &httpStatus)) {
-                snprintf(selectedHub, selectedHubSize, "%s", hubURL);
-
-                if (status != NULL) {
-                    *status = HttpStatus_OK;
-                }
-
-                usys_log_debug("Selected hub %s for %s:%s",
-                               selectedHub, name, tag);
-
-                return true;
-            }
-
-            usys_log_error("Hub failed %s for %s:%s http=%d",
-                           hubURL, name, tag, httpStatus);
-
-            if (status != NULL && httpStatus != 0) {
-                *status = httpStatus;
-            }
-        }
-
-        return false;
-    }
-
-    if (defaultHubURL == NULL || *defaultHubURL == '\0') {
-        if (status != NULL) {
-            *status = HttpStatus_BadRequest;
-        }
-        return false;
-    }
-
-    httpStatus = 0;
-
-    if (get_artifacts_info_from_hub(artifact, config, defaultHubURL,
-                                    name, tag, &httpStatus)) {
-        snprintf(selectedHub, selectedHubSize, "%s", defaultHubURL);
-
-        if (status != NULL) {
-            *status = HttpStatus_OK;
-        }
-
-        return true;
-    }
-
-    if (status != NULL) {
-        *status = httpStatus;
-    }
-
-    return false;
-}
-
 int web_service_cb_post_app(const URequest *request,
                             UResponse *response,
                             void *data) {
 
-    int httpStatus = 0;
-    char indexURL[WIMC_MAX_URL_LEN] = {0};
-    char storeURL[WIMC_MAX_URL_LEN] = {0};
+    int httpStatus;
+    int responseStatus;
+    char indexURL[WIMC_MAX_URL_LEN];
+    char storeURL[WIMC_MAX_URL_LEN];
+    char selectedHub[WIMC_MAX_URL_LEN];
     char *name;
     char *tag;
-    char *status = NULL;
-    char *path = NULL;
-    char *actualVersion = NULL;
-    char *error = NULL;
-    HubList hubList;
-    char selectedHub[WIMC_MAX_URL_LEN];
+    char *status;
+    char *path;
+    char *actualVersion;
+    char *error;
     const char *hubURL;
-
     Artifact artifact;
     Config *config;
-    WimcReq *wimcRequest = NULL;
-    ArtifactFormat *artifactFormat = NULL;
+    WimcReq *wimcRequest;
+    ArtifactFormat *artifactFormat;
     json_t *jResponse;
+    HubList hubList;
+    bool responseSet;
+    bool artifactLoaded;
 
-    memset(&artifact,   0, sizeof(artifact));
-    memset(&hubList,    0, sizeof(hubList));
+    httpStatus = 0;
+    responseStatus = HttpStatus_InternalServerError;
+    status = NULL;
+    path = NULL;
+    actualVersion = NULL;
+    error = NULL;
+    hubURL = NULL;
+    wimcRequest = NULL;
+    artifactFormat = NULL;
+    jResponse = NULL;
+    responseSet = false;
+    artifactLoaded = false;
+
+    memset(indexURL, 0, sizeof(indexURL));
+    memset(storeURL, 0, sizeof(storeURL));
     memset(selectedHub, 0, sizeof(selectedHub));
+    memset(&artifact, 0, sizeof(artifact));
+    memset(&hubList, 0, sizeof(hubList));
+
     config = (Config *)data;
-    
     name = (char *)u_map_get(request->map_url, "name");
     tag  = (char *)u_map_get(request->map_url, "tag");
 
     if (!pkg_is_valid_identifier(name) || !pkg_is_valid_identifier(tag)) {
-        ulfius_set_string_body_response(response, HttpStatus_BadRequest,
-                                        HttpStatusStr(HttpStatus_BadRequest));
-        return U_CALLBACK_CONTINUE;
+        responseStatus = HttpStatus_BadRequest;
+        goto done;
     }
 
     if (validate_cached_package(config, name, tag, &path, &actualVersion)) {
         jResponse = status_json(name, tag, WIMC_STATUS_AVAILABLE, path,
                                 actualVersion, NULL);
-        ulfius_set_json_body_response(response, HttpStatus_OK,
-                                      jResponse);
+        ulfius_set_json_body_response(response, HttpStatus_OK, jResponse);
         json_decref(jResponse);
-        free(path);
-        free(actualVersion);
-        return U_CALLBACK_CONTINUE;
+        jResponse = NULL;
+        responseSet = true;
+        goto done;
     }
 
     pthread_mutex_lock(&config->dbMutex);
@@ -610,12 +637,10 @@ int web_service_cb_post_app(const URequest *request,
             ulfius_set_json_body_response(response, HttpStatus_Conflict,
                                           jResponse);
             json_decref(jResponse);
-            free(status);
-            free(path);
-            free(actualVersion);
-            free(error);
+            jResponse = NULL;
+            responseSet = true;
             pthread_mutex_unlock(&config->dbMutex);
-            return U_CALLBACK_CONTINUE;
+            goto done;
         }
     }
 
@@ -628,6 +653,11 @@ int web_service_cb_post_app(const URequest *request,
     free(actualVersion);
     free(error);
 
+    status = NULL;
+    path = NULL;
+    actualVersion = NULL;
+    error = NULL;
+
     if (!parse_hub_overrides(request, &hubList)) {
         pthread_mutex_lock(&config->dbMutex);
         db_update_package_status(config->db, name, tag, NULL,
@@ -635,10 +665,8 @@ int web_service_cb_post_app(const URequest *request,
                                  "invalid hub list");
         pthread_mutex_unlock(&config->dbMutex);
 
-        ulfius_set_string_body_response(response,
-                                        HttpStatus_BadRequest,
-                                        HttpStatusStr(HttpStatus_BadRequest));
-        return U_CALLBACK_CONTINUE;
+        responseStatus = HttpStatus_BadRequest;
+        goto done;
     }
 
     if (!get_artifacts_info_from_any_hub(&artifact, config, &hubList,
@@ -651,14 +679,12 @@ int web_service_cb_post_app(const URequest *request,
                                  "hub lookup failed");
         pthread_mutex_unlock(&config->dbMutex);
 
-        ulfius_set_string_body_response(response,
-                                        httpStatus ? httpStatus :
-                                        HttpStatus_InternalServerError,
-                                        HttpStatusStr(httpStatus ? httpStatus :
-                                                      HttpStatus_InternalServerError));
-        free_hub_list(&hubList);
-        return U_CALLBACK_CONTINUE;
+        responseStatus = httpStatus ? httpStatus :
+                         HttpStatus_InternalServerError;
+        goto done;
     }
+
+    artifactLoaded = true;
     hubURL = selectedHub;
 
     artifactFormat = select_artifact_format(&artifact);
@@ -669,13 +695,8 @@ int web_service_cb_post_app(const URequest *request,
                                  "no matching agent");
         pthread_mutex_unlock(&config->dbMutex);
 
-        free_artifact(&artifact);
-        free_hub_list(&hubList);
-        ulfius_set_string_body_response(response,
-                                        HttpStatus_ServiceUnavailable,
-                                        HttpStatusStr(
-                                        HttpStatus_ServiceUnavailable));
-        return U_CALLBACK_CONTINUE;
+        responseStatus = HttpStatus_ServiceUnavailable;
+        goto done;
     }
 
     if (strcmp(artifactFormat->type, WIMC_METHOD_CHUNK_STR) == 0) {
@@ -693,25 +714,15 @@ int web_service_cb_post_app(const URequest *request,
                                  "unsupported package method");
         pthread_mutex_unlock(&config->dbMutex);
 
-        free_artifact(&artifact);
-        free_hub_list(&hubList);
-        ulfius_set_string_body_response(response,
-                                        HttpStatus_ServiceUnavailable,
-                                        HttpStatusStr(
-                                        HttpStatus_ServiceUnavailable));
-        return U_CALLBACK_CONTINUE;
+        responseStatus = HttpStatus_ServiceUnavailable;
+        goto done;
     }
 
     create_wimc_request(&wimcRequest, name, tag, indexURL, storeURL,
                         artifactFormat->type, DEFAULT_INTERVAL);
     if (wimcRequest == NULL) {
-        free_artifact(&artifact);
-        free_hub_list(&hubList);
-        ulfius_set_string_body_response(response,
-                                        HttpStatus_InternalServerError,
-                                        HttpStatusStr(
-                                        HttpStatus_InternalServerError));
-        return U_CALLBACK_CONTINUE;
+        responseStatus = HttpStatus_InternalServerError;
+        goto done;
     }
 
     if (artifactFormat->size > 0) {
@@ -722,15 +733,10 @@ int web_service_cb_post_app(const URequest *request,
                                      "package too large");
             pthread_mutex_unlock(&config->dbMutex);
 
-            cleanup_wimc_request(wimcRequest);
-            free_artifact(&artifact);
-            free_hub_list(&hubList);
-            ulfius_set_string_body_response(response,
-                                            HttpStatus_BadRequest,
-                                            HttpStatusStr(
-                                            HttpStatus_BadRequest));
-            return U_CALLBACK_CONTINUE;
+            responseStatus = HttpStatus_BadRequest;
+            goto done;
         }
+
         wimcRequest->fetch->content->expectedSizeBytes =
             (long)artifactFormat->size;
     }
@@ -740,26 +746,47 @@ int web_service_cb_post_app(const URequest *request,
         db_update_package_status(config->db, name, tag, NULL,
                                  WIMC_STATUS_DOWNLOAD, NULL, NULL);
         pthread_mutex_unlock(&config->dbMutex);
+
         jResponse = status_json(name, tag, WIMC_STATUS_DOWNLOAD,
                                 NULL, NULL, NULL);
         ulfius_set_json_body_response(response, HttpStatus_Accepted,
                                       jResponse);
         json_decref(jResponse);
-    } else {
-        pthread_mutex_lock(&config->dbMutex);
-        db_update_package_status(config->db, name, tag, NULL,
-                                 WIMC_STATUS_FAILED, NULL,
-                                 "agent request failed");
-        pthread_mutex_unlock(&config->dbMutex);
-        ulfius_set_string_body_response(response,
-                                        HttpStatus_ServiceUnavailable,
-                                        HttpStatusStr(
-                                        HttpStatus_ServiceUnavailable));
+        jResponse = NULL;
+        responseSet = true;
+        goto done;
     }
 
-    cleanup_wimc_request(wimcRequest);
-    free_artifact(&artifact);
+    pthread_mutex_lock(&config->dbMutex);
+    db_update_package_status(config->db, name, tag, NULL,
+                             WIMC_STATUS_FAILED, NULL,
+                             "agent request failed");
+    pthread_mutex_unlock(&config->dbMutex);
+
+    responseStatus = HttpStatus_ServiceUnavailable;
+
+done:
+    if (wimcRequest != NULL) {
+        cleanup_wimc_request(wimcRequest);
+        wimcRequest = NULL;
+    }
+
+    if (artifactLoaded) {
+        free_artifact(&artifact);
+    }
+
     free_hub_list(&hubList);
+
+    free(status);
+    free(path);
+    free(actualVersion);
+    free(error);
+
+    if (!responseSet) {
+        ulfius_set_string_body_response(response,
+                                        responseStatus,
+                                        HttpStatusStr(responseStatus));
+    }
 
     return U_CALLBACK_CONTINUE;
 }

--- a/nodes/ukamaOS/distro/system/wimcd/src/callback.c
+++ b/nodes/ukamaOS/distro/system/wimcd/src/callback.c
@@ -37,6 +37,12 @@ extern int process_agent_update_request(WTasks **tasks,
 
 extern bool deserialize_agent_request_update(Update **update, json_t *json);
 
+typedef struct {
+
+    char *items[WIMC_MAX_HUBS];
+    int count;
+} HubList;
+
 static bool is_absolute_url(const char *url) {
 
     if (url == NULL) {
@@ -47,37 +53,119 @@ static bool is_absolute_url(const char *url) {
            strncmp(url, "https://", 8) == 0;
 }
 
-static char *parse_hub_override(const URequest *request) {
+static void free_hub_list(HubList *list) {
+
+    int i;
+
+    if (list == NULL) {
+        return;
+    }
+
+    for (i = 0; i < list->count; i++) {
+        free(list->items[i]);
+        list->items[i] = NULL;
+    }
+
+    list->count = 0;
+}
+
+static bool hub_list_add(HubList *list, const char *hub) {
+
+    if (list == NULL || hub == NULL || *hub == '\0') {
+        return false;
+    }
+
+    if (list->count >= WIMC_MAX_HUBS) {
+        return false;
+    }
+
+    if (!is_absolute_url(hub)) {
+        return false;
+    }
+
+    list->items[list->count] = strdup(hub);
+    if (list->items[list->count] == NULL) {
+        return false;
+    }
+
+    list->count++;
+
+    return true;
+}
+
+static bool parse_hub_overrides(const URequest *request, HubList *list) {
 
     json_t *json;
     json_error_t jerr;
     json_t *jhub;
+    json_t *item;
     const char *hub;
-    char *ret;
+    size_t i;
+    bool ret;
 
     json = NULL;
     jhub = NULL;
     hub = NULL;
-    ret = NULL;
+    ret = true;
+
+    if (list == NULL) {
+        return false;
+    }
+
+    memset(list, 0, sizeof(HubList));
 
     if (!request || !request->binary_body || request->binary_body_length == 0) {
-        return NULL;
+        return true;
     }
+
+    memset(&jerr, 0, sizeof(jerr));
 
     json = ulfius_get_json_body_request(request, &jerr);
     if (!json) {
-        return NULL;
+        return true;
     }
 
     jhub = json_object_get(json, "hub");
-    hub = json_is_string(jhub) ? json_string_value(jhub) : NULL;
+    if (jhub == NULL) {
+        json_decref(json);
+        return true;
+    }
 
-    if (hub && *hub && is_absolute_url(hub)) {
-        ret = strdup(hub);
+    if (json_is_string(jhub)) {
+        hub = json_string_value(jhub);
+        if (hub && *hub && !hub_list_add(list, hub)) {
+            ret = false;
+        }
+
+        json_decref(json);
+        return ret;
+    }
+
+    if (json_is_array(jhub)) {
+        if (json_array_size(jhub) > WIMC_MAX_HUBS) {
+            json_decref(json);
+            return false;
+        }
+
+        json_array_foreach(jhub, i, item) {
+            hub = json_is_string(item) ? json_string_value(item) : NULL;
+            if (hub == NULL || *hub == '\0') {
+                ret = false;
+                break;
+            }
+
+            if (!hub_list_add(list, hub)) {
+                ret = false;
+                break;
+            }
+        }
+
+        json_decref(json);
+        return ret;
     }
 
     json_decref(json);
-    return ret;
+    return false;
 }
 
 static void free_agent_request_update(AgentReq *req) {
@@ -93,14 +181,33 @@ static void free_agent_request_update(AgentReq *req) {
 static void create_hub_url_for_agent(char *hubURL, char *srcURL,
                                      char *destURL) {
 
+    size_t hubLen;
+    bool hubSlash;
+    bool srcSlash;
+
     if (hubURL == NULL || srcURL == NULL || destURL == NULL) {
         return;
     }
 
-    if (!is_absolute_url(srcURL)) {
-        snprintf(destURL, WIMC_MAX_URL_LEN, "%s%s", hubURL, srcURL);
-    } else {
+    if (is_absolute_url(srcURL)) {
         snprintf(destURL, WIMC_MAX_URL_LEN, "%s", srcURL);
+        return;
+    }
+
+    hubLen = strlen(hubURL);
+    if (hubLen == 0 || srcURL[0] == '\0') {
+        return;
+    }
+
+    hubSlash = hubURL[hubLen - 1] == '/';
+    srcSlash = srcURL[0] == '/';
+
+    if (hubSlash && srcSlash) {
+        snprintf(destURL, WIMC_MAX_URL_LEN, "%s%s", hubURL, srcURL + 1);
+    } else if (!hubSlash && !srcSlash) {
+        snprintf(destURL, WIMC_MAX_URL_LEN, "%s/%s", hubURL, srcURL);
+    } else {
+        snprintf(destURL, WIMC_MAX_URL_LEN, "%s%s", hubURL, srcURL);
     }
 }
 
@@ -352,6 +459,98 @@ int web_service_cb_get_app_status(const URequest *request,
     return U_CALLBACK_CONTINUE;
 }
 
+static bool get_artifacts_info_from_any_hub(Artifact *artifact,
+                                            Config *config,
+                                            HubList *hubList,
+                                            const char *defaultHubURL,
+                                            char *name,
+                                            char *tag,
+                                            char *selectedHub,
+                                            size_t selectedHubSize,
+                                            int *status) {
+
+    int i;
+    int httpStatus;
+    const char *hubURL;
+
+    if (artifact == NULL || config == NULL || name == NULL || tag == NULL ||
+        selectedHub == NULL || selectedHubSize == 0) {
+        if (status != NULL) {
+            *status = HttpStatus_InternalServerError;
+        }
+        return false;
+    }
+
+    selectedHub[0] = '\0';
+
+    if (status != NULL) {
+        *status = HttpStatus_InternalServerError;
+    }
+
+    if (hubList != NULL && hubList->count > 0) {
+        for (i = 0; i < hubList->count; i++) {
+            hubURL = hubList->items[i];
+
+            if (hubURL == NULL || *hubURL == '\0') {
+                continue;
+            }
+
+            httpStatus = 0;
+
+            usys_log_debug("Trying hub %s for %s:%s", hubURL, name, tag);
+
+            if (get_artifacts_info_from_hub(artifact, config, hubURL,
+                                            name, tag, &httpStatus)) {
+                snprintf(selectedHub, selectedHubSize, "%s", hubURL);
+
+                if (status != NULL) {
+                    *status = HttpStatus_OK;
+                }
+
+                usys_log_debug("Selected hub %s for %s:%s",
+                               selectedHub, name, tag);
+
+                return true;
+            }
+
+            usys_log_error("Hub failed %s for %s:%s http=%d",
+                           hubURL, name, tag, httpStatus);
+
+            if (status != NULL && httpStatus != 0) {
+                *status = httpStatus;
+            }
+        }
+
+        return false;
+    }
+
+    if (defaultHubURL == NULL || *defaultHubURL == '\0') {
+        if (status != NULL) {
+            *status = HttpStatus_BadRequest;
+        }
+        return false;
+    }
+
+    httpStatus = 0;
+
+    if (get_artifacts_info_from_hub(artifact, config, defaultHubURL,
+                                    name, tag, &httpStatus)) {
+        snprintf(selectedHub, selectedHubSize, "%s", defaultHubURL);
+
+        if (status != NULL) {
+            *status = HttpStatus_OK;
+        }
+
+        return true;
+    }
+
+    if (status != NULL) {
+        *status = httpStatus;
+    }
+
+    return false;
+}
+
 int web_service_cb_post_app(const URequest *request,
                             UResponse *response,
                             void *data) {
@@ -365,16 +564,21 @@ int web_service_cb_post_app(const URequest *request,
     char *path = NULL;
     char *actualVersion = NULL;
     char *error = NULL;
-    char *hubOverride = NULL;
+    HubList hubList;
+    char selectedHub[WIMC_MAX_URL_LEN];
     const char *hubURL;
+
     Artifact artifact;
     Config *config;
     WimcReq *wimcRequest = NULL;
     ArtifactFormat *artifactFormat = NULL;
     json_t *jResponse;
 
-    memset(&artifact, 0, sizeof(artifact));
+    memset(&artifact,   0, sizeof(artifact));
+    memset(&hubList,    0, sizeof(hubList));
+    memset(selectedHub, 0, sizeof(selectedHub));
     config = (Config *)data;
+    
     name = (char *)u_map_get(request->map_url, "name");
     tag  = (char *)u_map_get(request->map_url, "tag");
 
@@ -424,11 +628,23 @@ int web_service_cb_post_app(const URequest *request,
     free(actualVersion);
     free(error);
 
-    hubOverride = parse_hub_override(request);
-    hubURL = (hubOverride && *hubOverride) ? hubOverride : config->hubURL;
+    if (!parse_hub_overrides(request, &hubList)) {
+        pthread_mutex_lock(&config->dbMutex);
+        db_update_package_status(config->db, name, tag, NULL,
+                                 WIMC_STATUS_FAILED, NULL,
+                                 "invalid hub list");
+        pthread_mutex_unlock(&config->dbMutex);
 
-    if (!get_artifacts_info_from_hub(&artifact, config, hubURL,
-                                     name, tag, &httpStatus)) {
+        ulfius_set_string_body_response(response,
+                                        HttpStatus_BadRequest,
+                                        HttpStatusStr(HttpStatus_BadRequest));
+        return U_CALLBACK_CONTINUE;
+    }
+
+    if (!get_artifacts_info_from_any_hub(&artifact, config, &hubList,
+                                         config->hubURL, name, tag,
+                                         selectedHub, sizeof(selectedHub),
+                                         &httpStatus)) {
         pthread_mutex_lock(&config->dbMutex);
         db_update_package_status(config->db, name, tag, NULL,
                                  WIMC_STATUS_FAILED, NULL,
@@ -439,10 +655,11 @@ int web_service_cb_post_app(const URequest *request,
                                         httpStatus ? httpStatus :
                                         HttpStatus_InternalServerError,
                                         HttpStatusStr(httpStatus ? httpStatus :
-                                        HttpStatus_InternalServerError));
-        free(hubOverride);
+                                                      HttpStatus_InternalServerError));
+        free_hub_list(&hubList);
         return U_CALLBACK_CONTINUE;
     }
+    hubURL = selectedHub;
 
     artifactFormat = select_artifact_format(&artifact);
     if (artifactFormat == NULL) {
@@ -453,7 +670,7 @@ int web_service_cb_post_app(const URequest *request,
         pthread_mutex_unlock(&config->dbMutex);
 
         free_artifact(&artifact);
-        free(hubOverride);
+        free_hub_list(&hubList);
         ulfius_set_string_body_response(response,
                                         HttpStatus_ServiceUnavailable,
                                         HttpStatusStr(
@@ -477,7 +694,7 @@ int web_service_cb_post_app(const URequest *request,
         pthread_mutex_unlock(&config->dbMutex);
 
         free_artifact(&artifact);
-        free(hubOverride);
+        free_hub_list(&hubList);
         ulfius_set_string_body_response(response,
                                         HttpStatus_ServiceUnavailable,
                                         HttpStatusStr(
@@ -489,7 +706,7 @@ int web_service_cb_post_app(const URequest *request,
                         artifactFormat->type, DEFAULT_INTERVAL);
     if (wimcRequest == NULL) {
         free_artifact(&artifact);
-        free(hubOverride);
+        free_hub_list(&hubList);
         ulfius_set_string_body_response(response,
                                         HttpStatus_InternalServerError,
                                         HttpStatusStr(
@@ -507,7 +724,7 @@ int web_service_cb_post_app(const URequest *request,
 
             cleanup_wimc_request(wimcRequest);
             free_artifact(&artifact);
-            free(hubOverride);
+            free_hub_list(&hubList);
             ulfius_set_string_body_response(response,
                                             HttpStatus_BadRequest,
                                             HttpStatusStr(
@@ -542,7 +759,7 @@ int web_service_cb_post_app(const URequest *request,
 
     cleanup_wimc_request(wimcRequest);
     free_artifact(&artifact);
-    free(hubOverride);
+    free_hub_list(&hubList);
 
     return U_CALLBACK_CONTINUE;
 }

--- a/nodes/ukamaOS/distro/system/wimcd/src/callback.c
+++ b/nodes/ukamaOS/distro/system/wimcd/src/callback.c
@@ -71,6 +71,8 @@ static void free_hub_list(HubList *list) {
 
 static bool hub_list_add(HubList *list, const char *hub) {
 
+    char normalized[WIMC_MAX_URL_LEN];
+
     if (list == NULL || hub == NULL || *hub == '\0') {
         return false;
     }
@@ -79,11 +81,19 @@ static bool hub_list_add(HubList *list, const char *hub) {
         return false;
     }
 
-    if (!is_absolute_url(hub)) {
+    memset(normalized, 0, sizeof(normalized));
+
+    if (is_absolute_url(hub)) {
+        snprintf(normalized, sizeof(normalized), "%s", hub);
+    } else {
+        snprintf(normalized, sizeof(normalized), "http://%s", hub);
+    }
+
+    if (!is_absolute_url(normalized)) {
         return false;
     }
 
-    list->items[list->count] = strdup(hub);
+    list->items[list->count] = strdup(normalized);
     if (list->items[list->count] == NULL) {
         return false;
     }

--- a/systems/node/software/pkg/server/software.go
+++ b/systems/node/software/pkg/server/software.go
@@ -122,11 +122,11 @@ func (s *SoftwareServer) UpdateSoftware(ctx context.Context, req *pb.UpdateSoftw
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get software: %v", err)
 	}
+
 	if len(list) == 0 {
 		return nil, status.Errorf(codes.NotFound, "software not found or already up to date")
 	}
 
-	// Unique index on (node_id, app_name) implies at most one record for this request
 	sw := list[0]
 
 	if validation.IsVersionMismatch(sw.DesiredVersion, req.Tag) {
@@ -139,37 +139,44 @@ func (s *SoftwareServer) UpdateSoftware(ctx context.Context, req *pb.UpdateSoftw
 		return &pb.UpdateSoftwareResponse{Message: "Software is already up to date"}, nil
 	}
 
-	target := fmt.Sprintf("%s...%s", s.orgName, nId.String())
-	path := fmt.Sprintf("/starter/v1/update/%s/%s", req.Name, req.Tag)
-	log.Infof("Publishing update for software %s to version %s on node %s", req.Name, req.Tag, nId.String())
-
 	nodeGwIP, err := s.getNodeGwIP()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get node gw ip: %v", err)
 	}
-	log.Infof("Node gw ip: %s", nodeGwIP)
-	jsonBody := map[string]string{"host": fmt.Sprintf("http://%s:8080", nodeGwIP)}
+
+	target := fmt.Sprintf("%s...%s", s.orgName, nId.String())
+	path := "/starter/v1/update"
+
+	log.Infof("Publishing update for software %s to version %s on node %s using hub %s",
+		req.Name, req.Tag, nId.String(), nodeGwIP)
+
+	jsonBody := map[string]string{
+		"name": req.Name,
+		"tag":  req.Tag,
+		"hub":  fmt.Sprintf("http://%s:8080", nodeGwIP),
+	}
+
 	data, err := json.Marshal(jsonBody)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get software: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to marshal update request: %v", err)
 	}
-	if len(list) == 0 {
-		return nil, status.Errorf(codes.NotFound, "software not found or already up to date")
-	}
-	
+
 	if err := s.publishMessage(target, "POST", path, nId.String(), data); err != nil {
 		log.Errorf("Failed to publish update message: %v", err)
 		return nil, status.Errorf(codes.Internal, "failed to publish update message: %v", err)
 	}
+
 	sw.CurrentVersion = req.Tag
 	sw.ChangeLogs = append(sw.ChangeLogs, "Software updated to version "+req.Tag)
 	sw.Status = ukama.SoftwareStatusType(ukama.UpToDate)
+
 	if err := s.sRepo.Update(sw); err != nil {
 		log.Errorf("Failed to persist software update: %v", err)
 		return nil, status.Errorf(codes.Internal, "failed to update software: %v", err)
 	}
 
 	log.Infof("Software %s updated to %s for node %s", req.Name, req.Tag, nId.String())
+
 	return &pb.UpdateSoftwareResponse{Message: "Software updated successfully"}, nil
 }
 

--- a/systems/node/software/pkg/server/software_test.go
+++ b/systems/node/software/pkg/server/software_test.go
@@ -10,6 +10,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	mbmocks "github.com/ukama/ukama/systems/common/mocks"
+	epb "github.com/ukama/ukama/systems/common/pb/gen/events"
 	"github.com/ukama/ukama/systems/common/ukama"
 	uuid "github.com/ukama/ukama/systems/common/uuid"
 	"github.com/ukama/ukama/systems/node/software/mocks"
@@ -40,6 +42,11 @@ const (
 	testTagVersion       = "1.2.0"
 	testCurrentVersion   = "1.0.0"
 	testDesiredVersion   = "1.2.0"
+	testNodeGwIP         = "192.168.0.1"
+	testHubURL           = "http://192.168.0.1:8080"
+	testStarterPath      = "/starter/v1/update"
+	testSoftwareRoute    = "request.cloud.local.test-org.node.software.nodefeeder.publish"
+	testTarget           = "test-org...uk-sa2156-hnode-a1-xxxx"
 )
 
 const errMsgDB = "db error"
@@ -57,7 +64,7 @@ var (
 // ========== Helpers to build server with mocks ==========
 
 func newTestServer(sRepo *mocks.SoftwareRepo, appRepo *mocks.AppRepo, nodeRepo *mocks.NodeRepo, msgBus *mbmocks.MsgBusServiceClient) *SoftwareServer {
-	return NewSoftwareServer(testOrgName, sRepo, appRepo, nodeRepo, nil, msgBus, false, []string{"192.168.0.1"})
+	return NewSoftwareServer(testOrgName, sRepo, appRepo, nodeRepo, nil, msgBus, false, []string{testNodeGwIP})
 }
 
 func dbAppFixture() db.App {
@@ -73,6 +80,7 @@ func dbAppFixture() db.App {
 func dbSoftwareFixture() *db.Software {
 	releaseDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	now := time.Now()
+
 	return &db.Software{
 		Id:             uuid.NewV4(),
 		NodeId:         testNodeId,
@@ -86,6 +94,70 @@ func dbSoftwareFixture() *db.Software {
 		UpdatedAt:      now,
 		Status:         ukama.UpdateAvailable,
 	}
+}
+
+func matchSoftwareRoute() interface{} {
+	return mock.MatchedBy(func(route string) bool {
+		return route == testSoftwareRoute
+	})
+}
+
+func matchStarterUpdateMessage(t *testing.T) interface{} {
+	return mock.MatchedBy(func(msg interface{}) bool {
+		m, ok := msg.(*epb.NodeFeederMessage)
+		if !ok {
+			t.Logf("unexpected msgbus message type: %T", msg)
+			return false
+		}
+
+		if m.Target != testTarget {
+			t.Logf("unexpected target: got=%s want=%s", m.Target, testTarget)
+			return false
+		}
+
+		if m.HttpMethod != "POST" {
+			t.Logf("unexpected method: got=%s want=POST", m.HttpMethod)
+			return false
+		}
+
+		if m.Path != testStarterPath {
+			t.Logf("unexpected path: got=%s want=%s", m.Path, testStarterPath)
+			return false
+		}
+
+		if m.NodeId != testNodeIdNormalized {
+			t.Logf("unexpected node id: got=%s want=%s", m.NodeId, testNodeIdNormalized)
+			return false
+		}
+
+		var body map[string]string
+		if err := json.Unmarshal(m.Msg, &body); err != nil {
+			t.Logf("failed to decode message body: %v", err)
+			return false
+		}
+
+		if body["name"] != testAppNameForUpdate {
+			t.Logf("unexpected body.name: got=%s want=%s", body["name"], testAppNameForUpdate)
+			return false
+		}
+
+		if body["tag"] != testTagVersion {
+			t.Logf("unexpected body.tag: got=%s want=%s", body["tag"], testTagVersion)
+			return false
+		}
+
+		if body["hub"] != testHubURL {
+			t.Logf("unexpected body.hub: got=%s want=%s", body["hub"], testHubURL)
+			return false
+		}
+
+		if _, ok := body["host"]; ok {
+			t.Logf("body must not contain deprecated host field")
+			return false
+		}
+
+		return true
+	})
 }
 
 // ========== CreateApp ==========
@@ -118,9 +190,11 @@ func TestCreateApp(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, resp)
+
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.Internal, st.Code())
+
 		appRepo.AssertExpectations(t)
 	})
 }
@@ -145,6 +219,7 @@ func TestGetAppList(t *testing.T) {
 		assert.Equal(t, testAppSpace, resp.Apps[0].Space)
 		assert.Equal(t, testAppNotes, resp.Apps[0].Notes)
 		assert.Equal(t, testMetricsKeys, resp.Apps[0].MetricsKeys)
+
 		appRepo.AssertExpectations(t)
 	})
 
@@ -158,6 +233,7 @@ func TestGetAppList(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		assert.Empty(t, resp.Apps)
+
 		appRepo.AssertExpectations(t)
 	})
 
@@ -170,9 +246,11 @@ func TestGetAppList(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, resp)
+
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.Internal, st.Code())
+
 		appRepo.AssertExpectations(t)
 	})
 }
@@ -199,6 +277,7 @@ func TestGetSoftwareList(t *testing.T) {
 		assert.Equal(t, testAppNameForUpdate, resp.Software[0].Name)
 		assert.Equal(t, testCurrentVersion, resp.Software[0].CurrentVersion)
 		assert.Equal(t, testDesiredVersion, resp.Software[0].DesiredVersion)
+
 		sRepo.AssertExpectations(t)
 	})
 
@@ -209,6 +288,7 @@ func TestGetSoftwareList(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, resp)
+
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, st.Code())
@@ -224,9 +304,11 @@ func TestGetSoftwareList(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, resp)
+
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.Internal, st.Code())
+
 		sRepo.AssertExpectations(t)
 	})
 }
@@ -241,11 +323,16 @@ func TestUpdateSoftware(t *testing.T) {
 		sRepo := mocks.NewSoftwareRepo(t)
 		sRepo.On("List", testNodeIdNormalized, ukama.UpdateAvailable, testAppNameForUpdate).Return([]*db.Software{sw}, nil)
 		sRepo.On("Update", mock.MatchedBy(func(s *db.Software) bool {
-			return s.CurrentVersion == testTagVersion && s.Status == ukama.UpToDate &&
+			return s.CurrentVersion == testTagVersion &&
+				s.Status == ukama.UpToDate &&
 				len(s.ChangeLogs) > 0
 		})).Return(nil)
+
 		msgBus := mbmocks.NewMsgBusServiceClient(t)
-		msgBus.On("PublishRequest", mock.Anything, mock.Anything).Return(nil)
+		msgBus.On("PublishRequest",
+			matchSoftwareRoute(),
+			matchStarterUpdateMessage(t),
+		).Return(nil)
 
 		s := newTestServer(sRepo, mocks.NewAppRepo(t), mocks.NewNodeRepo(t), msgBus)
 		req := &pb.UpdateSoftwareRequest{NodeId: testNodeId, Name: testAppNameForUpdate, Tag: testTagVersion}
@@ -254,6 +341,7 @@ func TestUpdateSoftware(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		assert.Equal(t, successUpdateMsg, resp.Message)
+
 		sRepo.AssertExpectations(t)
 		msgBus.AssertExpectations(t)
 	})
@@ -265,6 +353,7 @@ func TestUpdateSoftware(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, resp)
+
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, st.Code())
@@ -282,6 +371,7 @@ func TestUpdateSoftware(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		assert.Equal(t, invalidVersionMsg, resp.Message)
+
 		sRepo.AssertExpectations(t)
 	})
 
@@ -295,15 +385,18 @@ func TestUpdateSoftware(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, resp)
+
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.NotFound, st.Code())
+
 		sRepo.AssertExpectations(t)
 	})
 
 	t.Run("version_mismatch", func(t *testing.T) {
 		sw := dbSoftwareFixture()
 		sw.DesiredVersion = "2.0.0"
+
 		sRepo := mocks.NewSoftwareRepo(t)
 		sRepo.On("List", testNodeIdNormalized, ukama.UpdateAvailable, testAppNameForUpdate).Return([]*db.Software{sw}, nil)
 
@@ -314,12 +407,14 @@ func TestUpdateSoftware(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		assert.Equal(t, invalidVersionMsg, resp.Message)
+
 		sRepo.AssertExpectations(t)
 	})
 
 	t.Run("already_up_to_date", func(t *testing.T) {
 		sw := dbSoftwareFixture()
 		sw.CurrentVersion = testTagVersion
+
 		sRepo := mocks.NewSoftwareRepo(t)
 		sRepo.On("List", testNodeIdNormalized, ukama.UpdateAvailable, testAppNameForUpdate).Return([]*db.Software{sw}, nil)
 
@@ -330,6 +425,7 @@ func TestUpdateSoftware(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		assert.Equal(t, alreadyUpToDateMsg, resp.Message)
+
 		sRepo.AssertExpectations(t)
 	})
 
@@ -337,8 +433,12 @@ func TestUpdateSoftware(t *testing.T) {
 		sw := dbSoftwareFixture()
 		sRepo := mocks.NewSoftwareRepo(t)
 		sRepo.On("List", testNodeIdNormalized, ukama.UpdateAvailable, testAppNameForUpdate).Return([]*db.Software{sw}, nil)
+
 		msgBus := mbmocks.NewMsgBusServiceClient(t)
-		msgBus.On("PublishRequest", mock.Anything, mock.Anything).Return(errors.New("publish failed"))
+		msgBus.On("PublishRequest",
+			matchSoftwareRoute(),
+			matchStarterUpdateMessage(t),
+		).Return(errors.New("publish failed"))
 
 		s := newTestServer(sRepo, mocks.NewAppRepo(t), mocks.NewNodeRepo(t), msgBus)
 		req := &pb.UpdateSoftwareRequest{NodeId: testNodeId, Name: testAppNameForUpdate, Tag: testTagVersion}
@@ -346,9 +446,11 @@ func TestUpdateSoftware(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, resp)
+
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.Internal, st.Code())
+
 		sRepo.AssertExpectations(t)
 		msgBus.AssertExpectations(t)
 	})
@@ -358,8 +460,12 @@ func TestUpdateSoftware(t *testing.T) {
 		sRepo := mocks.NewSoftwareRepo(t)
 		sRepo.On("List", testNodeIdNormalized, ukama.UpdateAvailable, testAppNameForUpdate).Return([]*db.Software{sw}, nil)
 		sRepo.On("Update", mock.Anything).Return(errors.New("db update failed"))
+
 		msgBus := mbmocks.NewMsgBusServiceClient(t)
-		msgBus.On("PublishRequest", mock.Anything, mock.Anything).Return(nil)
+		msgBus.On("PublishRequest",
+			matchSoftwareRoute(),
+			matchStarterUpdateMessage(t),
+		).Return(nil)
 
 		s := newTestServer(sRepo, mocks.NewAppRepo(t), mocks.NewNodeRepo(t), msgBus)
 		req := &pb.UpdateSoftwareRequest{NodeId: testNodeId, Name: testAppNameForUpdate, Tag: testTagVersion}
@@ -367,9 +473,11 @@ func TestUpdateSoftware(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, resp)
+
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.Internal, st.Code())
+
 		sRepo.AssertExpectations(t)
 		msgBus.AssertExpectations(t)
 	})


### PR DESCRIPTION
Fix #1320 + fix contract between backend and starter.d

"space" is optional; if available only that space:app is updated otherwise all.

```
{
  "name": "myapp",
  "tag": "1.2.0",
  "hub": "http://192.168.0.1:8080"
}
```

```
curl -i -X POST http://localhost:18001/v1/update -H "Content-Type: application/json" -d '{
    "name": "example",
    "tag": "1.0.1-abcdefgh",
    "hub": ["http://3.12.59.80:8080", "http://3.139.132.96:8080"]
  }'

```