### PR TITLE
PCRF working on tower node (#1341)

### DIFF
--- a/nodes/apps/epcemu/inc/http_client.h
+++ b/nodes/apps/epcemu/inc/http_client.h
@@ -21,4 +21,11 @@ int http_send_json(const char *method,
                    JsonObj **outJson,
                    long *httpCode);
 
+int http_send_json_timeout(const char *method,
+                           const char *url,
+                           JsonObj *body,
+                           JsonObj **outJson,
+                           long *httpCode,
+                           int timeoutSec);
+
 #endif /* HTTP_CLIENT_H_ */

--- a/nodes/apps/epcemu/src/http_client.c
+++ b/nodes/apps/epcemu/src/http_client.c
@@ -64,8 +64,12 @@ static int parse_json_body(ResponseBuf *buf, JsonObj **outJson) {
     return USYS_TRUE;
 }
 
-int http_send_json(const char *method, const char *url, JsonObj *body,
-                   JsonObj **outJson, long *httpCode) {
+int http_send_json_timeout(const char *method,
+                           const char *url,
+                           JsonObj *body,
+                           JsonObj **outJson,
+                           long *httpCode,
+                           int timeoutSec) {
 
     CURL *curl;
     CURLcode res;
@@ -75,6 +79,10 @@ int http_send_json(const char *method, const char *url, JsonObj *body,
     int ret;
 
     if (method == NULL || url == NULL) return USYS_FALSE;
+
+    if (timeoutSec <= 0) {
+        timeoutSec = HTTP_TIMEOUT_SEC;
+    }
 
     response.data = NULL;
     response.size = 0;
@@ -97,7 +105,7 @@ int http_send_json(const char *method, const char *url, JsonObj *body,
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, HTTP_TIMEOUT_SEC);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeoutSec);
 
     if (!strcmp(method, "POST")) {
         curl_easy_setopt(curl, CURLOPT_POST, 1L);
@@ -107,7 +115,8 @@ int http_send_json(const char *method, const char *url, JsonObj *body,
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload ? payload : "{}");
     } else if (strcmp(method, "GET")) {
         curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method);
-        if (payload != NULL) curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload);
+        if (payload != NULL) curl_easy_setopt(curl, CURLOPT_POSTFIELDS,
+                         payload);
     }
 
     res = curl_easy_perform(curl);
@@ -132,6 +141,20 @@ done:
     curl_easy_cleanup(curl);
 
     return ret;
+}
+
+int http_send_json(const char *method,
+                   const char *url,
+                   JsonObj *body,
+                   JsonObj **outJson,
+                   long *httpCode) {
+
+    return http_send_json_timeout(method,
+                                  url,
+                                  body,
+                                  outJson,
+                                  httpCode,
+                                  HTTP_TIMEOUT_SEC);
 }
 
 int http_get_json(const char *url, JsonObj **outJson, long *httpCode) {

--- a/nodes/apps/epcemu/src/init_network.c
+++ b/nodes/apps/epcemu/src/init_network.c
@@ -13,6 +13,8 @@
 #include "http_client.h"
 #include "init_network.h"
 
+#define INIT_NETWORK_RECONCILE_TIMEOUT_SEC 30
+
 static int json_bool_path(JsonObj *root,
                           const char *parent,
                           const char *key,
@@ -87,6 +89,10 @@ int init_network_probe(EpcemuConfig *config, EpcemuStatus *status) {
         return USYS_FALSE;
     }
 
+    /*
+     * In this manifest, init-network runs in boot before EPCEMU.
+     * Therefore this should already be ready by the time EPCEMU starts.
+     */
     ready = json_object_get(root, "ready");
     if (!json_is_true(ready)) {
         json_decref(root);
@@ -148,7 +154,12 @@ int init_network_reconcile(EpcemuConfig *config, EpcemuStatus *status) {
 
     snprintf(url, sizeof(url), "%s/v1/reconcile", config->initNetworkUrl);
 
-    if (!http_send_json("POST", url, NULL, &root, &code)) {
+    if (!http_send_json_timeout("POST",
+                                url,
+                                NULL,
+                                &root,
+                                &code,
+                                INIT_NETWORK_RECONCILE_TIMEOUT_SEC)) {
         status_fail(status, "failed to call init-network reconcile");
         return USYS_FALSE;
     }

--- a/nodes/apps/init-network/inc/config.h
+++ b/nodes/apps/init-network/inc/config.h
@@ -27,8 +27,8 @@
 
 #define DEF_OVS_BRIDGE                  "br0"
 #define DEF_OVS_OF_VERSION              "OpenFlow15"
-#define DEF_OVS_MGMT_DIR                "/usr/local/var/run/openvswitch"
 #define DEF_OVS_RUN_DIR                 "/var/run/openvswitch"
+#define DEF_OVS_MGMT_DIR                DEF_OVS_RUN_DIR
 #define DEF_OVS_DB_DIR                  "/etc/openvswitch"
 #define DEF_OVS_SCHEMA                  "/usr/share/openvswitch/vswitch.ovsschema"
 
@@ -48,31 +48,27 @@
 #define DEF_EPC_SCTP_ADDR               "10.102.81.3"
 #define DEF_EPC_GTPU_ADDR               "10.102.81.75"
 
-#define DEF_EXT_IF                      "eth0"
-#define DEF_FORWARD_ENABLE              true
-#define DEF_NAT_ENABLE                  true
-#define DEF_POLICY_ROUTING_ENABLE       true
-#define DEF_TUN_TABLE                   2000
-#define DEF_BRIDGE_TABLE                1000
+#define DEF_EXTERNAL_IF                 "eth0"
 
 #define DEF_GATEWAY_ENABLE              true
 #define DEF_GATEWAY_MODE                "root"
 #define DEF_GATEWAY_NAME                "ukama-gw"
 #define DEF_GATEWAY_BRIDGE_IF           "gw-br"
-#define DEF_GATEWAY_NS_IF               "gw0"
+#define DEF_GATEWAY_NAMESPACE_IF        "gw0"
 #define DEF_GATEWAY_ADDR                "10.10.10.11/24"
 #define DEF_GATEWAY_IP                  "10.10.10.11"
 
-#define EP_BS                           "/"
-#define REST_API_VERSION                "v1"
-#define URL_PREFIX                      EP_BS REST_API_VERSION
-#define API_RES_EP(RES)                 EP_BS RES
+#define DEF_TUN_TABLE                   2000
+#define DEF_BRIDGE_TABLE                1000
+#define DEF_DEFAULT_DROP                true
 
 typedef struct {
 
-    char *serviceName;
-    int  servicePort;
-    int  cmdTimeoutSec;
+    char *configFile;
+    char *logLevel;
+
+    int servicePort;
+    int cmdTimeoutSec;
 
     char *bridge;
     char *openflow;
@@ -87,25 +83,19 @@ typedef struct {
     char *bridgeSubnet;
 
     char *ueCidr;
-    bool defaultDrop;
 
     bool tunEnable;
     char *tunIf;
     char *tunPrimaryCidr;
     char *tunExtraCidrs[INIT_NETWORK_MAX_EXTRA_IPS];
-    int  tunExtraCount;
+    int tunExtraCount;
 
     bool epcEnable;
-    char *epcIf;
+    char *epcSctpIf;
     char *epcSctpAddr;
     char *epcGtpuAddr;
 
     char *externalIf;
-    bool enableIpForward;
-    bool enableNat;
-    bool enablePolicyRouting;
-    int  tunTable;
-    int  bridgeTable;
 
     bool gatewayEnable;
     char *gatewayMode;
@@ -115,10 +105,15 @@ typedef struct {
     char *gatewayAddr;
     char *gatewayIp;
 
+    int tunTable;
+    int bridgeTable;
+
+    bool defaultDrop;
+
 } Config;
 
-void config_set_defaults(Config *config);
-bool config_load_from_file(Config *config, const char *path);
+Config *config_init(void);
 void config_free(Config *config);
+bool config_load(Config *config, const char *path);
 
 #endif /* CONFIG_H_ */

--- a/nodes/apps/pcrf/pkg/client/noded.go
+++ b/nodes/apps/pcrf/pkg/client/noded.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const NodeEndpoint = "/noded/v1/nodeinfo"
+const NodeEndpoint = "/v1/nodeinfo"
 
 type Version struct {
 	Major int `json:"major"`

--- a/nodes/apps/pcrf/pkg/client/noded.go
+++ b/nodes/apps/pcrf/pkg/client/noded.go
@@ -9,101 +9,106 @@
 package client
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/url"
+    "encoding/json"
+    "fmt"
+    "net/url"
+    "strings"
 
-	"github.com/ukama/ukama/nodes/apps/pcrf/pkg/api"
-	"github.com/ukama/ukama/systems/common/rest"
-
-	log "github.com/sirupsen/logrus"
+    log "github.com/sirupsen/logrus"
+    "github.com/ukama/ukama/systems/common/rest"
 )
 
 const NodeEndpoint = "/v1/nodeinfo"
 
 type Version struct {
-	Major int `json:"major"`
-	Minor int `json:"minor"`
+    Major int `json:"major"`
+    Minor int `json:"minor"`
 }
 
 type NodeInfo struct {
-	Id            string  `json:"uuid"`
-	Name          string  `json:"name"`
-	NodeType      int     `json:"type"`
-	PartNumber    string  `json:"partNumber"`
-	Skew          string  `json:"skew"`
-	Mac           string  `json:"mac"`
-	ProdSwVersion Version `json:"prodSwVersion"`
-	SwVersion     Version `json:"swVersion"`
-	AssemblyDate  string  `json:"assemblyDate"`
-	OemName       string  `json:"oemName"`
-	ModuleCount   int     `json:"moduleCount"`
+    Id            string  `json:"UUID"`
+    Name          string  `json:"name"`
+    NodeType      int     `json:"type"`
+    PartNumber    string  `json:"partNumber"`
+    Skew          string  `json:"skew"`
+    Mac           string  `json:"mac"`
+    ProdSwVersion Version `json:"prodSwVersion"`
+    SwVersion     Version `json:"swVersion"`
+    AssemblyDate  string  `json:"assemblyDate"`
+    OemName       string  `json:"oemName"`
+    ModuleCount   int     `json:"moduleCount"`
 }
 
 type Node struct {
-	NodeInfo NodeInfo `json:"nodeInfo"`
-}
-
-type NodedProvider interface {
-	GetNodeInfo() (*api.Spr, error)
+    NodeInfo NodeInfo `json:"nodeInfo"`
 }
 
 type nodedClient struct {
-	u     *url.URL
-	R     *rest.RestClient
-	debug bool
+    u     *url.URL
+    R     *rest.RestClient
+    debug bool
 }
 
 func NewNodedClient(h string, debug bool) (*nodedClient, error) {
-	u, err := url.Parse(h)
+    u, err := url.Parse(strings.TrimRight(h, "/"))
+    if err != nil {
+        log.Errorf("Can't parse %s url. Error: %s", h, err.Error())
+        return nil, err
+    }
 
-	if err != nil {
-		log.Errorf("Can't parse  %s url. Error: %s", h, err.Error())
-		return nil, err
-	}
-
-	return &nodedClient{
-		u:     u,
-		R:     rest.NewRestyClient(u, debug),
-		debug: debug,
-	}, nil
+    return &nodedClient{
+        u:     u,
+        R:     rest.NewRestyClient(u, debug),
+        debug: debug,
+    }, nil
 }
 
 func (r *nodedClient) GetNodeId() (string, error) {
-	ni, err := r.GetNodeInfo()
-	if err != nil {
-		return "", err
-	}
+    ni, err := r.GetNodeInfo()
+    if err != nil {
+        return "", err
+    }
 
-	return ni.Id, nil
+    if ni.Id == "" {
+        return "", fmt.Errorf("node info missing UUID")
+    }
+
+    return ni.Id, nil
 }
+
 func (r *nodedClient) GetNodeInfo() (*NodeInfo, error) {
-	log.Debugf("Geeting NodeInfo from Noded.")
+    var err error
+    var respBody string
+    node := &Node{}
 
-	node := &Node{}
+    log.Debugf("Getting NodeInfo from Noded.")
 
-	url := r.u.String() + NodeEndpoint
+    resp, err := r.R.C.R().Get(r.u.String() + NodeEndpoint)
+    if err != nil {
+        log.Errorf("Get NodeInfo failure. error: %s", err.Error())
+        return nil, fmt.Errorf("get NodeInfo failure: %w", err)
+    }
 
-	resp, err := r.R.C.R().
-		Get(url)
-	if err != nil {
-		log.Errorf("Get NodeInfo failure. error: %s", err.Error())
-		return nil, fmt.Errorf("get NodeInfo failure: %s", err.Error())
-	}
+    if resp.StatusCode() != 200 {
+        respBody = strings.TrimSpace(string(resp.Body()))
+        return nil, fmt.Errorf("node info returned http %d: %s",
+            resp.StatusCode(), respBody)
+    }
 
-	err = json.Unmarshal(resp.Body(), node)
-	if err != nil {
-		log.Errorf("Failed to deserialize node info. Error message is: %s", err.Error())
-		return nil, fmt.Errorf("node info deserailization failure: %w", err)
-	}
+    err = json.Unmarshal(resp.Body(), node)
+    if err != nil {
+        log.Errorf("Failed to deserialize node info. Error message is: %s",
+            err.Error())
+        return nil, fmt.Errorf("node info deserialization failure: %w", err)
+    }
 
-	log.Infof("NodeInfo Info: %+v", node)
+    log.Infof("NodeInfo Info: %+v", node)
 
-	return &node.NodeInfo, nil
+    return &node.NodeInfo, nil
 }
 
 type NodedClientAlias nodedClient
 
 func (r *NodedClientAlias) GetNodeId() (string, error) {
-	return (*nodedClient)(r).GetNodeId()
+    return (*nodedClient)(r).GetNodeId()
 }

--- a/nodes/configs/apps/init-network/config.toml
+++ b/nodes/configs/apps/init-network/config.toml
@@ -8,7 +8,7 @@ cmd_timeout_sec = 10
 [ovs]
 bridge = "br0"
 openflow = "OpenFlow15"
-management_dir = "/usr/local/var/run/openvswitch"
+management_dir = "/var/run/openvswitch"
 run_dir = "/var/run/openvswitch"
 db_dir = "/etc/openvswitch"
 schema = "/usr/share/openvswitch/vswitch.ovsschema"


### PR DESCRIPTION
Fix #1341 

1. corrected EP for node.d
2. fix no-wait on init-network
3. pcrf->node.d contract update
4. correct OVS management path (align with init-network)

``root@1a4e4317848b:/# curl localhost:18028/v1/status | jq
{
  "ready": true,
  "state": "ready",
  "reason": "none",
  "pcrf": {
    "url": "http://localhost:18030",
    "ready": true
  },
  "initNetwork": {
    "url": "http://localhost:18026",
    "ready": true,
    "routed": true,
    "bridge": "br0",
    "bridgeCidr": "10.10.10.1/24",
    "ueCidr": "192.168.8.0/22"
  },
  "ues": {
    "max": 128,
    "used": 0,
    "attached": 0,
    "failed": 0
  },
  "userPlane": {
    "enabled": true,
    "mode": "tun-udp",
    "service": "epcemu-data",
    "udpPort": 18029,
    "tun": "tun3",
    "tunAddress": "192.168.8.1/22",
    "uplinkPackets": 0,
    "uplinkBytes": 0,
    "downlinkPackets": 0,
    "downlinkBytes": 0,
    "droppedPackets": 6,
    "droppedBytes": 288
  }
}
root@1a4e4317848b:/# curl localhost:18030/v1/status | jq
{
  "datapath": {
    "bridge": "br0",
    "managementSocket": "/var/run/openvswitch/br0.mgmt",
    "connected": true,
    "connectedCount": 1,
    "ueCount": 0
  },
  "db": {
    "path": "/ukama/apps/db/pcrf.db"
  },
  "initNetwork": {
    "ready": true,
    "url": "http://localhost:18026"
  },
  "nodeId": "uk-sa2602-tnode-v0-344c",
  "ready": true,
  "reason": "none",
  "sessions": {
    "active": 0
  },
  "state": "ready",
  "ue": {
    "cidr": "192.168.8.0/22"
  }
}
