### PR TITLE
builder/script: fix typo in service name.

### DIFF
--- a/builder/scripts/make-sys-for-mac.sh
+++ b/builder/scripts/make-sys-for-mac.sh
@@ -67,7 +67,7 @@ filter_make_sys() {
                 PATHS+=("ukama-agent/api-gateway" "ukama-agent/cdr" "ukama-agent/asr" "ukama-agent/node-gateway")
                 ;;
             "hub")
-                PATHS+=("hub/api-gateway" "hub/artifactmanager" "hub/distributor" "hub/node-gateway")
+                PATHS+=("hub/api-gateway" "hub/artifactManager" "hub/distributor" "hub/node-gateway")
                 ;;
         esac
     done


### PR DESCRIPTION
Fix typo.