### PR TITLE
BFF > To provide screen related apis to ukama-console

### DIFF
--- a/interfaces/console/src/context/networkContext.tsx
+++ b/interfaces/console/src/context/networkContext.tsx
@@ -1,0 +1,53 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+'use client';
+
+import { TNetwork } from '@/types';
+import React, { createContext, useContext, useMemo, useState } from 'react';
+
+const defaultNetwork: TNetwork = { id: '', name: '' };
+
+interface NetworkContextState {
+  network: TNetwork;
+  selectedDefaultSite: string;
+}
+
+interface NetworkContextActions {
+  setNetwork: (network: TNetwork) => void;
+  setSelectedDefaultSite: (siteId: string) => void;
+}
+
+export type NetworkContextType = NetworkContextState & NetworkContextActions;
+
+const NetworkContext = createContext<NetworkContextType | undefined>(undefined);
+
+export const NetworkContextProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [network, setNetwork] = useState<TNetwork>(defaultNetwork);
+  const [selectedDefaultSite, setSelectedDefaultSite] = useState('');
+
+  const value = useMemo(
+    () => ({ network, selectedDefaultSite, setNetwork, setSelectedDefaultSite }),
+    [network, selectedDefaultSite],
+  );
+
+  return (
+    <NetworkContext.Provider value={value}>{children}</NetworkContext.Provider>
+  );
+};
+
+export function useNetworkContext() {
+  const context = useContext(NetworkContext);
+  if (context === undefined) {
+    throw new Error(
+      'useNetworkContext must be used within a NetworkContextProvider',
+    );
+  }
+  return context;
+}

--- a/interfaces/ukama-console/codegen.ts
+++ b/interfaces/ukama-console/codegen.ts
@@ -27,11 +27,16 @@ const GW = process.env.NEXT_PUBLIC_API_GW ?? 'http://localhost:8080';
  * needed because the gateway lets introspection past the auth gate when
  * ENABLE_INTROSPECTION is set.
  */
-const schema = {
-  [`${GW}/graphql`]: {
-    headers: { 'apollo-require-preflight': 'true' },
-  },
-};
+const schema = process.env.SCHEMA_PATH
+  ? // Offline mode: SDL file exported from the BFF (SCHEMA_PATH=schema.graphql
+    // pnpm codegen) — used by CI's contract check and when the gateway isn't
+    // running locally.
+    process.env.SCHEMA_PATH
+  : {
+      [`${GW}/graphql`]: {
+        headers: { 'apollo-require-preflight': 'true' },
+      },
+    };
 
 const hooksConfig = {
   withHooks: true,

--- a/interfaces/ukama-console/schema.graphql
+++ b/interfaces/ukama-console/schema.graphql
@@ -1,0 +1,1535 @@
+type Query {
+  getReport(id: String!): GetReportDto!
+  getReportPdf(id: String!): GetReportDto!
+  getReports(data: GetReportsInputDto!): GetReportsDto!
+  getComponentById(componentId: String!): ComponentDto!
+  getComponentsByUserId(data: ComponentTypeInputDto!): ComponentsResDto!
+  example: String
+  networkOverview(networkId: String!): NetworkOverview!
+  nodesView(networkId: String): NodesView!
+  nodeView(nodeId: String!): NodeView!
+  simPoolView(simType: String!): SimPoolView!
+  sitesView(networkId: String!): SitesView!
+  siteView(siteId: String!): SiteView!
+  subscribersView(networkId: String!): SubscribersView!
+  getHealthReport(data: GetHealthReportInputDto!): HealthInfo!
+  getCountries: CountriesRes!
+  getCurrencySymbol(code: String!): CurrencyRes!
+  getTimezones: TimezoneRes!
+  getInvitation(id: String!): InvitationDto!
+  getInvitations: InvitationsResDto!
+  getInvitationsByEmail(email: String!): InvitationsResDto!
+  getMember(id: String!): MemberDto!
+  getMemberByUserId(userId: String!): MemberDto!
+  getMembers: MembersResDto!
+  getNetworkStats(networkId: String!): NetworkStats!
+  getNodeLatestMetric(data: GetNodeLatestMetricInput!): NodeLatestMetric!
+  getNetwork(networkId: String!): NetworkDto!
+  getNetworks: NetworksResDto!
+  getAppsChangeLog(data: NodeAppsChangeLogInput!): AppChangeLogs!
+  getNode(data: NodeInput!): Node!
+  getNodeApps(data: NodeAppsChangeLogInput!): NodeApps!
+  getNodeState(id: String!): NodeStateRes!
+  getNodes(data: NodesFilterInput!): Nodes!
+  getNodesByNetwork(networkId: String!): Nodes!
+  getNodesByState(data: GetNodesByStateInput!): Nodes!
+  getNodesForSite(siteId: String!): Nodes!
+  getNodesLocation: Nodes!
+  getNotification(id: String!): NotificationResDto!
+  getNotifications: NotificationsResDto!
+  getOrg: OrgDto!
+  getOrgTree: OrgTreeRes!
+  getOrgs: OrgsResDto!
+  getPackage(packageId: String!): PackageDto!
+  getPackages: PackagesResDto!
+  getPayment(paymentId: String!): PaymentDto!
+  getPayments(data: GetPaymentsInputDto!): PaymentsDto!
+  getToken(paymentId: String!): TokenResDto!
+  getDefaultMarkup: DefaultMarkupResDto!
+  getDefaultMarkupHistory: DefaultMarkupHistoryResDto!
+  getGeneratedPdfReport(id: String!): GetPdfReportUrlDto!
+  getDataUsage(data: SimUsageInputDto!): SimDataUsage!
+  getDataUsages(data: SimUsagesInputDto!): SimDataUsages!
+  getPackagesForSim(data: GetPackagesForSimInputDto!): GetSimPackagesDtoAPI!
+  getSim(data: GetSimInputDto!): SimDto!
+  getSimPoolStats(data: GetSimsInput!): SimPoolStatsDto!
+  getSims(data: ListSimsInput!): SimsResDto!
+  getSimsBySubscriber(data: GetSimBySubscriberInputDto!): SubscriberToSimsDto!
+  getSimsFromPool(data: GetSimsInput!): SimsPoolResDto!
+  getSite(siteId: String!): SiteDto!
+  getSites(data: SitesInputDto!): SitesResDto!
+  getApps: Apps
+  getSoftwares(data: GetSoftwaresInput!): Softwares!
+  getSimsByNetwork(networkId: String!): SubscriberSimsResDto!
+  getSubscriber(subscriberId: String!): SubscriberDto!
+  getSubscriberMetricsByNetwork(networkId: String!): SubscriberMetricsByNetworkDto!
+  getSubscribersByNetwork(networkId: String!): SubscribersResDto!
+  getUser(userId: String!): UserResDto!
+  whoami: WhoamiDto!
+}
+
+type GetReportDto {
+  report: ReportDto!
+}
+
+type ReportDto {
+  id: String!
+  ownerId: String!
+  ownerType: String!
+  networkId: String!
+  period: String!
+  type: String!
+  rawReport: RawReportDto!
+  isPaid: Boolean!
+  createdAt: String!
+}
+
+type RawReportDto {
+  issuingDate: String!
+  paymentDueDate: String!
+  paymentOverdue: Boolean!
+  invoiceType: String!
+  status: String!
+  paymentStatus: String!
+  feesAmountCents: String!
+  taxesAmountCents: String!
+  subTotalExcludingTaxesAmountCents: String!
+  subTotalIncludingTaxesAmountCents: String!
+  vatAmountCents: String!
+  vatAmountCurrency: String
+  totalAmountCents: String!
+  currency: String!
+  fileUrl: String!
+  customer: CustomerDto!
+  subscriptions: [SubscriptionDto!]!
+  fees: [FeeDto!]!
+}
+
+type CustomerDto {
+  externalId: String!
+  name: String!
+  email: String
+  addressLine1: String
+  legalName: String
+  legalNumber: String
+  phone: String
+  currency: String!
+  timezone: String
+  vatRate: Float!
+  createdAt: String!
+}
+
+type SubscriptionDto {
+  externalCustomerId: String!
+  externalId: String!
+  planCode: String!
+  name: String
+  status: String!
+  createdAt: String!
+  startedAt: String!
+  canceledAt: String
+  terminatedAt: String
+}
+
+type FeeDto {
+  taxesAmountCents: String!
+  taxesPreciseAmount: String!
+  totalAmountCents: String!
+  totalAmountCurrency: String!
+  eventsCount: String!
+  units: Float!
+  item: ItemResDto!
+}
+
+type ItemResDto {
+  type: String!
+  code: String!
+  name: String!
+}
+
+type GetReportsDto {
+  reports: [ReportDto!]!
+}
+
+input GetReportsInputDto {
+  networkId: String
+  ownerId: String
+  ownerType: String!
+  report_type: String!
+  isPaid: Boolean
+  sort: Boolean
+  count: Float
+}
+
+type ComponentDto {
+  id: String!
+  inventoryId: String!
+  category: String!
+  type: String!
+  userId: String!
+  description: String!
+  datasheetUrl: String!
+  imageUrl: String!
+  partNumber: String!
+  manufacturer: String!
+  managed: String!
+  warranty: Float!
+  specification: String!
+}
+
+type ComponentsResDto {
+  components: [ComponentDto!]!
+}
+
+input ComponentTypeInputDto {
+  category: COMPONENT_TYPE!
+}
+
+enum COMPONENT_TYPE {
+  all
+  access
+  backhaul
+  power
+  switch
+  spectrum
+}
+
+type NetworkOverview {
+  networkId: String!
+  network: NetworkSection!
+  nodeStats: NodeStatsSection!
+  siteStats: SitesSection!
+  subscriberStats: SubscriberStatsSection!
+  latestAlerts(limit: Int! = 5): AlertsSection!
+  kpis: GapSection!
+}
+
+type NetworkSection {
+  error: SectionError
+  network: NetworkDto
+}
+
+"""
+Typed failure of one section of a composite query. The section's data field resolves to null and a SectionError describes why, so the UI can distinguish 'failed' from 'genuinely empty'.
+"""
+type SectionError {
+  section: String!
+  code: SectionErrorCode!
+  message: String!
+}
+
+"""
+Machine-readable failure code for a composite query section. UI branches on this code; `message` is for display/logs only.
+"""
+enum SectionErrorCode {
+  UPSTREAM_TIMEOUT
+  UPSTREAM_ERROR
+  NOT_FOUND
+  FORBIDDEN
+  INTERNAL
+  NOT_IMPLEMENTED
+}
+
+type NetworkDto {
+  id: String!
+  name: String!
+  isDefault: Boolean!
+  budget: Float!
+  overdraft: Float!
+  trafficPolicy: Float!
+  isDeactivated: Boolean!
+  paymentLinks: Boolean!
+  createdAt: String!
+  countries: [String!]!
+  networks: [String!]!
+}
+
+type NodeStatsSection {
+  error: SectionError
+  total: Int
+  online: Int
+  offline: Int
+}
+
+type SitesSection {
+  error: SectionError
+  sites: [SiteDto!]
+}
+
+type SiteDto {
+  id: String!
+  name: String!
+  networkId: String!
+  backhaulId: String!
+  powerId: String!
+  accessId: String!
+  spectrumId: String!
+  switchId: String!
+  isDeactivated: Boolean!
+  latitude: String!
+  longitude: String!
+  installDate: String!
+  createdAt: String!
+  location: String!
+}
+
+type SubscriberStatsSection {
+  error: SectionError
+  total: Int
+  active: Int
+  inactive: Int
+}
+
+type AlertsSection {
+  error: SectionError
+  notifications: [NotificationsDto!]
+}
+
+type NotificationsDto {
+  id: String!
+  title: String!
+  description: String!
+  type: NOTIFICATION_TYPE!
+  scope: NOTIFICATION_SCOPE!
+  isRead: Boolean!
+  createdAt: String!
+  eventKey: String!
+  resourceId: String!
+  redirect: NotificationRedirectDto
+}
+
+enum NOTIFICATION_TYPE {
+  TYPE_INVALID
+  TYPE_INFO
+  TYPE_WARNING
+  TYPE_ERROR
+  TYPE_CRITICAL
+  TYPE_ACTIONABLE_INFO
+  TYPE_ACTIONABLE_WARNING
+  TYPE_ACTIONABLE_ERROR
+  TYPE_ACTIONABLE_CRITICAL
+}
+
+enum NOTIFICATION_SCOPE {
+  SCOPE_INVALID
+  SCOPE_OWNER
+  SCOPE_ORG
+  SCOPE_NETWORKS
+  SCOPE_NETWORK
+  SCOPE_SITES
+  SCOPE_SITE
+  SCOPE_SUBSCRIBERS
+  SCOPE_SUBSCRIBER
+  SCOPE_USERS
+  SCOPE_USER
+  SCOPE_NODE
+}
+
+type NotificationRedirectDto {
+  title: String!
+  action: String!
+}
+
+type GapSection {
+  error: SectionError
+}
+
+type NodesView {
+  networkId: String
+  nodes: NodesSection!
+  health: GapSection!
+}
+
+type NodesSection {
+  error: SectionError
+  nodes: [Node!]
+}
+
+type Node {
+  id: String!
+  name: String!
+  latitude: String!
+  longitude: String!
+  type: NodeTypeEnum!
+  attached: [AttachedNodes!]!
+  site: NodeSite!
+  status: NodeStatus!
+}
+
+"""Node type enums"""
+enum NodeTypeEnum {
+  tnode
+  anode
+  hnode
+  cnode
+}
+
+type AttachedNodes {
+  id: String!
+  name: String!
+  latitude: String!
+  longitude: String!
+  type: NodeTypeEnum!
+  site: NodeSite!
+  status: NodeStatus!
+}
+
+type NodeSite {
+  nodeId: String
+  siteId: String
+  networkId: String
+  addedAt: String
+}
+
+type NodeStatus {
+  connectivity: String!
+  state: String!
+}
+
+type NodeView {
+  nodeId: String!
+  node: NodeSection!
+  health: HealthSection!
+  software: SoftwareSection!
+  stateHistory: NodeStateSection!
+  kpis: GapSection!
+  radioStatus: GapSection!
+}
+
+type NodeSection {
+  error: SectionError
+  node: Node
+}
+
+type HealthSection {
+  error: SectionError
+  health: HealthInfo
+}
+
+type HealthInfo {
+  id: String!
+  nodeId: String!
+  timestamp: String!
+  system: [HealthSystemInfo!]!
+  capps: [HealthCappInfo!]!
+}
+
+type HealthSystemInfo {
+  id: String!
+  healthId: String!
+  name: String!
+  value: String!
+}
+
+type HealthCappInfo {
+  id: String!
+  space: String!
+  name: String!
+  tag: String!
+  status: String!
+  resources: [HealthResourceInfo!]!
+}
+
+type HealthResourceInfo {
+  id: String!
+  cappId: String!
+  name: String!
+  value: String!
+}
+
+type SoftwareSection {
+  error: SectionError
+  softwares: Softwares
+}
+
+type Softwares {
+  software: [Software!]!
+}
+
+type Software {
+  id: String!
+  releaseDate: String!
+  nodeId: String!
+  status: SoftwareStatusEnum!
+  changeLog: [String!]!
+  currentVersion: String!
+  desiredVersion: String!
+  name: String!
+  space: String!
+  notes: String!
+  metricsKeys: [String!]!
+  createdAt: String!
+  updatedAt: String!
+}
+
+"""Software status enums"""
+enum SoftwareStatusEnum {
+  unknown
+  up_to_date
+  update_available
+  update_in_progress
+  update_failed
+}
+
+type NodeStateSection {
+  error: SectionError
+  stateHistory: NodeStateRes
+}
+
+type NodeStateRes {
+  id: String!
+  nodeId: String!
+  previousStateId: String
+  previousState: NodeStateEnum
+  currentState: NodeStateEnum!
+  createdAt: String!
+}
+
+"""Node state enums"""
+enum NodeStateEnum {
+  Unknown
+  Configured
+  Operational
+  Faulty
+}
+
+type SimPoolView {
+  simType: String!
+  stats: SimPoolStatsSection!
+  sims(limit: Int! = 20): PoolSimsSection!
+}
+
+type SimPoolStatsSection {
+  error: SectionError
+  total: Int
+  available: Int
+  consumed: Int
+  failed: Int
+  esim: Int
+  physical: Int
+  pctAssigned: Int
+  lowStock: Boolean
+}
+
+type PoolSimsSection {
+  error: SectionError
+  sims: [SimPoolResDto!]
+}
+
+type SimPoolResDto {
+  id: String!
+  qrCode: String!
+  iccid: String!
+  msisdn: String!
+  isAllocated: Boolean!
+  isFailed: Boolean!
+  simType: String!
+  smApAddress: String!
+  activationCode: String!
+  createdAt: String!
+  deletedAt: String!
+  updatedAt: String!
+  isPhysical: Boolean!
+}
+
+type SitesView {
+  networkId: String!
+  sites: SitesSection!
+  nodeCounts: SiteNodeCountsSection!
+  kpis: GapSection!
+  financials: GapSection!
+}
+
+type SiteNodeCountsSection {
+  error: SectionError
+  counts: [SiteNodeCountDto!]
+}
+
+type SiteNodeCountDto {
+  siteId: String!
+  total: Int!
+  online: Int!
+  offline: Int!
+}
+
+type SiteView {
+  siteId: String!
+  site: SiteSection!
+  nodes: NodesSection!
+  components: SiteComponentsSection!
+  power: GapSection!
+  kpis: GapSection!
+  financials: GapSection!
+}
+
+type SiteSection {
+  error: SectionError
+  site: SiteDto
+}
+
+type SiteComponentsSection {
+  error: SectionError
+  components: [SiteComponentDto!]
+}
+
+type SiteComponentDto {
+  elementType: String!
+  componentId: String
+  componentName: String
+}
+
+type SubscribersView {
+  networkId: String!
+  subscribers: SubscribersSection!
+  plans: PlansSection!
+  usage: GapSection!
+}
+
+type SubscribersSection {
+  error: SectionError
+  subscribers: [SubscriberDto!]
+}
+
+type SubscriberDto {
+  uuid: String!
+  address: String!
+  dob: String!
+  email: String!
+  name: String!
+  gender: String!
+  idSerial: String!
+  networkId: String!
+  phone: String!
+  proofOfIdentification: String!
+  sim: [SubscriberSimDto!]
+}
+
+type SubscriberSimDto {
+  id: String!
+  subscriberId: String!
+  networkId: String!
+  iccid: String!
+  msisdn: String!
+  imsi: String!
+  type: String!
+  status: String!
+  allocatedAt: String!
+  sync_status: String
+  isPhysical: Boolean
+  package: SimPackageDto
+}
+
+type SimPackageDto {
+  id: String!
+  package_id: String!
+  start_date: String!
+  end_date: String!
+  is_active: Boolean!
+  created_at: String!
+  updated_at: String!
+}
+
+type PlansSection {
+  error: SectionError
+  plans: [PlanNameDto!]
+}
+
+type PlanNameDto {
+  packageId: String!
+  name: String!
+}
+
+input GetHealthReportInputDto {
+  id: String!
+  timestamp: String!
+  timeframe: TIMEFRAME_FILTER!
+  nodeId: String!
+}
+
+enum TIMEFRAME_FILTER {
+  UNKNOWN
+  ALL
+  LATEST
+}
+
+type CountriesRes {
+  countries: [CountryDto!]!
+}
+
+type CountryDto {
+  name: String!
+  code: String!
+}
+
+type CurrencyRes {
+  code: String!
+  symbol: String!
+  image: String!
+}
+
+type TimezoneRes {
+  timezones: [TimezoneDto!]!
+}
+
+type TimezoneDto {
+  value: String!
+  abbr: String!
+  offset: Float!
+  isdst: Boolean!
+  text: String!
+  utc: [String!]!
+}
+
+type InvitationDto {
+  email: String!
+  expireAt: String!
+  id: String!
+  name: String!
+  role: String!
+  link: String!
+  userId: String!
+  status: INVITATION_STATUS!
+}
+
+enum INVITATION_STATUS {
+  INVITE_PENDING
+  INVITE_ACCEPTED
+  INVITE_DECLINED
+}
+
+type InvitationsResDto {
+  invitations: [InvitationDto!]!
+}
+
+type MemberDto {
+  userId: String!
+  name: String!
+  email: String!
+  memberId: String!
+  isDeactivated: Boolean!
+  role: String!
+  memberSince: String
+}
+
+type MembersResDto {
+  members: [MemberDto!]!
+}
+
+type NetworkStats {
+  activeSubscriber: Float!
+  averageSignalStrength: Float!
+  averageThroughput: Float!
+}
+
+type NodeLatestMetric {
+  success: Boolean!
+  msg: String!
+  orgId: String!
+  nodeId: String!
+  type: String!
+  value: [Float!]!
+}
+
+input GetNodeLatestMetricInput {
+  nodeId: String!
+  type: String!
+}
+
+type NetworksResDto {
+  networks: [NetworkDto!]!
+}
+
+type AppChangeLogs {
+  logs: [AppChangeLog!]!
+  type: NodeTypeEnum!
+}
+
+type AppChangeLog {
+  version: String!
+  date: Float!
+}
+
+input NodeAppsChangeLogInput {
+  type: NodeTypeEnum!
+}
+
+input NodeInput {
+  id: String!
+}
+
+type NodeApps {
+  apps: [NodeApp!]!
+  type: NodeTypeEnum!
+}
+
+type NodeApp {
+  name: String!
+  date: Float!
+  version: String!
+  cpu: String!
+  memory: String!
+  notes: String!
+}
+
+type Nodes {
+  nodes: [Node!]!
+}
+
+input NodesFilterInput {
+  id: String
+  siteId: String
+  networkId: String
+  type: String
+  state: String
+  connectivity: String
+}
+
+input GetNodesByStateInput {
+  connectivity: NodeConnectivityEnum!
+  state: NodeStateEnum!
+}
+
+"""Node connectivity enums"""
+enum NodeConnectivityEnum {
+  Unknown
+  Offline
+  Online
+}
+
+type NotificationResDto {
+  id: String!
+  title: String!
+  description: String!
+  type: NOTIFICATION_TYPE!
+  scope: NOTIFICATION_SCOPE!
+  orgId: String!
+  userId: String!
+  subscriberId: String!
+  networkId: String!
+  createdAt: String!
+  resourceId: String!
+}
+
+type NotificationsResDto {
+  notifications: [NotificationsDto!]!
+}
+
+type OrgDto {
+  id: String!
+  name: String!
+  owner: String!
+  country: String!
+  currency: String!
+  certificate: String!
+  isDeactivated: Boolean!
+  createdAt: String!
+}
+
+type OrgTreeRes {
+  org: Org!
+}
+
+type Org {
+  orgId: String!
+  orgName: String!
+  country: String!
+  currency: String!
+  ownerName: String!
+  ownerEmail: String!
+  ownerId: String!
+  elementType: String!
+  networks: [Network!]!
+  dataplans: [DataPlan!]!
+  sims: Sims
+  members: Members
+}
+
+type Network {
+  networkId: String!
+  networkName: String!
+  elementType: String!
+  sites: [Site!]!
+  subscribers: Subscribers
+}
+
+type Site {
+  siteId: String!
+  siteName: String!
+  elementType: String!
+  components: [Component!]!
+}
+
+type Component {
+  componentId: String
+  componentName: String
+  elementType: String!
+}
+
+type Subscribers {
+  totalSubscribers: String!
+  activeSubscribers: String!
+  inactiveSubscribers: String!
+}
+
+type DataPlan {
+  planId: String!
+  planName: String!
+  elementType: String!
+}
+
+type Sims {
+  availableSims: String!
+  consumed: String!
+  totalSims: String!
+}
+
+type Members {
+  totalMembers: String!
+  activeMembers: String!
+  inactiveMembers: String!
+}
+
+type OrgsResDto {
+  user: String!
+  ownerOf: [OrgDto!]!
+  memberOf: [OrgDto!]!
+}
+
+type PackageDto {
+  uuid: String!
+  name: String!
+  active: Boolean!
+  duration: Float!
+  simType: String!
+  createdAt: String!
+  deletedAt: String!
+  updatedAt: String!
+  smsVolume: Float!
+  dataVolume: Float!
+  voiceVolume: Float!
+  ulbr: String!
+  dlbr: String!
+  type: String!
+  dataUnit: String!
+  voiceUnit: String!
+  messageUnit: String!
+  flatrate: Boolean!
+  currency: String!
+  from: String!
+  to: String!
+  country: String!
+  provider: String!
+  apn: String!
+  ownerId: String!
+  amount: Float!
+  rate: PackageRateAPIDto!
+  markup: PackageMarkupAPIDto!
+}
+
+type PackageRateAPIDto {
+  sms_mo: String!
+  sms_mt: Float!
+  data: Float!
+  amount: Float!
+}
+
+type PackageMarkupAPIDto {
+  baserate: String!
+  markup: Float!
+}
+
+type PackagesResDto {
+  packages: [PackageDto!]!
+}
+
+type PaymentDto {
+  id: String!
+  itemId: String!
+  itemType: String!
+  amount: String!
+  currency: String!
+  paymentMethod: String!
+  depositedAmount: String!
+  paidAt: String!
+  payerName: String!
+  payerEmail: String!
+  payerPhone: String!
+  correspondent: String!
+  country: String!
+  description: String!
+  status: String!
+  extra: String!
+  failureReason: String!
+  createdAt: String!
+}
+
+type PaymentsDto {
+  payments: [PaymentDto!]!
+}
+
+input GetPaymentsInputDto {
+  type: String
+  paymentMethod: String
+  status: String
+}
+
+type TokenResDto {
+  token: String!
+}
+
+type DefaultMarkupResDto {
+  markup: Float!
+}
+
+type DefaultMarkupHistoryResDto {
+  markupRates: [DefaultMarkupHistoryDto!]
+}
+
+type DefaultMarkupHistoryDto {
+  createdAt: String!
+  deletedAt: String!
+  Markup: Float!
+}
+
+type GetPdfReportUrlDto {
+  id: String!
+  filename: String!
+  contentType: String!
+  downloadUrl: String!
+}
+
+type SimDataUsage {
+  usage: String!
+  simId: String!
+}
+
+input SimUsageInputDto {
+  iccid: String!
+  simId: String!
+  type: String!
+}
+
+type SimDataUsages {
+  usages: [SimDataUsage!]!
+}
+
+input SimUsagesInputDto {
+  networkId: String!
+  type: String!
+}
+
+type GetSimPackagesDtoAPI {
+  sim_id: String!
+  packages: [SimToPackagesDto!]!
+}
+
+type SimToPackagesDto {
+  id: String!
+  package_id: String!
+  start_date: String!
+  end_date: String!
+  is_active: Boolean!
+}
+
+input GetPackagesForSimInputDto {
+  sim_id: String!
+}
+
+type SimDto {
+  id: String!
+  subscriberId: String!
+  networkId: String!
+  package: SimPackage
+  iccid: String!
+  msisdn: String!
+  imsi: String!
+  type: String!
+  status: String!
+  isPhysical: Boolean!
+  trafficPolicy: Float!
+  firstActivatedOn: String!
+  lastActivatedOn: String!
+  activationsCount: String!
+  deactivationsCount: String!
+  allocatedAt: String!
+  syncStatus: String!
+}
+
+type SimPackage {
+  id: String!
+  packageId: String!
+  startDate: String!
+  endDate: String!
+  defaultDuration: String!
+  isActive: Boolean!
+  asExpired: Boolean!
+}
+
+input GetSimInputDto {
+  simId: String!
+}
+
+type SimPoolStatsDto {
+  total: Float!
+  available: Float!
+  consumed: Float!
+  failed: Float!
+  esim: Float!
+  physical: Float!
+}
+
+input GetSimsInput {
+  type: SIM_TYPES!
+  status: SIM_STATUS!
+}
+
+enum SIM_TYPES {
+  unknown
+  test
+  operator_data
+  ukama_data
+}
+
+enum SIM_STATUS {
+  ALL
+  ASSIGNED
+  UNASSIGNED
+}
+
+type SimsResDto {
+  sims: [SimDto!]!
+}
+
+input ListSimsInput {
+  status: String!
+  networkId: String!
+}
+
+type SubscriberToSimsDto {
+  subscriberId: String!
+  sims: [SubscriberSimsDto!]!
+}
+
+type SubscriberSimsDto {
+  id: String!
+  subscriberId: String!
+  networkId: String!
+  syncStatus: String!
+  iccid: String!
+  msisdn: String!
+  imsi: String!
+  type: String!
+  status: String!
+  isPhysical: Boolean!
+  trafficPolicy: Float!
+  allocatedAt: String!
+}
+
+input GetSimBySubscriberInputDto {
+  subscriberId: String!
+}
+
+type SimsPoolResDto {
+  sims: [SimPoolResDto!]!
+}
+
+type SitesResDto {
+  sites: [SiteDto!]!
+}
+
+input SitesInputDto {
+  networkId: String
+}
+
+type Apps {
+  apps: [App!]!
+}
+
+type App {
+  name: String!
+  space: String!
+  notes: String!
+  metricsKeys: [String!]!
+}
+
+input GetSoftwaresInput {
+  name: String!
+  nodeId: String!
+  status: SoftwareStatusEnum!
+}
+
+type SubscriberSimsResDto {
+  sims: [SubscriberSimDto!]!
+}
+
+type SubscriberMetricsByNetworkDto {
+  total: Float!
+  active: Float!
+  inactive: Float!
+  terminated: Float!
+}
+
+type SubscribersResDto {
+  subscribers: [SubscriberDto!]!
+}
+
+type UserResDto {
+  name: String!
+  email: String!
+  uuid: String!
+  phone: String!
+  isDeactivated: Boolean!
+  authId: String!
+  registeredSince: String!
+}
+
+type WhoamiDto {
+  user: UserResDto!
+  ownerOf: [OrgDto!]!
+  memberOf: [OrgDto!]!
+}
+
+type Mutation {
+  restartNode(data: RestartNodeInputDto!): CBooleanResponse!
+  restartNodes(data: RestartNodesInputDto!): CBooleanResponse!
+  restartSite(data: RestartSiteInputDto!): CBooleanResponse!
+  toggleInternetSwitch(data: ToggleInternetSwitchInputDto!): CBooleanResponse!
+  toggleRFStatus(data: ToggleRFStatusInputDto!): CBooleanResponse!
+  toggleService(data: ToggleRFStatusInputDto!): CBooleanResponse!
+  createInvitation(data: CreateInvitationInputDto!): InvitationDto!
+  deleteInvitation(id: String!): DeleteInvitationResDto!
+  updateInvitation(data: UpdateInvitationInputDto!): UpdateInvitationResDto!
+  addMember(data: AddMemberInputDto!): MemberDto!
+  removeMember(id: String!): CBooleanResponse!
+  updateMember(data: UpdateMemberInputDto!, memberId: String!): CBooleanResponse!
+  addNetwork(data: AddNetworkInputDto!): NetworkDto!
+  setDefaultNetwork(data: SetDefaultNetworkInputDto!): CBooleanResponse!
+  addNode(data: AddNodeInput!): Node!
+  addNodeToSite(data: AddNodeToSiteInput!): CBooleanResponse!
+  attachNode(data: AttachNodeInput!): CBooleanResponse!
+  deleteNodeFromOrg(data: NodeInput!): DeleteNode!
+  detachhNode(data: NodeInput!): CBooleanResponse!
+  releaseNodeFromSite(data: NodeInput!): CBooleanResponse!
+  updateNode(data: UpdateNodeInput!): Node!
+  updateNodeState(data: UpdateNodeStateInput!): Node!
+  updateNotification(isRead: Boolean!, id: String!): UpdateNotificationResDto!
+  addPackage(data: AddPackageInputDto!): PackageDto!
+  deletePackage(packageId: String!): IdResponse!
+  updatePackage(data: UpdatePackageInputDto!, packageId: String!): PackageDto!
+  processPayment(data: ProcessPaymentInputDto!): ProcessPaymentDto!
+  updatePayment(data: UpdatePaymentInputDto!): PaymentDto!
+  defaultMarkup(data: DefaultMarkupInputDto!): CBooleanResponse!
+  addPackagesToSim(data: AddPackagesToSimInputDto!): AddPackagesSimResDto!
+  allocateSim(data: AllocateSimInputDto!): AllocateSimAPIDto!
+  deleteSim(data: DeleteSimInputDto!): DeleteSimResDto!
+  removePackageForSim(data: RemovePackageFormSimInputDto!): RemovePackageFromSimResDto!
+  toggleSimStatus(data: ToggleSimStatusInputDto!): SimStatusResDto!
+  uploadSims(data: UploadSimsInputDto!): UploadSimsResDto!
+  addSite(data: AddSiteInputDto!): SiteDto!
+  updateSite(data: UpdateSiteInputDto!, siteId: String!): SiteDto!
+  updateSoftware(data: UpdateSoftwareInputDto!): StringResponse!
+  addSubscriber(data: SubscriberInputDto!): SubscriberDto!
+  deleteSubscriber(subscriberId: String!): CBooleanResponse!
+  updateSubscriber(data: UpdateSubscriberInputDto!, subscriberId: String!): CBooleanResponse!
+  updateFirstVisit(data: UserFirstVisitInputDto!): UserFirstVisitResDto!
+}
+
+type CBooleanResponse {
+  success: Boolean!
+}
+
+input RestartNodeInputDto {
+  nodeId: String!
+}
+
+input RestartNodesInputDto {
+  networkId: String!
+  nodeIds: [String!]!
+}
+
+input RestartSiteInputDto {
+  siteId: String!
+  networkId: String!
+}
+
+input ToggleInternetSwitchInputDto {
+  siteId: String!
+  port: Float!
+  status: Boolean!
+}
+
+input ToggleRFStatusInputDto {
+  nodeId: String!
+  status: Boolean!
+}
+
+input CreateInvitationInputDto {
+  name: String!
+  email: String!
+  role: ROLE_TYPE!
+}
+
+enum ROLE_TYPE {
+  ROLE_INVALID
+  ROLE_OWNER
+  ROLE_ADMIN
+  ROLE_NETWORK_OWNER
+  ROLE_VENDOR
+  ROLE_USER
+}
+
+type DeleteInvitationResDto {
+  id: String!
+}
+
+type UpdateInvitationResDto {
+  id: String!
+}
+
+input UpdateInvitationInputDto {
+  id: String!
+  email: String!
+  status: INVITATION_STATUS!
+}
+
+input AddMemberInputDto {
+  userId: String!
+  role: String!
+}
+
+input UpdateMemberInputDto {
+  isDeactivated: Boolean!
+  role: String!
+}
+
+input AddNetworkInputDto {
+  name: String!
+  isDefault: Boolean! = false
+  budget: Float
+  countries: [String!]
+  networks: [String!]
+}
+
+input SetDefaultNetworkInputDto {
+  id: String!
+}
+
+input AddNodeInput {
+  name: String!
+  id: String!
+}
+
+input AddNodeToSiteInput {
+  nodeId: String!
+  networkId: String!
+  siteId: String!
+}
+
+input AttachNodeInput {
+  anodel: String!
+  anoder: String!
+  parentNode: String!
+}
+
+type DeleteNode {
+  id: String!
+}
+
+input UpdateNodeInput {
+  id: String!
+  name: String!
+}
+
+input UpdateNodeStateInput {
+  id: String!
+  state: NodeStateEnum!
+}
+
+type UpdateNotificationResDto {
+  id: String!
+}
+
+input AddPackageInputDto {
+  name: String!
+  duration: Int!
+  dataUnit: String!
+  amount: Float!
+  dataVolume: Int!
+  country: String!
+  currency: String!
+}
+
+type IdResponse {
+  uuid: String!
+}
+
+input UpdatePackageInputDto {
+  name: String!
+  active: Boolean!
+}
+
+type ProcessPaymentDto {
+  payment: PaymentDto!
+}
+
+input ProcessPaymentInputDto {
+  id: String!
+  correspondent: String
+  token: String!
+}
+
+input UpdatePaymentInputDto {
+  id: String!
+  country: String
+  currency: String
+  payerEmail: String
+  payerName: String
+  paymentMethod: String
+}
+
+input DefaultMarkupInputDto {
+  markup: Float!
+}
+
+type AddPackagesSimResDto {
+  packages: [AddPackagSimResDto!]!
+}
+
+type AddPackagSimResDto {
+  packageId: String
+  success: Boolean
+  error: String
+}
+
+input AddPackagesToSimInputDto {
+  sim_id: String!
+  packages: [PackagesToSimInputDto!]!
+}
+
+input PackagesToSimInputDto {
+  package_id: String!
+  start_date: String!
+}
+
+type AllocateSimAPIDto {
+  id: String!
+  subscriber_id: String!
+  network_id: String!
+  package: SimAllocatePackageDto!
+  iccid: String!
+  msisdn: String!
+  imsi: String
+  type: String!
+  status: String!
+  is_physical: Boolean!
+  traffic_policy: Float!
+  allocated_at: String!
+  sync_status: String!
+}
+
+type SimAllocatePackageDto {
+  id: String
+  packageId: String
+  startDate: String
+  endDate: String
+  isActive: Boolean
+}
+
+input AllocateSimInputDto {
+  network_id: String!
+  package_id: String!
+  iccid: String
+  sim_type: String!
+  subscriber_id: String!
+  traffic_policy: Float!
+}
+
+type DeleteSimResDto {
+  simId: String
+}
+
+input DeleteSimInputDto {
+  simId: String!
+}
+
+type RemovePackageFromSimResDto {
+  packageId: String
+}
+
+input RemovePackageFormSimInputDto {
+  simId: String!
+  packageId: String!
+}
+
+type SimStatusResDto {
+  simId: String
+}
+
+input ToggleSimStatusInputDto {
+  sim_id: String!
+  status: String!
+}
+
+type UploadSimsResDto {
+  iccid: [String!]!
+}
+
+input UploadSimsInputDto {
+  data: String!
+  simType: SIM_TYPES!
+}
+
+input AddSiteInputDto {
+  name: String!
+  network_id: String!
+  backhaul_id: String!
+  power_id: String!
+  access_id: String!
+  spectrum_id: String!
+  switch_id: String!
+  latitude: String!
+  longitude: String!
+  install_date: String!
+  location: String!
+}
+
+input UpdateSiteInputDto {
+  name: String!
+}
+
+type StringResponse {
+  message: String!
+}
+
+input UpdateSoftwareInputDto {
+  name: String!
+  nodeId: String!
+  tag: String!
+}
+
+input SubscriberInputDto {
+  email: String!
+  name: String!
+  network_id: String!
+  phone: String
+}
+
+input UpdateSubscriberInputDto {
+  address: String
+  email: String
+  id_serial: String
+  name: String
+  phone: String
+  proof_of_identification: String
+}
+
+type UserFirstVisitResDto {
+  firstVisit: Boolean!
+}
+
+input UserFirstVisitInputDto {
+  userId: String!
+  name: String!
+  email: String!
+  firstVisit: Boolean!
+}

--- a/interfaces/ukama-console/schema.graphql
+++ b/interfaces/ukama-console/schema.graphql
@@ -5,12 +5,16 @@ type Query {
   getComponentById(componentId: String!): ComponentDto!
   getComponentsByUserId(data: ComponentTypeInputDto!): ComponentsResDto!
   example: String
+  commerceView(networkId: String): CommerceView!
+  inventoryView: InventoryView!
+  membersView: MembersView!
   networkOverview(networkId: String!): NetworkOverview!
   nodesView(networkId: String): NodesView!
   nodeView(nodeId: String!): NodeView!
   simPoolView(simType: String!): SimPoolView!
   sitesView(networkId: String!): SitesView!
   siteView(siteId: String!): SiteView!
+  subscriberView(subscriberId: String!): SubscriberView!
   subscribersView(networkId: String!): SubscribersView!
   getHealthReport(data: GetHealthReportInputDto!): HealthInfo!
   getCountries: CountriesRes!
@@ -194,19 +198,21 @@ enum COMPONENT_TYPE {
   spectrum
 }
 
-type NetworkOverview {
-  networkId: String!
-  network: NetworkSection!
-  nodeStats: NodeStatsSection!
-  siteStats: SitesSection!
-  subscriberStats: SubscriberStatsSection!
-  latestAlerts(limit: Int! = 5): AlertsSection!
-  kpis: GapSection!
+type CommerceView {
+  networkId: String
+  revenue: RevenueSection!
+  plans: PlanStatsSection!
+  invoices(limit: Int! = 20): InvoicesSection!
+  balance: BalanceSection!
 }
 
-type NetworkSection {
+type RevenueSection {
   error: SectionError
-  network: NetworkDto
+  totalPaid: Float
+  totalPending: Float
+  monthPaid: Float
+  prevMonthPaid: Float
+  momPct: Int
 }
 
 """
@@ -228,6 +234,146 @@ enum SectionErrorCode {
   FORBIDDEN
   INTERNAL
   NOT_IMPLEMENTED
+}
+
+type PlanStatsSection {
+  error: SectionError
+  mrr: Float
+  arpu: Float
+  plans: [PlanStatsDto!]
+}
+
+type PlanStatsDto {
+  packageId: String!
+  name: String!
+  amount: Float!
+  currency: String!
+  active: Boolean!
+  attachCount: Int
+  revenue: Float!
+  revenueSharePct: Int!
+}
+
+type InvoicesSection {
+  error: SectionError
+  reports: [ReportDto!]
+}
+
+type BalanceSection {
+  error: SectionError
+  outstandingCount: Int
+  latestUnpaidPeriod: String
+}
+
+type InventoryView {
+  orgName: String!
+  components: ComponentStatsSection!
+  unassignedNodes: NodesSection!
+  simStock: SimPoolStatsSection!
+}
+
+type ComponentStatsSection {
+  error: SectionError
+  total: Int
+  byCategory: [CategoryCountDto!]
+}
+
+type CategoryCountDto {
+  category: String!
+  count: Int!
+}
+
+type NodesSection {
+  error: SectionError
+  nodes: [Node!]
+}
+
+type Node {
+  id: String!
+  name: String!
+  latitude: String!
+  longitude: String!
+  type: NodeTypeEnum!
+  attached: [AttachedNodes!]!
+  site: NodeSite!
+  status: NodeStatus!
+}
+
+"""Node type enums"""
+enum NodeTypeEnum {
+  tnode
+  anode
+  hnode
+  cnode
+}
+
+type AttachedNodes {
+  id: String!
+  name: String!
+  latitude: String!
+  longitude: String!
+  type: NodeTypeEnum!
+  site: NodeSite!
+  status: NodeStatus!
+}
+
+type NodeSite {
+  nodeId: String
+  siteId: String
+  networkId: String
+  addedAt: String
+}
+
+type NodeStatus {
+  connectivity: String!
+  state: String!
+}
+
+type SimPoolStatsSection {
+  error: SectionError
+  total: Int
+  available: Int
+  consumed: Int
+  failed: Int
+  esim: Int
+  physical: Int
+  pctAssigned: Int
+  lowStock: Boolean
+}
+
+type MembersView {
+  orgName: String!
+  team: TeamSection!
+}
+
+type TeamSection {
+  error: SectionError
+  rows: [TeamMemberDto!]
+}
+
+type TeamMemberDto {
+  id: String!
+  name: String
+  email: String
+  role: String!
+  status: String!
+  memberSince: String
+  inviteExpiresAt: String
+}
+
+type NetworkOverview {
+  networkId: String!
+  network: NetworkSection!
+  nodeStats: NodeStatsSection!
+  siteStats: SitesSection!
+  subscriberStats: SubscriberStatsSection!
+  latestAlerts(limit: Int! = 5): AlertsSection!
+  kpis: GapSection!
+}
+
+type NetworkSection {
+  error: SectionError
+  network: NetworkDto
 }
 
 type NetworkDto {
@@ -338,52 +484,6 @@ type NodesView {
   networkId: String
   nodes: NodesSection!
   health: GapSection!
-}
-
-type NodesSection {
-  error: SectionError
-  nodes: [Node!]
-}
-
-type Node {
-  id: String!
-  name: String!
-  latitude: String!
-  longitude: String!
-  type: NodeTypeEnum!
-  attached: [AttachedNodes!]!
-  site: NodeSite!
-  status: NodeStatus!
-}
-
-"""Node type enums"""
-enum NodeTypeEnum {
-  tnode
-  anode
-  hnode
-  cnode
-}
-
-type AttachedNodes {
-  id: String!
-  name: String!
-  latitude: String!
-  longitude: String!
-  type: NodeTypeEnum!
-  site: NodeSite!
-  status: NodeStatus!
-}
-
-type NodeSite {
-  nodeId: String
-  siteId: String
-  networkId: String
-  addedAt: String
-}
-
-type NodeStatus {
-  connectivity: String!
-  state: String!
 }
 
 type NodeView {
@@ -499,18 +599,6 @@ type SimPoolView {
   sims(limit: Int! = 20): PoolSimsSection!
 }
 
-type SimPoolStatsSection {
-  error: SectionError
-  total: Int
-  available: Int
-  consumed: Int
-  failed: Int
-  esim: Int
-  physical: Int
-  pctAssigned: Int
-  lowStock: Boolean
-}
-
 type PoolSimsSection {
   error: SectionError
   sims: [SimPoolResDto!]
@@ -578,16 +666,17 @@ type SiteComponentDto {
   componentName: String
 }
 
-type SubscribersView {
-  networkId: String!
-  subscribers: SubscribersSection!
-  plans: PlansSection!
+type SubscriberView {
+  subscriberId: String!
+  subscriber: SubscriberSection!
+  plans: SubscriberPlansSection!
+  billing: SubscriberBillingSection!
   usage: GapSection!
 }
 
-type SubscribersSection {
+type SubscriberSection {
   error: SectionError
-  subscribers: [SubscriberDto!]
+  subscriber: SubscriberDto
 }
 
 type SubscriberDto {
@@ -629,7 +718,7 @@ type SimPackageDto {
   updated_at: String!
 }
 
-type PlansSection {
+type SubscriberPlansSection {
   error: SectionError
   plans: [PlanNameDto!]
 }
@@ -637,6 +726,49 @@ type PlansSection {
 type PlanNameDto {
   packageId: String!
   name: String!
+}
+
+type SubscriberBillingSection {
+  error: SectionError
+  payments: [PaymentDto!]
+}
+
+type PaymentDto {
+  id: String!
+  itemId: String!
+  itemType: String!
+  amount: String!
+  currency: String!
+  paymentMethod: String!
+  depositedAmount: String!
+  paidAt: String!
+  payerName: String!
+  payerEmail: String!
+  payerPhone: String!
+  correspondent: String!
+  country: String!
+  description: String!
+  status: String!
+  extra: String!
+  failureReason: String!
+  createdAt: String!
+}
+
+type SubscribersView {
+  networkId: String!
+  subscribers: SubscribersSection!
+  plans: PlansSection!
+  usage: GapSection!
+}
+
+type SubscribersSection {
+  error: SectionError
+  subscribers: [SubscriberDto!]
+}
+
+type PlansSection {
+  error: SectionError
+  plans: [PlanNameDto!]
 }
 
 input GetHealthReportInputDto {
@@ -940,27 +1072,6 @@ type PackageMarkupAPIDto {
 
 type PackagesResDto {
   packages: [PackageDto!]!
-}
-
-type PaymentDto {
-  id: String!
-  itemId: String!
-  itemType: String!
-  amount: String!
-  currency: String!
-  paymentMethod: String!
-  depositedAmount: String!
-  paidAt: String!
-  payerName: String!
-  payerEmail: String!
-  payerPhone: String!
-  correspondent: String!
-  country: String!
-  description: String!
-  status: String!
-  extra: String!
-  failureReason: String!
-  createdAt: String!
 }
 
 type PaymentsDto {

--- a/interfaces/ukama-console/schema.graphql
+++ b/interfaces/ukama-console/schema.graphql
@@ -8,6 +8,7 @@ type Query {
   commerceView(networkId: String): CommerceView!
   inventoryView: InventoryView!
   membersView: MembersView!
+  metricsRange(data: MetricsRangeInput!): MetricsRes!
   networkOverview(networkId: String!): NetworkOverview!
   nodesView(networkId: String): NodesView!
   nodeView(nodeId: String!): NodeView!
@@ -361,6 +362,41 @@ type TeamMemberDto {
   inviteExpiresAt: String
 }
 
+type MetricsRes {
+  metrics: [MetricRes!]!
+}
+
+type MetricRes {
+  success: Boolean!
+  msg: String!
+  nodeId: String
+  networkId: String
+  packageId: String
+  dataPlanId: String
+  siteId: String
+  type: String!
+  values: [[Float!]!]!
+  unit: String
+  format: String
+  tickInterval: Float
+  tickPositions: [Float!]
+  threshold: MetricThreshold
+}
+
+type MetricThreshold {
+  min: Float!
+  normal: Float!
+  max: Float!
+}
+
+input MetricsRangeInput {
+  keys: [String!]!
+  from: Int!
+  to: Int
+  nodeId: String
+  operation: String
+}
+
 type NetworkOverview {
   networkId: String!
   network: NetworkSection!
@@ -368,7 +404,7 @@ type NetworkOverview {
   siteStats: SitesSection!
   subscriberStats: SubscriberStatsSection!
   latestAlerts(limit: Int! = 5): AlertsSection!
-  kpis: GapSection!
+  kpis: KpisSection!
 }
 
 type NetworkSection {
@@ -476,8 +512,16 @@ type NotificationRedirectDto {
   action: String!
 }
 
-type GapSection {
+type KpisSection {
   error: SectionError
+  metrics: [KpiEntryDto!]
+}
+
+type KpiEntryDto {
+  key: String!
+  value: Float!
+  timestamp: Float!
+  success: Boolean!
 }
 
 type NodesView {
@@ -486,13 +530,17 @@ type NodesView {
   health: GapSection!
 }
 
+type GapSection {
+  error: SectionError
+}
+
 type NodeView {
   nodeId: String!
   node: NodeSection!
   health: HealthSection!
   software: SoftwareSection!
   stateHistory: NodeStateSection!
-  kpis: GapSection!
+  kpis: KpisSection!
   radioStatus: GapSection!
 }
 
@@ -645,8 +693,8 @@ type SiteView {
   site: SiteSection!
   nodes: NodesSection!
   components: SiteComponentsSection!
-  power: GapSection!
-  kpis: GapSection!
+  power: KpisSection!
+  kpis: KpisSection!
   financials: GapSection!
 }
 

--- a/interfaces/ukama-console/src/app/(dashboard)/_components/NotificationsMenu.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/_components/NotificationsMenu.tsx
@@ -8,17 +8,36 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Menu from '@mui/material/Menu';
 import Typography from '@mui/material/Typography';
 import ChevronRightRounded from '@mui/icons-material/ChevronRightRounded';
 import NotificationsRounded from '@mui/icons-material/NotificationsRounded';
+import { useTopBarAlertsQuery } from '@/client/graphql/network-home.generated';
 import { useToast } from '@/components/ToastProvider';
-import { ALERTS, NODES, SITES } from '@/data';
 import type { Alert } from '@/data';
+import { POLL_OVERVIEW_MS, visiblePoll } from '@/lib/polling';
+import { useUiPrefs } from '@/lib/store';
 import AlertDialog from './AlertDialog';
 import { Ic } from './icons';
+
+/** NotificationsDto.type → alert severity. */
+const sevFromType = (type: string): Alert['sev'] => {
+  const t = type.toUpperCase();
+  if (t.includes('CRITICAL') || t.includes('ERROR')) return 'critical';
+  if (t.includes('WARNING')) return 'warning';
+  return 'info';
+};
+
+const relativeAge = (iso: string): string => {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+};
 
 const SEV_ICON: Record<Alert['sev'], string> = {
   critical: 'error',
@@ -34,21 +53,32 @@ const SEV_COLOR: Record<Alert['sev'], string> = {
 export default function NotificationsMenu() {
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const [openAlert, setOpenAlert] = useState<Alert | null>(null);
-  const router = useRouter();
   const toast = useToast();
-  const unread = ALERTS.filter((a) => a.sev !== 'info').length;
+  const networkId = useUiPrefs((s) => s.networkId);
+
+  // Polled notifications (v1: no subscriptions — BUILD-PLAN §5.1·4); shares
+  // the networkOverview cache entry with the home screen.
+  const { data } = useTopBarAlertsQuery({
+    variables: { networkId },
+    skip: !networkId,
+    ...visiblePoll(POLL_OVERVIEW_MS),
+  });
+  const alerts: Alert[] = (
+    data?.networkOverview.latestAlerts.notifications ?? []
+  ).map((n) => ({
+    id: n.id,
+    sev: sevFromType(n.type),
+    icon: 'info',
+    title: n.title,
+    detail: n.description,
+    action: 'View',
+    age: relativeAge(n.createdAt),
+  }));
+  const unread = alerts.filter((a) => a.sev !== 'info').length;
 
   const runAction = (a: Alert) => {
     setOpenAlert(null);
-    const site = a.site ? SITES.find((s) => s.name === a.site) : undefined;
-    if (a.action === 'View node') {
-      const node = NODES.find((n) => a.detail.includes(n.serial.slice(-4)));
-      router.push(`/network/nodes/${node ? node.id : ''}`);
-    } else if (site && (a.action === 'View site' || a.action === 'Diagnose')) {
-      router.push(`/network/sites/${site.id}`);
-    } else {
-      toast(`${a.action} — done`);
-    }
+    toast(`${a.action} — done`);
   };
 
   return (
@@ -86,7 +116,12 @@ export default function NotificationsMenu() {
             </Typography>
           )}
         </Box>
-        {ALERTS.map((a) => (
+        {alerts.length === 0 && (
+          <Box sx={{ px: 2, py: 2, fontSize: 13, color: 'text.secondary' }}>
+            No notifications.
+          </Box>
+        )}
+        {alerts.map((a) => (
           <Box
             key={a.id}
             component="button"

--- a/interfaces/ukama-console/src/app/(dashboard)/business/_components/BizHomeScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/business/_components/BizHomeScreen.tsx
@@ -7,23 +7,43 @@
  */
 'use client';
 
-/** Business Home — KPIs + full-height sites map + site summary modal. */
-import { useState } from 'react';
+/**
+ * Business Home — KPIs + full-height sites map, wired to `commerceView`
+ * (revenue) and `networkOverview` (customers + sites). Per-site revenue is
+ * backend gap #10 and renders as "—" until it lands.
+ */
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Button from '@mui/material/Button';
+import Skeleton from '@mui/material/Skeleton';
 import ListAltRounded from '@mui/icons-material/ListAltRounded';
+
+import {
+  useBizHomeNetworkQuery,
+  useBizHomeRevenueQuery,
+} from '@/client/graphql/commerce.generated';
 import AppModal from '@/components/AppModal';
 import DateChip from '@/components/DateChip';
 import { KpiRow } from '@/components/Kpi';
 import SiteMap, { StatusDot } from '@/components/Map/SiteMap';
 import PageHeader from '@/components/PageHeader';
-import { BIZ_HOME, BIZ_SITES } from '@/data';
+import { sectionValue } from '@/components/SectionFallback';
 import type { BizSite } from '@/data';
+import { useUiPrefs } from '@/lib/store';
 
-function SiteSummaryList({ onSite }: { onSite: (s: BizSite) => void }) {
+const money = (value?: number | null): string =>
+  value == null ? '—' : `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+
+function SiteSummaryList({
+  sites,
+  onSite,
+}: {
+  sites: BizSite[];
+  onSite: (s: BizSite) => void;
+}) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      {BIZ_SITES.map((s, i) => (
+      {sites.map((s, i) => (
         <div
           key={s.id}
           role="button"
@@ -38,7 +58,7 @@ function SiteSummaryList({ onSite }: { onSite: (s: BizSite) => void }) {
             gap: 11,
             padding: '13px 0',
             cursor: 'pointer',
-            borderBottom: i < BIZ_SITES.length - 1 ? '1px solid var(--uk-line-soft)' : 'none',
+            borderBottom: i < sites.length - 1 ? '1px solid var(--uk-line-soft)' : 'none',
           }}
         >
           <span style={{ marginTop: 4, display: 'inline-flex' }}>
@@ -47,9 +67,8 @@ function SiteSummaryList({ onSite }: { onSite: (s: BizSite) => void }) {
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ fontSize: 13.5, fontWeight: 600 }}>{s.name}</div>
             <div style={{ fontSize: 12.5, color: 'var(--uk-ink-2)', marginTop: 1 }}>
-              {s.status === 'offline'
-                ? `$0 today · ${s.customers} affected · Offline`
-                : `$${s.revToday} today · ${s.custToday} customers · ${s.status === 'warning' ? 'Warning' : 'Online'}`}
+              {/* per-site revenue/customers: backend gap #10 */}
+              {s.status === 'offline' ? 'Offline' : 'Online'} · revenue —
             </div>
           </div>
         </div>
@@ -60,35 +79,111 @@ function SiteSummaryList({ onSite }: { onSite: (s: BizSite) => void }) {
 
 export default function BizHomeScreen() {
   const router = useRouter();
+  const networkId = useUiPrefs((s) => s.networkId);
   const [showSummary, setShowSummary] = useState(false);
-  const online = BIZ_SITES.filter((s) => s.status === 'online').length;
+
+  const { data: revenueData, loading: revenueLoading } = useBizHomeRevenueQuery({
+    variables: { networkId },
+  });
+  const { data: networkData, loading: networkLoading } = useBizHomeNetworkQuery({
+    variables: { networkId },
+    skip: !networkId,
+  });
+  const revenue = revenueData?.commerceView.revenue;
+  const subStats = networkData?.networkOverview.subscriberStats;
+  const siteStats = networkData?.networkOverview.siteStats;
+  const loading = revenueLoading || networkLoading;
+
+  const sites: BizSite[] = useMemo(
+    () =>
+      (siteStats?.sites ?? []).map((s) => ({
+        id: s.id,
+        name: s.name,
+        status: s.isDeactivated ? 'offline' : 'online',
+        // TODO(backend-gap #10): per-site revenue/customer rollup
+        revenue: 0,
+        revToday: 0,
+        customers: 0,
+        custToday: 0,
+        data: '—',
+        uptime: 0,
+        top: '—',
+        issue: null,
+        lat: parseFloat(s.latitude) || 0,
+        lng: parseFloat(s.longitude) || 0,
+      })),
+    [siteStats?.sites]
+  );
+  const online = sites.filter((s) => s.status === 'online').length;
   const goSite = (id: string) => router.push(`/business/sites/${id}`);
 
   return (
     <div className="page">
       <PageHeader
         title="Home"
-        sub="Your network served 142 customers and sold 87 GB today."
+        sub="Revenue, customers and sites at a glance."
         actions={<DateChip />}
       />
-      <KpiRow items={BIZ_HOME.kpis} />
+      {loading ? (
+        <Skeleton variant="rounded" sx={{ height: 96 }} />
+      ) : (
+        <KpiRow
+          items={[
+            {
+              icon: 'monetization_on',
+              color: 'var(--uk-beige)',
+              label: 'Revenue this month',
+              value: revenue?.error ? '—' : money(revenue?.monthPaid),
+              sub:
+                revenue?.momPct != null
+                  ? `${revenue.momPct >= 0 ? '+' : ''}${revenue.momPct}% vs last month`
+                  : undefined,
+            },
+            {
+              icon: 'group',
+              color: 'var(--uk-secondary)',
+              label: 'Active customers',
+              value: sectionValue(subStats?.active, subStats?.error),
+              sub:
+                subStats?.total != null ? `${subStats.total} total` : undefined,
+            },
+            {
+              icon: 'donut_small',
+              color: 'var(--uk-ac)',
+              label: 'Collected to date',
+              value: revenue?.error ? '—' : money(revenue?.totalPaid),
+            },
+            {
+              icon: 'cell_tower',
+              color: 'var(--uk-success-bright)',
+              label: 'Sites online',
+              value: siteStats?.error ? '—' : `${online}/${sites.length}`,
+              danger: online < sites.length,
+            },
+          ]}
+        />
+      )}
 
       <div style={{ flex: 1, minHeight: 420, display: 'flex', flexDirection: 'column' }}>
-        <SiteMap
-          sites={BIZ_SITES}
-          title="Sites"
-          fill
-          action={
-            <Button
-              variant="text"
-              startIcon={<ListAltRounded />}
-              onClick={() => setShowSummary(true)}
-            >
-              View summary
-            </Button>
-          }
-          onSelect={(s) => goSite(s.id)}
-        />
+        {networkLoading ? (
+          <Skeleton variant="rounded" sx={{ flex: 1, minHeight: 380 }} />
+        ) : (
+          <SiteMap
+            sites={sites}
+            title="Sites"
+            fill
+            action={
+              <Button
+                variant="text"
+                startIcon={<ListAltRounded />}
+                onClick={() => setShowSummary(true)}
+              >
+                View summary
+              </Button>
+            }
+            onSelect={(s) => goSite(s.id)}
+          />
+        )}
       </div>
 
       {showSummary && (
@@ -103,9 +198,10 @@ export default function BizHomeScreen() {
           }
         >
           <div style={{ fontSize: 12.5, color: 'var(--uk-ink-3)', marginBottom: 4 }}>
-            {online} of {BIZ_SITES.length} sites online
+            {online} of {sites.length} sites online
           </div>
           <SiteSummaryList
+            sites={sites}
             onSite={(s) => {
               setShowSummary(false);
               goSite(s.id);

--- a/interfaces/ukama-console/src/app/(dashboard)/business/_components/BizInventoryScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/business/_components/BizInventoryScreen.tsx
@@ -7,25 +7,34 @@
  */
 'use client';
 
+/** Inventory — SIMs / Nodes / Hardware pill tabs, wired to `inventoryView`. */
+import { useState } from 'react';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 
-/** Inventory — SIMs / Nodes / Hardware pill tabs (biz-ops.jsx BizInventory). */
-import { useState } from 'react';
-import MemoryRounded from '@mui/icons-material/MemoryRounded';
+import { useInventoryOverviewQuery } from '@/client/graphql/team.generated';
 import DateChip from '@/components/DateChip';
+import { EmptyState } from '@/components/EmptyState';
 import FilterChips from '@/components/FilterChips';
 import { KpiRow } from '@/components/Kpi';
 import PageHeader from '@/components/PageHeader';
+import { sectionValue } from '@/components/SectionFallback';
+import SkeletonTable from '@/components/data-table/SkeletonTable';
 import StatusBadge from '@/components/StatusBadge';
-import { BIZ_INVENTORY } from '@/data';
+import { toUkamaNode } from '@/lib/mappers/nodes';
 
 export default function BizInventoryScreen() {
-  const b = BIZ_INVENTORY;
   const [tab, setTab] = useState('SIMs');
+  const { data, loading, refetch } = useInventoryOverviewQuery();
+  const view = data?.inventoryView;
+  const simStock = view?.simStock;
+  const componentsSection = view?.components;
+  const nodesSection = view?.unassignedNodes;
+  const nodes = (nodesSection?.nodes ?? []).map((n) => toUkamaNode(n));
+  const categories = componentsSection?.byCategory ?? [];
 
   return (
     <div className="page">
@@ -34,7 +43,40 @@ export default function BizInventoryScreen() {
         sub="Do I have enough SIMs and nodes to operate and grow?"
         actions={<DateChip />}
       />
-      <KpiRow items={b.kpis} />
+      <KpiRow
+        items={[
+          {
+            icon: 'sim_card',
+            color: 'var(--uk-ac)',
+            label: 'SIMs available',
+            value: sectionValue(simStock?.available, simStock?.error),
+            sub: simStock?.lowStock ? 'low stock' : undefined,
+            danger: !!simStock?.lowStock,
+          },
+          {
+            icon: 'donut_small',
+            color: 'var(--uk-secondary)',
+            label: 'SIMs assigned',
+            value: sectionValue(simStock?.consumed, simStock?.error),
+            sub:
+              simStock?.pctAssigned != null
+                ? `${simStock.pctAssigned}% of pool`
+                : undefined,
+          },
+          {
+            icon: 'cell_tower',
+            color: 'var(--uk-success-bright)',
+            label: 'Nodes ready to install',
+            value: sectionValue(nodes.length || null, nodesSection?.error),
+          },
+          {
+            icon: 'memory',
+            color: 'var(--uk-beige)',
+            label: 'Components in stock',
+            value: sectionValue(componentsSection?.total, componentsSection?.error),
+          },
+        ]}
+      />
       <div style={{ marginBottom: 18 }}>
         <FilterChips
           options={[
@@ -48,88 +90,122 @@ export default function BizInventoryScreen() {
       </div>
 
       <div className="card card-pad">
-        {tab === 'SIMs' && (
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>SIM / ICCID</TableCell>
-                <TableCell>Status</TableCell>
-                <TableCell>Assigned customer</TableCell>
-                <TableCell>Site / network</TableCell>
-                <TableCell>Activation date</TableCell>
-                <TableCell>Issue</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {b.sims.map((r) => (
-                <TableRow key={r.iccid}>
-                  <TableCell className="tnum" style={{ fontWeight: 600 }}>
-                    {r.iccid}
-                  </TableCell>
-                  <TableCell>
-                    <StatusBadge status={r.status} variant="pill" />
-                  </TableCell>
-                  <TableCell className="tnum">{r.cust}</TableCell>
-                  <TableCell className="muted">{r.site}</TableCell>
-                  <TableCell className="muted">{r.date}</TableCell>
-                  <TableCell
-                    style={{
-                      color: r.issue !== '—' ? 'var(--uk-error-deep, #cf121b)' : 'var(--uk-ink-3)',
-                    }}
-                  >
-                    {r.issue}
-                  </TableCell>
-                </TableRow>
+        {loading ? (
+          <SkeletonTable cols={4} rows={4} />
+        ) : (
+          <>
+            {tab === 'SIMs' &&
+              (simStock?.error ? (
+                <EmptyState
+                  art="error"
+                  title="Couldn't load SIM stock"
+                  sub={simStock.error.message}
+                  cta="Try again"
+                  onCta={() => refetch()}
+                />
+              ) : (
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Metric</TableCell>
+                      <TableCell align="right">Count</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {(
+                      [
+                        ['Total in pool', simStock?.total],
+                        ['Available', simStock?.available],
+                        ['Assigned', simStock?.consumed],
+                      ] as const
+                    ).map(([label, value]) => (
+                      <TableRow key={label}>
+                        <TableCell style={{ fontWeight: 600 }}>{label}</TableCell>
+                        <TableCell align="right" className="tnum">
+                          {value ?? '—'}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
               ))}
-            </TableBody>
-          </Table>
-        )}
-        {tab === 'Nodes' && (
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>Serial</TableCell>
-                <TableCell>Type</TableCell>
-                <TableCell>Status</TableCell>
-                <TableCell>Site</TableCell>
-                <TableCell>Date</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {b.nodes.map((r) => (
-                <TableRow key={r.serial}>
-                  <TableCell className="tnum" style={{ fontWeight: 600 }}>
-                    {r.serial}
-                  </TableCell>
-                  <TableCell className="muted">{r.type}</TableCell>
-                  <TableCell>
-                    <StatusBadge status={r.status} variant="pill" />
-                  </TableCell>
-                  <TableCell>{r.site}</TableCell>
-                  <TableCell className="muted">{r.date}</TableCell>
-                </TableRow>
+            {tab === 'Nodes' &&
+              (nodesSection?.error ? (
+                <EmptyState
+                  art="error"
+                  title="Couldn't load nodes"
+                  sub={nodesSection.error.message}
+                  cta="Try again"
+                  onCta={() => refetch()}
+                />
+              ) : nodes.length === 0 ? (
+                <EmptyState
+                  art="node"
+                  title="No unassigned nodes"
+                  sub="All registered nodes are deployed to sites."
+                />
+              ) : (
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Serial</TableCell>
+                      <TableCell>Type</TableCell>
+                      <TableCell>Status</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {nodes.map((n) => (
+                      <TableRow key={n.id}>
+                        <TableCell className="tnum" style={{ fontWeight: 600 }}>
+                          {n.serial}
+                        </TableCell>
+                        <TableCell className="muted">{n.type}</TableCell>
+                        <TableCell>
+                          <StatusBadge status="available" variant="pill">
+                            Available
+                          </StatusBadge>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
               ))}
-            </TableBody>
-          </Table>
-        )}
-        {tab === 'Hardware' && (
-          <div style={{ textAlign: 'center', padding: 48, color: 'var(--uk-ink-3)' }}>
-            <MemoryRounded sx={{ fontSize: 42 }} />
-            <div
-              style={{
-                fontFamily: 'var(--font-display)',
-                fontSize: 18,
-                fontWeight: 500,
-                marginTop: 12,
-                color: 'var(--uk-ink)',
-              }}
-            >
-              Hardware
-            </div>
-            <div style={{ fontSize: 13.5, marginTop: 6 }}>
-              Routers, amplifiers and accessories in inventory.
-            </div>
-          </div>
+            {tab === 'Hardware' &&
+              (componentsSection?.error ? (
+                <EmptyState
+                  art="error"
+                  title="Couldn't load components"
+                  sub={componentsSection.error.message}
+                  cta="Try again"
+                  onCta={() => refetch()}
+                />
+              ) : categories.length === 0 ? (
+                <EmptyState
+                  art="search"
+                  title="No components"
+                  sub="Components registered to your org appear here."
+                />
+              ) : (
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Category</TableCell>
+                      <TableCell align="right">Count</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {categories.map((c) => (
+                      <TableRow key={c.category}>
+                        <TableCell style={{ fontWeight: 600 }}>{c.category}</TableCell>
+                        <TableCell align="right" className="tnum">
+                          {c.count}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ))}
+          </>
         )}
       </div>
     </div>

--- a/interfaces/ukama-console/src/app/(dashboard)/business/_components/BizPackagesScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/business/_components/BizPackagesScreen.tsx
@@ -7,6 +7,8 @@
  */
 'use client';
 
+/** Packages — selling & performance, wired to `commerceView.plans`
+ *  (MRR/ARPU/revenue share computed server-side). */
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -14,28 +16,47 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Meter from '@/components/Meter';
 
-/** Packages — how the data packages sell and perform (biz-home.jsx). */
+import { usePackagesDashboardQuery } from '@/client/graphql/commerce.generated';
 import BarList from '@/components/BarList';
 import DateChip from '@/components/DateChip';
+import { EmptyState } from '@/components/EmptyState';
 import { KpiRow } from '@/components/Kpi';
 import PageHeader from '@/components/PageHeader';
 import SectionCard from '@/components/SectionCard';
+import { sectionValue } from '@/components/SectionFallback';
+import SkeletonTable from '@/components/data-table/SkeletonTable';
 import StatusBadge from '@/components/StatusBadge';
-import { BIZ_HOME, BIZ_PACKAGES, PLANS } from '@/data';
+import { useUiPrefs } from '@/lib/store';
+
+const BAR_COLORS = [
+  'var(--uk-ac)',
+  'var(--uk-secondary)',
+  'var(--uk-success-bright)',
+  'var(--uk-beige)',
+  'var(--uk-orange)',
+];
+
+const money = (value?: number | null): string =>
+  value == null ? '—' : `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
 
 export default function BizPackagesScreen() {
-  const b = BIZ_PACKAGES;
-  const total = PLANS.reduce((s, p) => s + p.subs, 0);
-  const sold = b.rows.reduce((s, r) => s + r.sold, 0);
-  const mrr = PLANS.reduce((s, p) => s + p.subs * p.price, 0);
-  const arpu = mrr / total;
-  const byRev = [...PLANS]
-    .map((p) => ({ name: p.name, rev: p.subs * p.price }))
-    .sort((a, z) => z.rev - a.rev);
-  const top = byRev[0];
-  const topShare = top ? Math.round((top.rev / mrr) * 100) : 0;
-  const topPkgs = BIZ_HOME.topPackages;
-  const maxSold = Math.max(...topPkgs.map((p) => p.sold));
+  const networkId = useUiPrefs((s) => s.networkId);
+  const { data, loading, refetch } = usePackagesDashboardQuery({
+    variables: { networkId },
+  });
+  const section = data?.commerceView.plans;
+  const plans = section?.plans ?? [];
+  const byRevenue = [...plans].sort((a, z) => z.revenue - a.revenue);
+  const top = byRevenue[0];
+  const topPkgs = byRevenue.slice(0, 3);
+  const maxRevenue = Math.max(...topPkgs.map((p) => p.revenue), 1);
+  const mix = byRevenue
+    .filter((p) => p.revenue > 0)
+    .map((p, i) => ({
+      name: p.name,
+      value: p.revenue,
+      color: BAR_COLORS[i % BAR_COLORS.length] ?? 'var(--uk-ac)',
+    }));
 
   return (
     <div className="page">
@@ -51,29 +72,32 @@ export default function BizPackagesScreen() {
             icon: 'monetization_on',
             color: 'var(--uk-beige)',
             label: 'Monthly recurring revenue',
-            value: `$${mrr.toLocaleString()}`,
-            sub: 'estimated · all plans',
+            value: section?.error ? '—' : money(section?.mrr),
+            sub: 'paid this month',
           },
           {
             icon: 'payments',
             color: 'var(--uk-ac)',
             label: 'ARPU',
-            value: `$${arpu.toFixed(2)}`,
-            sub: 'avg revenue / customer',
+            value: section?.error ? '—' : money(section?.arpu),
+            sub: 'avg revenue / active SIM',
           },
           {
             icon: 'donut_small',
             color: 'var(--uk-success-bright)',
             label: 'Top plan by revenue',
-            value: top ? top.name : '—',
-            sub: `${topShare}% of revenue`,
+            value: top && top.revenue > 0 ? top.name : '—',
+            sub: top && top.revenue > 0 ? `${top.revenueSharePct}% of revenue` : undefined,
           },
           {
             icon: 'sell',
             color: 'var(--uk-secondary)',
-            label: 'Packages sold',
-            value: sold.toLocaleString(),
-            sub: `across ${b.rows.length} packages`,
+            label: 'Active plans',
+            value: sectionValue(
+              plans.filter((p) => p.active).length || null,
+              section?.error
+            ),
+            sub: `across ${plans.length} packages`,
           },
         ]}
       />
@@ -83,36 +107,54 @@ export default function BizPackagesScreen() {
           <div className="sec-title">Package performance</div>
         </div>
         <div className="tbl-wrap">
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>Package</TableCell>
-                <TableCell align="right">Price</TableCell>
-                <TableCell>Validity</TableCell>
-                <TableCell align="right">Sold</TableCell>
-                <TableCell align="right">Revenue</TableCell>
-                <TableCell align="right">Data used</TableCell>
-                <TableCell>Status</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {b.rows.map((r) => (
-                <TableRow key={r.pkg}>
-                  <TableCell style={{ fontWeight: 600 }}>{r.pkg}</TableCell>
-                  <TableCell align="right" className="tnum">{r.price}</TableCell>
-                  <TableCell className="muted">{r.validity}</TableCell>
-                  <TableCell align="right" className="tnum">{r.sold}</TableCell>
-                  <TableCell align="right" className="tnum" style={{ fontWeight: 600 }}>
-                    {r.revenue}
-                  </TableCell>
-                  <TableCell align="right" className="tnum muted">{r.data}</TableCell>
-                  <TableCell>
-                    <StatusBadge status={r.status} variant="pill" />
-                  </TableCell>
+          {loading ? (
+            <SkeletonTable cols={6} rows={4} />
+          ) : section?.error ? (
+            <EmptyState
+              art="error"
+              title="Couldn't load packages"
+              sub={section.error.message}
+              cta="Try again"
+              onCta={() => refetch()}
+            />
+          ) : plans.length === 0 ? (
+            <EmptyState art="invoice" title="No packages" sub="Create a data plan to get started." />
+          ) : (
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Package</TableCell>
+                  <TableCell align="right">Price</TableCell>
+                  <TableCell align="right">Active SIMs</TableCell>
+                  <TableCell align="right">Revenue</TableCell>
+                  <TableCell align="right">Share</TableCell>
+                  <TableCell>Status</TableCell>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHead>
+              <TableBody>
+                {byRevenue.map((p) => (
+                  <TableRow key={p.packageId}>
+                    <TableCell style={{ fontWeight: 600 }}>{p.name}</TableCell>
+                    <TableCell align="right" className="tnum">
+                      {p.amount} {p.currency}
+                    </TableCell>
+                    <TableCell align="right" className="tnum">
+                      {p.attachCount ?? '—'}
+                    </TableCell>
+                    <TableCell align="right" className="tnum" style={{ fontWeight: 600 }}>
+                      {money(p.revenue)}
+                    </TableCell>
+                    <TableCell align="right" className="tnum muted">
+                      {p.revenueSharePct}%
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge status={p.active ? 'active' : 'inactive'} variant="pill" />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
         </div>
       </div>
 
@@ -121,62 +163,77 @@ export default function BizPackagesScreen() {
           title="Top packages"
           right={
             <span style={{ fontSize: 12.5, color: 'var(--uk-ink-3)' }}>
-              Best sellers this month
+              By revenue collected
             </span>
           }
         >
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            {topPkgs.map((p, i) => (
-              <div
-                key={p.name}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 14,
-                  padding: '13px 0',
-                  borderBottom:
-                    i < topPkgs.length - 1 ? '1px solid var(--uk-line-soft)' : 'none',
-                }}
-              >
-                <span
-                  className="tnum"
+          {topPkgs.length === 0 || section?.error ? (
+            <div style={{ padding: 24, fontSize: 13, color: 'var(--uk-ink-3)' }}>
+              No package revenue yet.
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              {topPkgs.map((p, i) => (
+                <div
+                  key={p.packageId}
                   style={{
-                    fontFamily: 'var(--font-display)',
-                    fontSize: 15,
-                    fontWeight: 500,
-                    color: 'var(--uk-ink-3)',
-                    width: 18,
-                    flex: 'none',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 14,
+                    padding: '13px 0',
+                    borderBottom:
+                      i < topPkgs.length - 1 ? '1px solid var(--uk-line-soft)' : 'none',
                   }}
                 >
-                  {i + 1}
-                </span>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div
+                  <span
+                    className="tnum"
                     style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      gap: 12,
-                      marginBottom: 6,
+                      fontFamily: 'var(--font-display)',
+                      fontSize: 15,
+                      fontWeight: 500,
+                      color: 'var(--uk-ink-3)',
+                      width: 18,
+                      flex: 'none',
                     }}
                   >
-                    <span style={{ fontSize: 13.5, fontWeight: 600 }}>{p.name}</span>
-                    <span
-                      className="tnum"
-                      style={{ fontSize: 13, color: 'var(--uk-ink-2)', whiteSpace: 'nowrap' }}
+                    {i + 1}
+                  </span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        gap: 12,
+                        marginBottom: 6,
+                      }}
                     >
-                      <b style={{ color: 'var(--uk-ink)' }}>${p.revenue.toLocaleString()}</b> ·{' '}
-                      {p.sold} sold
-                    </span>
+                      <span style={{ fontSize: 13.5, fontWeight: 600 }}>{p.name}</span>
+                      <span
+                        className="tnum"
+                        style={{ fontSize: 13, color: 'var(--uk-ink-2)', whiteSpace: 'nowrap' }}
+                      >
+                        <b style={{ color: 'var(--uk-ink)' }}>{money(p.revenue)}</b>
+                        {p.attachCount != null ? ` · ${p.attachCount} active` : ''}
+                      </span>
+                    </div>
+                    <Meter
+                      value={Math.round((p.revenue / maxRevenue) * 100)}
+                      color={BAR_COLORS[i % BAR_COLORS.length]}
+                    />
                   </div>
-                  <Meter value={Math.round((p.sold / maxSold) * 100)} color={p.color} />
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
         </SectionCard>
         <SectionCard title="Package revenue mix">
-          <BarList rows={b.mix} />
+          {mix.length === 0 || section?.error ? (
+            <div style={{ padding: 24, fontSize: 13, color: 'var(--uk-ink-3)' }}>
+              No package revenue yet.
+            </div>
+          ) : (
+            <BarList rows={mix} />
+          )}
         </SectionCard>
       </div>
     </div>

--- a/interfaces/ukama-console/src/app/(dashboard)/business/_components/BizSalesScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/business/_components/BizSalesScreen.tsx
@@ -7,17 +7,44 @@
  */
 'use client';
 
-/** Revenue — the single most important number (biz-home.jsx BizSales). */
+/** Revenue — the single most important number, wired to `commerceView`. */
+import Skeleton from '@mui/material/Skeleton';
+
+import { useRevenueOverviewQuery } from '@/client/graphql/commerce.generated';
 import BarList from '@/components/BarList';
-import { LineChart } from '@/components/charts';
 import DateChip from '@/components/DateChip';
 import { Delta, KpiRow } from '@/components/Kpi';
 import PageHeader from '@/components/PageHeader';
 import SectionCard from '@/components/SectionCard';
-import { BIZ_SALES } from '@/data';
+import { sectionValue } from '@/components/SectionFallback';
+import { useUiPrefs } from '@/lib/store';
+
+const money = (value?: number | null): string =>
+  value == null ? '—' : `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
 
 export default function BizSalesScreen() {
-  const b = BIZ_SALES;
+  const networkId = useUiPrefs((s) => s.networkId);
+  const { data, loading } = useRevenueOverviewQuery({
+    variables: { networkId },
+  });
+  const revenue = data?.commerceView.revenue;
+  const plansSection = data?.commerceView.plans;
+  const BAR_COLORS = [
+    'var(--uk-ac)',
+    'var(--uk-secondary)',
+    'var(--uk-success-bright)',
+    'var(--uk-beige)',
+    'var(--uk-orange)',
+  ];
+  const byPackage = (plansSection?.plans ?? [])
+    .filter((p) => p.revenue > 0)
+    .sort((a, z) => z.revenue - a.revenue)
+    .map((p, i) => ({
+      name: p.name,
+      value: p.revenue,
+      color: BAR_COLORS[i % BAR_COLORS.length] ?? 'var(--uk-ac)',
+    }));
+
   return (
     <div className="page">
       <PageHeader
@@ -30,68 +57,109 @@ export default function BizSalesScreen() {
         <div className="sec-title" style={{ marginBottom: 12 }}>
           Revenue collected
         </div>
-        <div style={{ display: 'flex', alignItems: 'flex-end', gap: 20, flexWrap: 'wrap' }}>
-          <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
-            <span
-              className="tnum"
-              style={{
-                fontFamily: 'var(--font-display)',
-                fontSize: 48,
-                fontWeight: 500,
-                lineHeight: 1,
-              }}
-            >
-              $48,210
-            </span>
-            <Delta fontSize={14}>+22% YoY</Delta>
-          </div>
-          <div style={{ flex: 1, minWidth: 20 }} />
-          <div style={{ display: 'flex', gap: 30, flexWrap: 'wrap' }}>
-            {(
-              [
-                ['This month', '$1,284'],
-                ['Last month', '$1,206'],
-                ['Monthly average', '$4,017'],
-              ] as const
-            ).map(([k, v]) => (
-              <div key={k}>
-                <div style={{ fontSize: 12, color: 'var(--uk-ink-3)' }}>{k}</div>
-                <div
-                  className="tnum"
-                  style={{
-                    fontFamily: 'var(--font-display)',
-                    fontSize: 19,
-                    fontWeight: 500,
-                    marginTop: 2,
-                  }}
-                >
-                  {v}
+        {loading ? (
+          <Skeleton variant="rounded" sx={{ height: 72 }} />
+        ) : (
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: 20, flexWrap: 'wrap' }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+              <span
+                className="tnum"
+                style={{
+                  fontFamily: 'var(--font-display)',
+                  fontSize: 48,
+                  fontWeight: 500,
+                  lineHeight: 1,
+                }}
+              >
+                {revenue?.error ? '—' : money(revenue?.totalPaid)}
+              </span>
+              {revenue?.momPct != null && (
+                <Delta fontSize={14}>
+                  {revenue.momPct >= 0 ? '+' : ''}
+                  {revenue.momPct}% MoM
+                </Delta>
+              )}
+            </div>
+            <div style={{ flex: 1, minWidth: 20 }} />
+            <div style={{ display: 'flex', gap: 30, flexWrap: 'wrap' }}>
+              {(
+                [
+                  ['This month', revenue?.error ? '—' : money(revenue?.monthPaid)],
+                  ['Last month', revenue?.error ? '—' : money(revenue?.prevMonthPaid)],
+                  ['Pending', revenue?.error ? '—' : money(revenue?.totalPending)],
+                ] as const
+              ).map(([k, v]) => (
+                <div key={k}>
+                  <div style={{ fontSize: 12, color: 'var(--uk-ink-3)' }}>{k}</div>
+                  <div
+                    className="tnum"
+                    style={{
+                      fontFamily: 'var(--font-display)',
+                      fontSize: 19,
+                      fontWeight: 500,
+                      marginTop: 2,
+                    }}
+                  >
+                    {v}
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-        </div>
+        )}
         <div style={{ fontSize: 12.5, color: 'var(--uk-ink-3)', marginTop: 8 }}>
-          Collected over the last 12 months
+          All payments collected to date
         </div>
       </div>
 
-      <KpiRow items={b.kpis} />
-
-      <SectionCard
-        title="Revenue trend"
-        style={{ marginBottom: 'var(--uk-gap)' }}
-        right={<span style={{ fontSize: 12.5, color: 'var(--uk-ink-3)' }}>Last 9 weeks</span>}
-      >
-        <LineChart data={b.trend} height={240} />
-      </SectionCard>
+      <KpiRow
+        items={[
+          {
+            icon: 'monetization_on',
+            color: 'var(--uk-beige)',
+            label: 'Revenue this month',
+            value: revenue?.error ? '—' : money(revenue?.monthPaid),
+            sub:
+              revenue?.momPct != null
+                ? `${revenue.momPct >= 0 ? '+' : ''}${revenue.momPct}% vs last month`
+                : undefined,
+          },
+          {
+            icon: 'payments',
+            color: 'var(--uk-ac)',
+            label: 'Pending payments',
+            value: revenue?.error ? '—' : money(revenue?.totalPending),
+          },
+          {
+            icon: 'donut_small',
+            color: 'var(--uk-success-bright)',
+            label: 'Collected to date',
+            value: revenue?.error ? '—' : money(revenue?.totalPaid),
+          },
+          {
+            icon: 'sell',
+            color: 'var(--uk-secondary)',
+            label: 'Plans earning revenue',
+            value: sectionValue(byPackage.length || null, plansSection?.error),
+          },
+        ]}
+      />
 
       <div className="tile-grid" style={{ gridTemplateColumns: '1fr 1fr' }}>
-        <SectionCard title="Revenue by site">
-          <BarList rows={b.bySite} />
-        </SectionCard>
         <SectionCard title="Revenue by package">
-          <BarList rows={b.byPackage} />
+          {plansSection?.error || byPackage.length === 0 ? (
+            <div style={{ padding: 24, fontSize: 13, color: 'var(--uk-ink-3)' }}>
+              {plansSection?.error ? '—' : 'No package revenue yet.'}
+            </div>
+          ) : (
+            <BarList rows={byPackage} />
+          )}
+        </SectionCard>
+        <SectionCard title="Revenue by site">
+          {/* TODO(backend-gap #10): per-site revenue rollup */}
+          <div style={{ padding: 24, fontSize: 13, color: 'var(--uk-ink-3)' }}>
+            Per-site revenue is not available yet.
+          </div>
         </SectionCard>
       </div>
     </div>

--- a/interfaces/ukama-console/src/app/(dashboard)/business/manage/_components/BillingScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/business/manage/_components/BillingScreen.tsx
@@ -18,18 +18,25 @@ import BoltRounded from '@mui/icons-material/BoltRounded';
 import CreditCardRounded from '@mui/icons-material/CreditCardRounded';
 import DownloadRounded from '@mui/icons-material/DownloadRounded';
 import ReceiptLongRounded from '@mui/icons-material/ReceiptLongRounded';
+import { useBillingOverviewQuery } from '@/client/graphql/commerce.generated';
+import { EmptyState } from '@/components/EmptyState';
 import SkeletonTable from '@/components/data-table/SkeletonTable';
 import TableFooter from '@/components/data-table/TableFooter';
 import PageHeader from '@/components/PageHeader';
+import { sectionValue } from '@/components/SectionFallback';
 import StatusBadge from '@/components/StatusBadge';
 import { useToast } from '@/components/ToastProvider';
-import { BILLING } from '@/data';
-import { useFirstLoad } from '@/lib/useFirstLoad';
+import { useUiPrefs } from '@/lib/store';
 
 export default function BillingScreen({ embed }: { embed?: boolean }) {
-  const b = BILLING;
-  const invLoading = useFirstLoad('billing-invoices');
   const toast = useToast();
+  const networkId = useUiPrefs((s) => s.networkId);
+  const { data, loading: invLoading, refetch } = useBillingOverviewQuery({
+    variables: { networkId },
+  });
+  const invoicesSection = data?.commerceView.invoices;
+  const balanceSection = data?.commerceView.balance;
+  const invoices = invoicesSection?.reports ?? [];
 
   const body = (
     <>
@@ -39,7 +46,7 @@ export default function BillingScreen({ embed }: { embed?: boolean }) {
       >
         <div className="card card-pad" style={{ display: 'flex', flexDirection: 'column' }}>
           <div style={{ fontSize: 13, color: 'var(--uk-ink-2)' }}>
-            Current balance · {b.cycle}
+            Current balance
           </div>
           <div
             className="tnum"
@@ -50,24 +57,20 @@ export default function BillingScreen({ embed }: { embed?: boolean }) {
               margin: '6px 0 2px',
             }}
           >
-            ${b.current.toLocaleString(undefined, { minimumFractionDigits: 2 })}
+            {/* TODO(backend-gap #11): outstanding amount needs an invoice
+                amount field on the reports list */}
+            {sectionValue(null, balanceSection?.error ?? null)}
           </div>
           <div style={{ fontSize: 13, color: 'var(--uk-ink-2)' }}>
-            Due {b.due} · {b.method}
-          </div>
-          <hr className="divider" style={{ margin: '16px 0' }} />
-          <div style={{ display: 'grid', gap: 10 }}>
-            {b.breakdown.map((r) => (
-              <div
-                key={r.label}
-                style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13.5 }}
-              >
-                <span style={{ color: 'var(--uk-ink-2)' }}>{r.label}</span>
-                <span className="tnum" style={{ fontWeight: 600 }}>
-                  ${r.amt.toFixed(2)}
-                </span>
-              </div>
-            ))}
+            {balanceSection?.error
+              ? '—'
+              : `${balanceSection?.outstandingCount ?? 0} unpaid invoice${
+                  (balanceSection?.outstandingCount ?? 0) === 1 ? '' : 's'
+                }${
+                  balanceSection?.latestUnpaidPeriod
+                    ? ` · latest ${balanceSection.latestUnpaidPeriod}`
+                    : ''
+                }`}
           </div>
           <div style={{ marginTop: 'auto', paddingTop: 16 }}>
             <Button
@@ -88,10 +91,9 @@ export default function BillingScreen({ embed }: { embed?: boolean }) {
           <div style={{ display: 'grid', gap: 14 }}>
             {(
               [
-                ['Plan', b.plan],
-                ['Payment method', b.method],
-                ['Billing cycle', b.cycle],
-                ['Next invoice due', b.due],
+                ['Billing cycle', 'Monthly'],
+                ['Unpaid invoices', sectionValue(balanceSection?.outstandingCount, balanceSection?.error)],
+                ['Latest unpaid period', balanceSection?.latestUnpaidPeriod ?? '—'],
               ] as const
             ).map(([k, v]) => (
               <div key={k}>
@@ -125,6 +127,16 @@ export default function BillingScreen({ embed }: { embed?: boolean }) {
         <div className="tbl-wrap">
           {invLoading ? (
             <SkeletonTable cols={5} rows={4} />
+          ) : invoicesSection?.error ? (
+            <EmptyState
+              art="error"
+              title="Couldn't load invoices"
+              sub={invoicesSection.error.message}
+              cta="Try again"
+              onCta={() => refetch()}
+            />
+          ) : invoices.length === 0 ? (
+            <EmptyState art="invoice" title="No invoices yet" sub="Invoices appear here each cycle." />
           ) : (
             <Table>
               <TableHead>
@@ -137,15 +149,16 @@ export default function BillingScreen({ embed }: { embed?: boolean }) {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {b.invoices.map((inv) => (
+                {invoices.map((inv) => (
                   <TableRow key={inv.id}>
                     <TableCell className="tnum" style={{ fontWeight: 600 }}>
-                      {inv.id}
+                      {inv.id.slice(0, 8)}
                     </TableCell>
                     <TableCell>{inv.period}</TableCell>
-                    <TableCell align="right" className="tnum">${inv.amt.toFixed(2)}</TableCell>
+                    {/* TODO(backend-gap #11): invoice amount field */}
+                    <TableCell align="right" className="tnum">—</TableCell>
                     <TableCell>
-                      <StatusBadge status="paid" variant="pill" />
+                      <StatusBadge status={inv.isPaid ? 'paid' : 'pending'} variant="pill" />
                     </TableCell>
                     <TableCell>
                       <Button
@@ -163,7 +176,9 @@ export default function BillingScreen({ embed }: { embed?: boolean }) {
             </Table>
           )}
         </div>
-        {!invLoading && <TableFooter count={b.invoices.length} noun="invoices" />}
+        {!invLoading && !invoicesSection?.error && (
+          <TableFooter count={invoices.length} noun="invoices" />
+        )}
       </div>
     </>
   );

--- a/interfaces/ukama-console/src/app/(dashboard)/business/manage/_components/MembersScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/business/manage/_components/MembersScreen.tsx
@@ -24,17 +24,28 @@ import MailRounded from '@mui/icons-material/MailRounded';
 import MoreVertRounded from '@mui/icons-material/MoreVertRounded';
 import PersonAddRounded from '@mui/icons-material/PersonAddRounded';
 import PersonRemoveRounded from '@mui/icons-material/PersonRemoveRounded';
+import { useTeamListQuery } from '@/client/graphql/team.generated';
+import { EmptyState } from '@/components/EmptyState';
 import SkeletonTable from '@/components/data-table/SkeletonTable';
 import TableFooter from '@/components/data-table/TableFooter';
 import PageHeader from '@/components/PageHeader';
 import StatusBadge from '@/components/StatusBadge';
 import { useToast } from '@/components/ToastProvider';
-import { MEMBERS, ROLE_DESC } from '@/data';
-import type { Member } from '@/data';
-import { useFirstLoad } from '@/lib/useFirstLoad';
+import { ROLE_DESC } from '@/data';
 import InviteMemberDialog from './InviteMemberDialog';
 
-function MemberMenu({ m }: { m: Member }) {
+/** Team row view-model from the membersView composite (members +
+ *  invitations merged server-side; status: Active | Deactivated | Invited). */
+interface TeamRow {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  role: string;
+  status: string;
+  memberSince?: string | null;
+}
+
+function MemberMenu({ m }: { m: TeamRow }) {
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const toast = useToast();
   return (
@@ -84,14 +95,16 @@ function MemberMenu({ m }: { m: Member }) {
 }
 
 export default function MembersScreen() {
-  const loading = useFirstLoad('members');
   const [showInvite, setShowInvite] = useState(false);
+  const { data, loading, refetch } = useTeamListQuery();
+  const teamSection = data?.membersView.team;
+  const rows: TeamRow[] = teamSection?.rows ?? [];
 
   return (
     <div className="page">
       <PageHeader
         title="Members"
-        count={MEMBERS.length}
+        count={rows.length}
         sub="People with access to this organization."
         actions={
           <Button
@@ -107,6 +120,20 @@ export default function MembersScreen() {
         <div className="tbl-wrap">
           {loading ? (
             <SkeletonTable cols={5} rows={5} lead />
+          ) : teamSection?.error ? (
+            <EmptyState
+              art="error"
+              title="Couldn't load members"
+              sub={teamSection.error.message}
+              cta="Try again"
+              onCta={() => refetch()}
+            />
+          ) : rows.length === 0 ? (
+            <EmptyState
+              art="people"
+              title="No members yet"
+              sub="Invite teammates to give them access."
+            />
           ) : (
             <Table>
               <TableHead>
@@ -119,20 +146,20 @@ export default function MembersScreen() {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {MEMBERS.map((m) => (
+                {rows.map((m) => (
                   <TableRow key={m.id}>
                     <TableCell>
                       <div style={{ display: 'flex', alignItems: 'center', gap: 11 }}>
                         <span className="av-sm">
-                          {m.name
+                          {(m.name ?? m.email ?? '?')
                             .split(' ')
                             .map((x) => x[0])
                             .join('')}
                         </span>
                         <div>
-                          <div style={{ fontWeight: 600 }}>{m.name}</div>
+                          <div style={{ fontWeight: 600 }}>{m.name ?? '—'}</div>
                           <div className="muted" style={{ fontSize: 12 }}>
-                            {m.email}
+                            {m.email ?? '—'}
                           </div>
                         </div>
                       </div>
@@ -140,13 +167,21 @@ export default function MembersScreen() {
                     <TableCell>
                       <div style={{ fontWeight: 600 }}>{m.role}</div>
                       <div className="muted" style={{ fontSize: 12 }}>
-                        {ROLE_DESC[m.role]}
+                        {(ROLE_DESC as Record<string, string>)[m.role] ?? ''}
                       </div>
                     </TableCell>
-                    <TableCell className="muted">{m.last}</TableCell>
+                    <TableCell className="muted">{m.memberSince ?? '—'}</TableCell>
                     <TableCell>
-                      <StatusBadge status={m.status === 'active' ? 'active' : 'pending'}>
-                        {m.status === 'active' ? 'Active' : 'Pending'}
+                      <StatusBadge
+                        status={
+                          m.status === 'Active'
+                            ? 'active'
+                            : m.status === 'Invited'
+                              ? 'pending'
+                              : 'inactive'
+                        }
+                      >
+                        {m.status}
                       </StatusBadge>
                     </TableCell>
                     <TableCell>
@@ -158,7 +193,9 @@ export default function MembersScreen() {
             </Table>
           )}
         </div>
-        {!loading && <TableFooter count={MEMBERS.length} noun="members" />}
+        {!loading && !teamSection?.error && (
+          <TableFooter count={rows.length} noun="members" />
+        )}
       </div>
       {showInvite && <InviteMemberDialog onClose={() => setShowInvite(false)} />}
     </div>

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/NetworkHomeScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/NetworkHomeScreen.tsx
@@ -25,6 +25,7 @@ import PageHeader from '@/components/PageHeader';
 import { sectionValue } from '@/components/SectionFallback';
 import StatusBadge from '@/components/StatusBadge';
 import type { Site } from '@/data';
+import { POLL_OVERVIEW_MS, visiblePoll } from '@/lib/polling';
 import { useUiPrefs } from '@/lib/store';
 
 export default function NetworkHomeScreen() {
@@ -35,8 +36,17 @@ export default function NetworkHomeScreen() {
   const { data, loading, refetch } = useNetworkHomeQuery({
     variables: { networkId },
     skip: !networkId,
+    ...visiblePoll(POLL_OVERVIEW_MS),
   });
   const overview = data?.networkOverview;
+  const kpiByKey = new Map(
+    (overview?.kpis.metrics ?? []).map((m) => [m.key, m])
+  );
+  const kpiValue = (key: string, unit = ''): string => {
+    const entry = kpiByKey.get(key);
+    if (!entry || !entry.success) return '—';
+    return `${Math.round(entry.value * 100) / 100}${unit}`;
+  };
 
   // Map SiteDto → the map's Site view-model. Per-site uptime/subscriber
   // figures are metrics-phase data (kpis backend gap) — placeholders until
@@ -79,10 +89,9 @@ export default function NetworkHomeScreen() {
             {
               icon: 'network_check',
               color: 'var(--uk-success-bright)',
-              // TODO(metrics-phase): networkOverview.kpis (backend gap #5)
               label: 'Network uptime',
-              value: sectionValue(null, kpisGap),
-              sub: 'last 30 days',
+              value: kpisGap ? '—' : kpiValue('network_uptime', '%'),
+              sub: 'latest reading',
             },
             {
               icon: 'group',
@@ -93,9 +102,8 @@ export default function NetworkHomeScreen() {
             {
               icon: 'donut_small',
               color: 'var(--uk-beige)',
-              // TODO(metrics-phase): networkOverview.kpis (backend gap #5)
               label: 'Data volume',
-              value: sectionValue(null, kpisGap),
+              value: kpisGap ? '—' : kpiValue('data_usage'),
               unit: 'GB',
             },
             {

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/NetworkHomeScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/NetworkHomeScreen.tsx
@@ -7,65 +7,113 @@
  */
 'use client';
 
-/** Ops Home — KPIs + live network map with inline inspector (home.jsx). */
-import { useState } from 'react';
+/**
+ * Ops Home — KPIs + live network map, wired to the `networkOverview`
+ * composite (NetworkHome query). Section data follows the §4.5 contract:
+ * loading → skeleton, failed/not-implemented → "—", empty → empty state.
+ */
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Button from '@mui/material/Button';
+import Skeleton from '@mui/material/Skeleton';
+
+import { useNetworkHomeQuery } from '@/client/graphql/network-home.generated';
 import DateChip from '@/components/DateChip';
 import { KpiRow } from '@/components/Kpi';
 import MapPanel from '@/components/Map/MapPanel';
 import PageHeader from '@/components/PageHeader';
+import { sectionValue } from '@/components/SectionFallback';
 import StatusBadge from '@/components/StatusBadge';
-import { SITES } from '@/data';
+import type { Site } from '@/data';
+import { useUiPrefs } from '@/lib/store';
 
 export default function NetworkHomeScreen() {
   const router = useRouter();
+  const networkId = useUiPrefs((s) => s.networkId);
   const [sel, setSel] = useState<string | null>(null);
-  const site = SITES.find((s) => s.id === sel);
-  const online = SITES.filter((s) => s.status === 'online').length;
-  const avgUptime = (
-    SITES.reduce((a, s) => a + s.uptime, 0) / SITES.length
-  ).toFixed(1);
+
+  const { data, loading, refetch } = useNetworkHomeQuery({
+    variables: { networkId },
+    skip: !networkId,
+  });
+  const overview = data?.networkOverview;
+
+  // Map SiteDto → the map's Site view-model. Per-site uptime/subscriber
+  // figures are metrics-phase data (kpis backend gap) — placeholders until
+  // then; status derives from isDeactivated (honest, if coarse).
+  const mapSites: Site[] = useMemo(
+    () =>
+      (overview?.siteStats.sites ?? []).map((s) => ({
+        id: s.id,
+        name: s.name,
+        area: s.location,
+        status: s.isDeactivated ? 'offline' : 'online',
+        subs: 0,
+        nodes: 0,
+        uptime: 0,
+        battery: 0,
+        signal: null,
+        data: '',
+        lat: parseFloat(s.latitude) || 0,
+        lng: parseFloat(s.longitude) || 0,
+        plan: '',
+      })),
+    [overview?.siteStats.sites]
+  );
+
+  const site = mapSites.find((s) => s.id === sel);
+  const sitesTotal = mapSites.length;
+  const sitesOnline = mapSites.filter((s) => s.status === 'online').length;
+  const subStats = overview?.subscriberStats;
+  const kpisGap = overview?.kpis.error ?? null;
 
   return (
     <div className="page">
       <PageHeader title="Home" actions={<DateChip />} />
-      <KpiRow
-        cols={4}
-        items={[
-          {
-            icon: 'network_check',
-            color: 'var(--uk-success-bright)',
-            label: 'Network uptime',
-            value: `${avgUptime}%`,
-            sub: 'last 30 days',
-          },
-          {
-            icon: 'group',
-            color: 'var(--uk-secondary)',
-            label: 'Active customers',
-            value: '1,284',
-          },
-          {
-            icon: 'donut_small',
-            color: 'var(--uk-beige)',
-            label: 'Data volume',
-            value: '312',
-            unit: 'GB',
-          },
-          {
-            icon: 'cell_tower',
-            color: 'var(--uk-ac)',
-            label: 'Sites online',
-            value: `${online}/${SITES.length}`,
-            sub:
-              online < SITES.length
-                ? `${SITES.length - online} need attention`
-                : 'all healthy',
-            danger: online < SITES.length,
-          },
-        ]}
-      />
+      {loading ? (
+        <Skeleton variant="rounded" sx={{ width: '100%', height: 96 }} />
+      ) : (
+        <KpiRow
+          cols={4}
+          items={[
+            {
+              icon: 'network_check',
+              color: 'var(--uk-success-bright)',
+              // TODO(metrics-phase): networkOverview.kpis (backend gap #5)
+              label: 'Network uptime',
+              value: sectionValue(null, kpisGap),
+              sub: 'last 30 days',
+            },
+            {
+              icon: 'group',
+              color: 'var(--uk-secondary)',
+              label: 'Active customers',
+              value: sectionValue(subStats?.active, subStats?.error),
+            },
+            {
+              icon: 'donut_small',
+              color: 'var(--uk-beige)',
+              // TODO(metrics-phase): networkOverview.kpis (backend gap #5)
+              label: 'Data volume',
+              value: sectionValue(null, kpisGap),
+              unit: 'GB',
+            },
+            {
+              icon: 'cell_tower',
+              color: 'var(--uk-ac)',
+              label: 'Sites online',
+              value: overview?.siteStats.error
+                ? '—'
+                : `${sitesOnline}/${sitesTotal}`,
+              sub:
+                sitesOnline < sitesTotal
+                  ? `${sitesTotal - sitesOnline} need attention`
+                  : 'all healthy',
+              danger: sitesOnline < sitesTotal,
+            },
+          ]}
+        />
+      )}
 
       <div
         className="card"
@@ -85,7 +133,18 @@ export default function NetworkHomeScreen() {
           <div className="sec-title">Network</div>
         </div>
         <div style={{ flex: 1, position: 'relative', minHeight: 300, padding: '16px 20px' }}>
-          <MapPanel sites={SITES} selected={sel} onSelect={(s) => setSel(s.id)} />
+          {loading ? (
+            <Skeleton variant="rounded" sx={{ width: '100%', height: '100%', minHeight: 280 }} />
+          ) : overview?.siteStats.error ? (
+            <div style={{ padding: 24, color: 'var(--uk-ink-2)', fontSize: 13 }}>
+              Couldn&apos;t load sites.{' '}
+              <Button size="small" onClick={() => refetch()}>
+                Retry
+              </Button>
+            </div>
+          ) : (
+            <MapPanel sites={mapSites} selected={sel} onSelect={(s) => setSel(s.id)} />
+          )}
         </div>
         {site && (
           <div style={{ padding: '0 20px 16px' }}>
@@ -107,7 +166,7 @@ export default function NetworkHomeScreen() {
                   <StatusBadge status={site.status} />
                 </div>
                 <div style={{ fontSize: 12.5, color: 'var(--uk-ink-2)', marginTop: 3 }}>
-                  {site.subs} customers · {site.uptime}% uptime
+                  {site.area || '—'}
                 </div>
               </div>
               <Button

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/NodeDetailScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/NodeDetailScreen.tsx
@@ -23,15 +23,20 @@ import PowerSettingsNewRounded from '@mui/icons-material/PowerSettingsNewRounded
 import RestartAltRounded from '@mui/icons-material/RestartAltRounded';
 import SyncRounded from '@mui/icons-material/SyncRounded';
 import WifiOffRounded from '@mui/icons-material/WifiOffRounded';
+import Skeleton from '@mui/material/Skeleton';
+
+import { useNodeDetailQuery } from '@/client/graphql/node-detail.generated';
 import AppTabs from '@/components/AppTabs';
 import { LineChart } from '@/components/charts';
 import DetailPicker from '@/components/DetailPicker';
+import { EmptyState } from '@/components/EmptyState';
 import KV from '@/components/KV';
 import PageHeader from '@/components/PageHeader';
 import SectionCard from '@/components/SectionCard';
+import { sectionValue } from '@/components/SectionFallback';
 import StatusBadge from '@/components/StatusBadge';
 import { useToast } from '@/components/ToastProvider';
-import { NODES } from '@/data';
+import { toUkamaNode } from '@/lib/mappers/nodes';
 import { series } from '@/lib/series';
 
 const NODE_TEMP = series(46, 22, 0.18, 0.12);
@@ -141,14 +146,48 @@ function PowerMenu({ serial }: { serial: string }) {
 export default function NodeDetailScreen({ nodeId }: { nodeId: string }) {
   const router = useRouter();
   const toast = useToast();
-  const n = NODES.find((x) => x.id === nodeId) ?? NODES[0];
   const [tab, setTab] = useState('Overview');
-  if (!n) return null;
 
+  const { data, loading, refetch } = useNodeDetailQuery({
+    variables: { nodeId },
+  });
+  const view = data?.nodeView;
+  const nodeSection = view?.node;
+  const healthSection = view?.health;
+  const softwareSection = view?.software;
+  const kpisGap = view?.kpis.error ?? null;
+
+  if (loading) {
+    return (
+      <div className="page">
+        <PageHeader crumb={['Nodes', nodeId]} title={`Node ${nodeId}`} />
+        <Skeleton variant="rounded" sx={{ height: 42, mb: 2 }} />
+        <Skeleton variant="rounded" sx={{ height: 420 }} />
+      </div>
+    );
+  }
+  if (!nodeSection?.node) {
+    return (
+      <div className="page">
+        <PageHeader crumb={['Nodes', nodeId]} title={`Node ${nodeId}`} />
+        <div className="card">
+          <EmptyState
+            art="error"
+            title="Couldn't load node"
+            sub={nodeSection?.error?.message ?? 'Node not found.'}
+            cta="Try again"
+            onCta={() => refetch()}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const n = toUkamaNode(nodeSection.node);
   const off = n.status === 'offline';
-  const hot = (n.temp ?? 0) > 55;
-  const tempTrx = off ? null : n.temp;
-  const tempCom = off || n.temp == null ? null : n.temp + 3;
+  const healthRows = healthSection?.health?.system?.slice(0, 4) ?? [];
+  const firstSoftware = softwareSection?.softwares?.software?.[0];
+  const updateAvailable = firstSoftware?.status === 'update_available';
 
   return (
     <div className="page">
@@ -172,7 +211,7 @@ export default function NodeDetailScreen({ nodeId }: { nodeId: string }) {
       <div className="detail-subrow">
         <DetailPicker
           value={{ id: n.id, label: n.serial, status: n.status }}
-          items={NODES.map((x) => ({ id: x.id, label: x.serial, status: x.status }))}
+          items={[{ id: n.id, label: n.serial, status: n.status }]}
           onPick={(it) => router.push(`/network/nodes/${it.id}`)}
         />
         <StatusBadge status={n.status} />
@@ -188,28 +227,28 @@ export default function NodeDetailScreen({ nodeId }: { nodeId: string }) {
           <SectionCard title="Node information">
             <KV k="Model type" v={n.type} />
             <KV k="Serial #" v={n.serial} />
-            <KV k="Firmware" v={n.fw} />
-            <KV k="Node group" v="Default group" />
+            <KV
+              k="Firmware"
+              v={firstSoftware?.currentVersion ?? '—'}
+            />
+            <KV k="Site" v={n.site} />
           </SectionCard>
           <SectionCard title="Node health">
-            <KV
-              k="Temp. (TRX)"
-              v={tempTrx != null ? tempTrx + ' °C' : '—'}
-              warn={hot}
-              vColor={hot ? 'var(--uk-orange)' : null}
-            />
-            <KV
-              k="Temp. (COM)"
-              v={tempCom != null ? tempCom + ' °C' : '—'}
-              warn={hot}
-              vColor={hot ? 'var(--uk-orange)' : null}
-            />
-            <KV k="CPU load" v={off ? '—' : n.cpu + '%'} />
-            <KV k="Memory" v={off ? '—' : n.mem + '%'} />
+            {healthSection?.error || healthRows.length === 0 ? (
+              <>
+                <KV k="Temp. (TRX)" v="—" />
+                <KV k="Temp. (COM)" v="—" />
+                <KV k="CPU load" v="—" />
+                <KV k="Memory" v="—" />
+              </>
+            ) : (
+              healthRows.map((row) => <KV key={row.name} k={row.name} v={row.value} />)
+            )}
           </SectionCard>
           <SectionCard title="Customers">
-            <KV k="Attached" v={off ? '0' : '100'} />
-            <KV k="Active" v={off ? '0' : '86'} />
+            {/* nodeView.kpis backend gap (#6) — attach counts land with metrics */}
+            <KV k="Attached" v={sectionValue(null, kpisGap)} />
+            <KV k="Active" v={sectionValue(null, kpisGap)} />
           </SectionCard>
         </div>
 
@@ -242,14 +281,22 @@ export default function NodeDetailScreen({ nodeId }: { nodeId: string }) {
           )}
           {tab === 'Software' && (
             <SectionCard title="Software & firmware">
-              <KV k="Firmware version" v={n.fw} />
-              <KV k="Channel" v="Stable" />
-              <KV k="Last update" v="12 Oct 2025" />
-              <KV
-                k="Update available"
-                v={n.fw === '13.2.1' ? 'Up to date' : '13.2.1'}
-                vColor={n.fw === '13.2.1' ? 'var(--uk-success)' : 'var(--uk-ac-dark)'}
-              />
+              {softwareSection?.error ? (
+                <>
+                  <KV k="Firmware version" v="—" />
+                  <KV k="Update available" v="—" />
+                </>
+              ) : (
+                <>
+                  <KV k="Firmware version" v={firstSoftware?.currentVersion ?? '—'} />
+                  <KV k="Release date" v={firstSoftware?.releaseDate ?? '—'} />
+                  <KV
+                    k="Update available"
+                    v={updateAvailable ? (firstSoftware?.desiredVersion ?? 'Yes') : 'Up to date'}
+                    vColor={updateAvailable ? 'var(--uk-ac-dark)' : 'var(--uk-success)'}
+                  />
+                </>
+              )}
               <div style={{ marginTop: 16 }}>
                 <Button
                   variant="outlined"

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/NodeDetailScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/NodeDetailScreen.tsx
@@ -37,6 +37,7 @@ import { sectionValue } from '@/components/SectionFallback';
 import StatusBadge from '@/components/StatusBadge';
 import { useToast } from '@/components/ToastProvider';
 import { toUkamaNode } from '@/lib/mappers/nodes';
+import { POLL_LIVE_MS, visiblePoll } from '@/lib/polling';
 import { series } from '@/lib/series';
 
 const NODE_TEMP = series(46, 22, 0.18, 0.12);
@@ -150,12 +151,18 @@ export default function NodeDetailScreen({ nodeId }: { nodeId: string }) {
 
   const { data, loading, refetch } = useNodeDetailQuery({
     variables: { nodeId },
+    ...visiblePoll(POLL_LIVE_MS),
   });
   const view = data?.nodeView;
   const nodeSection = view?.node;
   const healthSection = view?.health;
   const softwareSection = view?.software;
   const kpisGap = view?.kpis.error ?? null;
+  const kpiByKey = new Map(
+    (view?.kpis.metrics ?? [])
+      .filter((m) => m.success)
+      .map((m) => [m.key, Math.round(m.value * 100) / 100])
+  );
 
   if (loading) {
     return (
@@ -234,19 +241,31 @@ export default function NodeDetailScreen({ nodeId }: { nodeId: string }) {
             <KV k="Site" v={n.site} />
           </SectionCard>
           <SectionCard title="Node health">
-            {healthSection?.error || healthRows.length === 0 ? (
+            {healthRows.length > 0 && !healthSection?.error ? (
+              healthRows.map((row) => <KV key={row.name} k={row.name} v={row.value} />)
+            ) : kpiByKey.size > 0 ? (
+              // Polled node KPIs from the metric service (Phase 4)
               <>
-                <KV k="Temp. (TRX)" v="—" />
-                <KV k="Temp. (COM)" v="—" />
-                <KV k="CPU load" v="—" />
-                <KV k="Memory" v="—" />
+                <KV k="Uptime" v={kpiByKey.has('uptime') ? `${kpiByKey.get('uptime')}` : '—'} />
+                <KV
+                  k="Temp. (CPU)"
+                  v={kpiByKey.has('cpu_temperature') ? `${kpiByKey.get('cpu_temperature')} °C` : '—'}
+                />
+                <KV
+                  k="Memory"
+                  v={kpiByKey.has('memory') ? `${kpiByKey.get('memory')}%` : '—'}
+                />
               </>
             ) : (
-              healthRows.map((row) => <KV key={row.name} k={row.name} v={row.value} />)
+              <>
+                <KV k="Uptime" v="—" />
+                <KV k="Temp. (CPU)" v="—" />
+                <KV k="Memory" v="—" />
+              </>
             )}
           </SectionCard>
           <SectionCard title="Customers">
-            {/* nodeView.kpis backend gap (#6) — attach counts land with metrics */}
+            {/* attach counts not in metric keys yet — renders "—" */}
             <KV k="Attached" v={sectionValue(null, kpisGap)} />
             <KV k="Active" v={sectionValue(null, kpisGap)} />
           </SectionCard>

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/NodePoolScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/NodePoolScreen.tsx
@@ -7,8 +7,9 @@
  */
 'use client';
 
-/** Node pool — hardware in inventory, ready to install (screens-manage.jsx). */
-import { useState } from 'react';
+/** Node pool — hardware inventory, wired to the `nodesView` composite
+ *  (NodePool operation: nodes without a site are available to install). */
+import { useMemo, useState } from 'react';
 import Divider from '@mui/material/Divider';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -22,15 +23,16 @@ import AddLocationAltRounded from '@mui/icons-material/AddLocationAltRounded';
 import DeleteOutlineRounded from '@mui/icons-material/DeleteOutlineRounded';
 import InfoRounded from '@mui/icons-material/InfoRounded';
 import MoreVertRounded from '@mui/icons-material/MoreVertRounded';
+import { useNodePoolQuery } from '@/client/graphql/nodes-list.generated';
+import { EmptyState } from '@/components/EmptyState';
 import SkeletonTable from '@/components/data-table/SkeletonTable';
 import TableFooter from '@/components/data-table/TableFooter';
 import { KpiRow } from '@/components/Kpi';
 import PageHeader from '@/components/PageHeader';
 import StatusBadge from '@/components/StatusBadge';
 import { useToast } from '@/components/ToastProvider';
-import { NODE_POOL, NODES } from '@/data';
 import type { NodePoolItem } from '@/data';
-import { useFirstLoad } from '@/lib/useFirstLoad';
+import { toUkamaNode } from '@/lib/mappers/nodes';
 
 const NP_LABEL: Record<NodePoolItem['status'], string> = {
   available: 'Available',
@@ -90,15 +92,36 @@ function PoolMenu({ item }: { item: NodePoolItem }) {
 }
 
 export default function NodePoolScreen() {
-  const avail = NODE_POOL.filter((n) => n.status === 'available').length;
-  const loading = useFirstLoad('nodepool');
+  const { data, loading, refetch } = useNodePoolQuery();
+  const nodesSection = data?.nodesView.nodes;
+
+  // Pool view-model: a node without a site is available to install.
+  const pool: NodePoolItem[] = useMemo(
+    () =>
+      (nodesSection?.nodes ?? []).map((n) => {
+        const mapped = toUkamaNode(n);
+        const assigned = !!n.site?.siteId;
+        return {
+          id: n.id,
+          serial: mapped.serial,
+          type: mapped.type,
+          status: assigned ? ('assigned' as const) : ('available' as const),
+          site: n.site?.siteId ?? undefined,
+          added: '—',
+        };
+      }),
+    [nodesSection?.nodes]
+  );
+
+  const avail = pool.filter((n) => n.status === 'available').length;
+  const deployed = pool.length - avail;
 
   return (
     <div className="page">
       <PageHeader
         crumb={['Manage', 'Node pool']}
         title="Node pool"
-        count={NODE_POOL.length}
+        count={pool.length}
         sub="Hardware in inventory, ready to install at a site."
       />
       <KpiRow
@@ -109,14 +132,24 @@ export default function NodePoolScreen() {
             value: avail,
             color: 'var(--uk-success-bright)',
           },
-          { icon: 'cell_tower', label: 'Deployed (live)', value: NODES.length, color: 'var(--uk-ac)' },
-          { icon: 'account_tree', label: 'In inventory', value: NODE_POOL.length },
+          { icon: 'cell_tower', label: 'Deployed (live)', value: deployed, color: 'var(--uk-ac)' },
+          { icon: 'account_tree', label: 'In inventory', value: pool.length },
         ]}
       />
       <div className="card card-pad">
         <div className="tbl-wrap">
           {loading ? (
             <SkeletonTable cols={6} rows={5} />
+          ) : nodesSection?.error ? (
+            <EmptyState
+              art="error"
+              title="Couldn't load node pool"
+              sub={nodesSection.error.message}
+              cta="Try again"
+              onCta={() => refetch()}
+            />
+          ) : pool.length === 0 ? (
+            <EmptyState art="node" title="No nodes in inventory" sub="Registered nodes appear here." />
           ) : (
             <Table>
               <TableHead>
@@ -130,7 +163,7 @@ export default function NodePoolScreen() {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {NODE_POOL.map((n) => (
+                {pool.map((n) => (
                   <TableRow key={n.id}>
                     <TableCell className="tnum" style={{ fontWeight: 600 }}>
                       {n.serial}
@@ -150,7 +183,7 @@ export default function NodePoolScreen() {
             </Table>
           )}
         </div>
-        {!loading && <TableFooter count={NODE_POOL.length} noun="nodes" />}
+        {!loading && !nodesSection?.error && <TableFooter count={pool.length} noun="nodes" />}
       </div>
     </div>
   );

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/NodesScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/NodesScreen.tsx
@@ -7,17 +7,22 @@
  */
 'use client';
 
-/** Nodes — radio hardware card grid (screens-console.jsx). */
+/** Nodes — radio hardware card grid, wired to the `nodesView` composite. */
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import PlaceRounded from '@mui/icons-material/PlaceRounded';
 import RouterRounded from '@mui/icons-material/RouterRounded';
 import SettingsInputAntennaRounded from '@mui/icons-material/SettingsInputAntennaRounded';
+import Skeleton from '@mui/material/Skeleton';
+
+import { useNodesListQuery } from '@/client/graphql/nodes-list.generated';
+import { EmptyState } from '@/components/EmptyState';
 import FilterChips from '@/components/FilterChips';
 import PageHeader from '@/components/PageHeader';
 import StatusBadge from '@/components/StatusBadge';
-import { NODES } from '@/data';
 import type { UkamaNode } from '@/data';
+import { useUiPrefs } from '@/lib/store';
+import { toUkamaNode } from '@/lib/mappers/nodes';
 import NodeDrawer from './NodeDrawer';
 
 function NodeCard({ n, onOpen }: { n: UkamaNode; onOpen: (n: UkamaNode) => void }) {
@@ -81,15 +86,27 @@ function NodeCard({ n, onOpen }: { n: UkamaNode; onOpen: (n: UkamaNode) => void 
 
 export default function NodesScreen() {
   const router = useRouter();
+  const networkId = useUiPrefs((s) => s.networkId);
   const [filter, setFilter] = useState('all');
   const [drawerNode, setDrawerNode] = useState<UkamaNode | null>(null);
+
+  const { data, loading, refetch } = useNodesListQuery({
+    variables: { networkId },
+    skip: !networkId,
+  });
+  const nodesSection = data?.nodesView.nodes;
+  const nodes: UkamaNode[] = useMemo(
+    () => (nodesSection?.nodes ?? []).map((n) => toUkamaNode(n)),
+    [nodesSection?.nodes]
+  );
+
   const counts = {
-    all: NODES.length,
-    online: NODES.filter((n) => n.status === 'online').length,
-    degraded: NODES.filter((n) => n.status === 'degraded' || n.status === 'configuring').length,
-    offline: NODES.filter((n) => n.status === 'offline').length,
+    all: nodes.length,
+    online: nodes.filter((n) => n.status === 'online').length,
+    degraded: nodes.filter((n) => n.status === 'degraded' || n.status === 'configuring').length,
+    offline: nodes.filter((n) => n.status === 'offline').length,
   };
-  const list = NODES.filter(
+  const list = nodes.filter(
     (n) =>
       filter === 'all' ||
       n.status === filter ||
@@ -98,7 +115,7 @@ export default function NodesScreen() {
 
   return (
     <div className="page">
-      <PageHeader title="Nodes" count={NODES.length} sub="Radio hardware deployed across your sites." />
+      <PageHeader title="Nodes" count={nodes.length} sub="Radio hardware deployed across your sites." />
       <div style={{ display: 'flex', gap: 8, marginBottom: 18, flexWrap: 'wrap' }}>
         <FilterChips
           value={filter}
@@ -111,11 +128,29 @@ export default function NodesScreen() {
           ]}
         />
       </div>
-      <div className="tile-grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))' }}>
-        {list.map((n) => (
-          <NodeCard key={n.id} n={n} onOpen={(node) => setDrawerNode(node)} />
-        ))}
-      </div>
+      {loading ? (
+        <div className="tile-grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))' }}>
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} variant="rounded" sx={{ height: 132 }} />
+          ))}
+        </div>
+      ) : nodesSection?.error ? (
+        <EmptyState
+          art="error"
+          title="Couldn't load nodes"
+          sub={nodesSection.error.message}
+          cta="Try again"
+          onCta={() => refetch()}
+        />
+      ) : list.length === 0 ? (
+        <EmptyState art="node" title="No nodes" sub="No nodes match this filter." />
+      ) : (
+        <div className="tile-grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))' }}>
+          {list.map((n) => (
+            <NodeCard key={n.id} n={n} onOpen={(node) => setDrawerNode(node)} />
+          ))}
+        </div>
+      )}
       {drawerNode && (
         <NodeDrawer
           node={drawerNode}

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/NodesScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/NodesScreen.tsx
@@ -21,6 +21,7 @@ import FilterChips from '@/components/FilterChips';
 import PageHeader from '@/components/PageHeader';
 import StatusBadge from '@/components/StatusBadge';
 import type { UkamaNode } from '@/data';
+import { POLL_OVERVIEW_MS, visiblePoll } from '@/lib/polling';
 import { useUiPrefs } from '@/lib/store';
 import { toUkamaNode } from '@/lib/mappers/nodes';
 import NodeDrawer from './NodeDrawer';
@@ -93,6 +94,7 @@ export default function NodesScreen() {
   const { data, loading, refetch } = useNodesListQuery({
     variables: { networkId },
     skip: !networkId,
+    ...visiblePoll(POLL_OVERVIEW_MS),
   });
   const nodesSection = data?.nodesView.nodes;
   const nodes: UkamaNode[] = useMemo(

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/SiteDetailScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/SiteDetailScreen.tsx
@@ -32,6 +32,7 @@ import PageHeader from '@/components/PageHeader';
 import SectionCard from '@/components/SectionCard';
 import StatusBadge from '@/components/StatusBadge';
 import { useToast } from '@/components/ToastProvider';
+import { POLL_LIVE_MS, visiblePoll } from '@/lib/polling';
 import { toUkamaNode } from '@/lib/mappers/nodes';
 import { toSite } from '@/lib/mappers/sites';
 import { series } from '@/lib/series';
@@ -172,6 +173,7 @@ export default function SiteDetailScreen({ siteId }: { siteId: string }) {
 
   const { data, loading, refetch } = useNetworkSiteDetailQuery({
     variables: { siteId },
+    ...visiblePoll(POLL_LIVE_MS),
   });
   const view = data?.siteView;
   const siteSection = view?.site;

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/SiteDetailScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/SiteDetailScreen.tsx
@@ -20,15 +20,20 @@ import Button from '@mui/material/Button';
 import ArrowBackRounded from '@mui/icons-material/ArrowBackRounded';
 import GroupRounded from '@mui/icons-material/GroupRounded';
 import RestartAltRounded from '@mui/icons-material/RestartAltRounded';
+import Skeleton from '@mui/material/Skeleton';
+
+import { useNetworkSiteDetailQuery } from '@/client/graphql/site-detail.generated';
 import AppModal from '@/components/AppModal';
 import { ComboChart, MiniSpark } from '@/components/charts';
 import DetailPicker from '@/components/DetailPicker';
+import { EmptyState } from '@/components/EmptyState';
 import MapPanel from '@/components/Map/MapPanel';
 import PageHeader from '@/components/PageHeader';
 import SectionCard from '@/components/SectionCard';
 import StatusBadge from '@/components/StatusBadge';
 import { useToast } from '@/components/ToastProvider';
-import { NODES, SITES } from '@/data';
+import { toUkamaNode } from '@/lib/mappers/nodes';
+import { toSite } from '@/lib/mappers/sites';
 import { series } from '@/lib/series';
 import { Ic } from '../../_components/icons';
 
@@ -160,20 +165,57 @@ function PortRow({
 export default function SiteDetailScreen({ siteId }: { siteId: string }) {
   const router = useRouter();
   const toast = useToast();
-  const s = SITES.find((x) => x.id === siteId) ?? SITES[0];
   const [restart, setRestart] = useState(false);
   const [confirm, setConfirm] = useState('');
   const [selComp, setSelComp] = useState('switch');
   const [ports, setPorts] = useState<Record<number, boolean>>({ 1: true, 2: false, 3: false });
-  if (!s) return null;
 
-  const node = NODES.find((nn) => nn.site === s.name);
+  const { data, loading, refetch } = useNetworkSiteDetailQuery({
+    variables: { siteId },
+  });
+  const view = data?.siteView;
+  const siteSection = view?.site;
+  const nodesSection = view?.nodes;
+
+  if (loading) {
+    return (
+      <div className="page">
+        <PageHeader crumb={['Sites', siteId]} title="Site" />
+        <Skeleton variant="rounded" sx={{ height: 42, mb: 2 }} />
+        <Skeleton variant="rounded" sx={{ height: 420 }} />
+      </div>
+    );
+  }
+  if (!siteSection?.site) {
+    return (
+      <div className="page">
+        <PageHeader crumb={['Sites', siteId]} title="Site" />
+        <div className="card">
+          <EmptyState
+            art="error"
+            title="Couldn't load site"
+            sub={siteSection?.error?.message ?? 'Site not found.'}
+            cta="Try again"
+            onCta={() => refetch()}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const siteNodes = (nodesSection?.nodes ?? []).map((n) => toUkamaNode(n));
+  const s = toSite(siteSection.site, {
+    total: siteNodes.length,
+    online: siteNodes.filter((n) => n.status === 'online').length,
+  });
+  const node = siteNodes[0];
+  const installDate = siteSection.site.installDate || '—';
   const statusText =
     s.status === 'offline'
-      ? 'has been offline for 2h 14m'
+      ? 'is offline'
       : s.status === 'degraded'
         ? 'is online with warnings'
-        : 'is online for 3 days';
+        : 'is online';
 
   return (
     <div className="page">
@@ -206,7 +248,7 @@ export default function SiteDetailScreen({ siteId }: { siteId: string }) {
       <div className="detail-subrow">
         <DetailPicker
           value={{ id: s.id, label: s.name, status: s.status }}
-          items={SITES.map((x) => ({ id: x.id, label: x.name, status: x.status }))}
+          items={[{ id: s.id, label: s.name, status: s.status }]}
           onPick={(it) => router.push(`/network/sites/${it.id}`)}
         />
         <StatusBadge status={s.status} />
@@ -218,9 +260,9 @@ export default function SiteDetailScreen({ siteId }: { siteId: string }) {
           <div style={{ display: 'grid', gap: 13, marginTop: 2 }}>
             {(
               [
-                ['Date created', '13 Jul 2023'],
+                ['Installed', installDate],
                 ['Location', s.area],
-                ['Power plan', s.plan],
+                ['Nodes', `${siteNodes.length}`],
                 ['Node', node ? node.serial : '—'],
               ] as const
             ).map(([k, v]) => (
@@ -266,7 +308,8 @@ export default function SiteDetailScreen({ siteId }: { siteId: string }) {
             }}
           >
             <GroupRounded sx={{ fontSize: 16, color: 'var(--uk-ac)' }} />
-            {s.subs}
+            {/* per-site subscriber count: metrics-phase (siteView.kpis gap) */}
+            —
           </div>
         </div>
       </div>

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/SitesScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/SitesScreen.tsx
@@ -7,18 +7,22 @@
  */
 'use client';
 
-/** Sites — card grid with status count chips (screens-console.jsx). */
-import { useState } from 'react';
+/** Sites — card grid with status count chips, wired to `sitesView`. */
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import CellTowerRounded from '@mui/icons-material/CellTowerRounded';
 import ErrorOutlineRounded from '@mui/icons-material/ErrorOutlineRounded';
+import Skeleton from '@mui/material/Skeleton';
+
+import { useSitesListQuery } from '@/client/graphql/sites-list.generated';
 import { EmptyState } from '@/components/EmptyState';
 import FilterChips from '@/components/FilterChips';
 import PageHeader from '@/components/PageHeader';
 import SearchField from '@/components/SearchField';
 import StatusBadge from '@/components/StatusBadge';
-import { SITES } from '@/data';
 import type { Site, UkamaNode } from '@/data';
+import { useUiPrefs } from '@/lib/store';
+import { toSite } from '@/lib/mappers/sites';
 import NodeDrawer from './NodeDrawer';
 import SiteDrawer from './SiteDrawer';
 
@@ -99,17 +103,36 @@ function SiteCard({ s, onOpen }: { s: Site; onOpen: (s: Site) => void }) {
 
 export default function SitesScreen() {
   const router = useRouter();
+  const networkId = useUiPrefs((s) => s.networkId);
   const [filter, setFilter] = useState('all');
   const [q, setQ] = useState('');
   const [drawerSite, setDrawerSite] = useState<Site | null>(null);
   const [drawerNode, setDrawerNode] = useState<UkamaNode | null>(null);
+
+  const { data, loading, refetch } = useSitesListQuery({
+    variables: { networkId },
+    skip: !networkId,
+  });
+  const sitesSection = data?.sitesView.sites;
+  const sites: Site[] = useMemo(() => {
+    const countsBySite = new Map(
+      (data?.sitesView.nodeCounts.counts ?? []).map((c) => [
+        c.siteId,
+        { total: c.total, online: c.online },
+      ])
+    );
+    return (sitesSection?.sites ?? []).map((s) =>
+      toSite(s, countsBySite.get(s.id))
+    );
+  }, [sitesSection?.sites, data?.sitesView.nodeCounts.counts]);
+
   const counts = {
-    all: SITES.length,
-    online: SITES.filter((s) => s.status === 'online').length,
-    degraded: SITES.filter((s) => s.status === 'degraded').length,
-    offline: SITES.filter((s) => s.status === 'offline').length,
+    all: sites.length,
+    online: sites.filter((s) => s.status === 'online').length,
+    degraded: sites.filter((s) => s.status === 'degraded').length,
+    offline: sites.filter((s) => s.status === 'offline').length,
   };
-  const list = SITES.filter(
+  const list = sites.filter(
     (s) =>
       (filter === 'all' || s.status === filter) &&
       s.name.toLowerCase().includes(q.toLowerCase()),
@@ -120,7 +143,7 @@ export default function SitesScreen() {
     <div className="page">
       <PageHeader
         title="Sites"
-        count={SITES.length}
+        count={sites.length}
         sub="Physical locations where your network is installed."
       />
       <div style={{ display: 'flex', gap: 10, marginBottom: 18, flexWrap: 'wrap', alignItems: 'center' }}>
@@ -136,15 +159,35 @@ export default function SitesScreen() {
           ]}
         />
       </div>
-      <div className="tile-grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(310px, 1fr))' }}>
-        {list.map((s) => (
-          <SiteCard key={s.id} s={s} onOpen={open} />
-        ))}
-      </div>
-      {list.length === 0 && (
-        <div className="card">
-          <EmptyState art="search" title="No matching sites" sub="Try a different filter or search term." />
+      {loading ? (
+        <div className="tile-grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(310px, 1fr))' }}>
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} variant="rounded" sx={{ height: 150 }} />
+          ))}
         </div>
+      ) : sitesSection?.error ? (
+        <div className="card">
+          <EmptyState
+            art="error"
+            title="Couldn't load sites"
+            sub={sitesSection.error.message}
+            cta="Try again"
+            onCta={() => refetch()}
+          />
+        </div>
+      ) : (
+        <>
+          <div className="tile-grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(310px, 1fr))' }}>
+            {list.map((s) => (
+              <SiteCard key={s.id} s={s} onOpen={open} />
+            ))}
+          </div>
+          {list.length === 0 && (
+            <div className="card">
+              <EmptyState art="search" title="No matching sites" sub="Try a different filter or search term." />
+            </div>
+          )}
+        </>
       )}
       {drawerSite && (
         <SiteDrawer

--- a/interfaces/ukama-console/src/app/(dashboard)/network/_components/SitesScreen.tsx
+++ b/interfaces/ukama-console/src/app/(dashboard)/network/_components/SitesScreen.tsx
@@ -21,6 +21,7 @@ import PageHeader from '@/components/PageHeader';
 import SearchField from '@/components/SearchField';
 import StatusBadge from '@/components/StatusBadge';
 import type { Site, UkamaNode } from '@/data';
+import { POLL_OVERVIEW_MS, visiblePoll } from '@/lib/polling';
 import { useUiPrefs } from '@/lib/store';
 import { toSite } from '@/lib/mappers/sites';
 import NodeDrawer from './NodeDrawer';
@@ -112,6 +113,7 @@ export default function SitesScreen() {
   const { data, loading, refetch } = useSitesListQuery({
     variables: { networkId },
     skip: !networkId,
+    ...visiblePoll(POLL_OVERVIEW_MS),
   });
   const sitesSection = data?.sitesView.sites;
   const sites: Site[] = useMemo(() => {

--- a/interfaces/ukama-console/src/client/graphql/commerce.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/commerce.generated.ts
@@ -1,0 +1,276 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+import { SectionErrorFieldsFragmentDoc } from './views-shared.generated';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type BizHomeRevenueQueryVariables = Types.Exact<{
+  networkId?: Types.InputMaybe<Types.Scalars['String']['input']>;
+}>;
+
+
+export type BizHomeRevenueQuery = { __typename?: 'Query', commerceView: { __typename?: 'CommerceView', networkId?: string | null, revenue: { __typename?: 'RevenueSection', totalPaid?: number | null, monthPaid?: number | null, momPct?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+
+export type RevenueOverviewQueryVariables = Types.Exact<{
+  networkId?: Types.InputMaybe<Types.Scalars['String']['input']>;
+}>;
+
+
+export type RevenueOverviewQuery = { __typename?: 'Query', commerceView: { __typename?: 'CommerceView', networkId?: string | null, revenue: { __typename?: 'RevenueSection', totalPaid?: number | null, totalPending?: number | null, monthPaid?: number | null, prevMonthPaid?: number | null, momPct?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, invoices: { __typename?: 'InvoicesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, reports?: Array<{ __typename?: 'ReportDto', id: string, period: string, type: string, isPaid: boolean, networkId: string }> | null } } };
+
+export type PackagesDashboardQueryVariables = Types.Exact<{
+  networkId?: Types.InputMaybe<Types.Scalars['String']['input']>;
+}>;
+
+
+export type PackagesDashboardQuery = { __typename?: 'Query', commerceView: { __typename?: 'CommerceView', networkId?: string | null, plans: { __typename?: 'PlanStatsSection', mrr?: number | null, arpu?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, plans?: Array<{ __typename?: 'PlanStatsDto', packageId: string, name: string, amount: number, currency: string, active: boolean, attachCount?: number | null, revenue: number, revenueSharePct: number }> | null } } };
+
+export type BillingOverviewQueryVariables = Types.Exact<{
+  networkId?: Types.InputMaybe<Types.Scalars['String']['input']>;
+  invoiceLimit?: Types.Scalars['Int']['input'];
+}>;
+
+
+export type BillingOverviewQuery = { __typename?: 'Query', commerceView: { __typename?: 'CommerceView', networkId?: string | null, invoices: { __typename?: 'InvoicesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, reports?: Array<{ __typename?: 'ReportDto', id: string, period: string, type: string, isPaid: boolean, networkId: string, createdAt: string }> | null }, balance: { __typename?: 'BalanceSection', outstandingCount?: number | null, latestUnpaidPeriod?: string | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+
+
+export const BizHomeRevenueDocument = gql`
+    query BizHomeRevenue($networkId: String) {
+  commerceView(networkId: $networkId) {
+    networkId
+    revenue {
+      error {
+        ...SectionErrorFields
+      }
+      totalPaid
+      monthPaid
+      momPct
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}`;
+
+/**
+ * __useBizHomeRevenueQuery__
+ *
+ * To run a query within a React component, call `useBizHomeRevenueQuery` and pass it any options that fit your needs.
+ * When your component renders, `useBizHomeRevenueQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useBizHomeRevenueQuery({
+ *   variables: {
+ *      networkId: // value for 'networkId'
+ *   },
+ * });
+ */
+export function useBizHomeRevenueQuery(baseOptions?: Apollo.QueryHookOptions<BizHomeRevenueQuery, BizHomeRevenueQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<BizHomeRevenueQuery, BizHomeRevenueQueryVariables>(BizHomeRevenueDocument, options);
+      }
+export function useBizHomeRevenueLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<BizHomeRevenueQuery, BizHomeRevenueQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<BizHomeRevenueQuery, BizHomeRevenueQueryVariables>(BizHomeRevenueDocument, options);
+        }
+// @ts-ignore
+export function useBizHomeRevenueSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<BizHomeRevenueQuery, BizHomeRevenueQueryVariables>): Apollo.UseSuspenseQueryResult<BizHomeRevenueQuery, BizHomeRevenueQueryVariables>;
+export function useBizHomeRevenueSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BizHomeRevenueQuery, BizHomeRevenueQueryVariables>): Apollo.UseSuspenseQueryResult<BizHomeRevenueQuery | undefined, BizHomeRevenueQueryVariables>;
+export function useBizHomeRevenueSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BizHomeRevenueQuery, BizHomeRevenueQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<BizHomeRevenueQuery, BizHomeRevenueQueryVariables>(BizHomeRevenueDocument, options);
+        }
+export type BizHomeRevenueQueryHookResult = ReturnType<typeof useBizHomeRevenueQuery>;
+export type BizHomeRevenueLazyQueryHookResult = ReturnType<typeof useBizHomeRevenueLazyQuery>;
+export type BizHomeRevenueSuspenseQueryHookResult = ReturnType<typeof useBizHomeRevenueSuspenseQuery>;
+export type BizHomeRevenueQueryResult = Apollo.QueryResult<BizHomeRevenueQuery, BizHomeRevenueQueryVariables>;
+export const RevenueOverviewDocument = gql`
+    query RevenueOverview($networkId: String) {
+  commerceView(networkId: $networkId) {
+    networkId
+    revenue {
+      error {
+        ...SectionErrorFields
+      }
+      totalPaid
+      totalPending
+      monthPaid
+      prevMonthPaid
+      momPct
+    }
+    invoices(limit: 10) {
+      error {
+        ...SectionErrorFields
+      }
+      reports {
+        id
+        period
+        type
+        isPaid
+        networkId
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}`;
+
+/**
+ * __useRevenueOverviewQuery__
+ *
+ * To run a query within a React component, call `useRevenueOverviewQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRevenueOverviewQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useRevenueOverviewQuery({
+ *   variables: {
+ *      networkId: // value for 'networkId'
+ *   },
+ * });
+ */
+export function useRevenueOverviewQuery(baseOptions?: Apollo.QueryHookOptions<RevenueOverviewQuery, RevenueOverviewQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RevenueOverviewQuery, RevenueOverviewQueryVariables>(RevenueOverviewDocument, options);
+      }
+export function useRevenueOverviewLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RevenueOverviewQuery, RevenueOverviewQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RevenueOverviewQuery, RevenueOverviewQueryVariables>(RevenueOverviewDocument, options);
+        }
+// @ts-ignore
+export function useRevenueOverviewSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<RevenueOverviewQuery, RevenueOverviewQueryVariables>): Apollo.UseSuspenseQueryResult<RevenueOverviewQuery, RevenueOverviewQueryVariables>;
+export function useRevenueOverviewSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<RevenueOverviewQuery, RevenueOverviewQueryVariables>): Apollo.UseSuspenseQueryResult<RevenueOverviewQuery | undefined, RevenueOverviewQueryVariables>;
+export function useRevenueOverviewSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<RevenueOverviewQuery, RevenueOverviewQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<RevenueOverviewQuery, RevenueOverviewQueryVariables>(RevenueOverviewDocument, options);
+        }
+export type RevenueOverviewQueryHookResult = ReturnType<typeof useRevenueOverviewQuery>;
+export type RevenueOverviewLazyQueryHookResult = ReturnType<typeof useRevenueOverviewLazyQuery>;
+export type RevenueOverviewSuspenseQueryHookResult = ReturnType<typeof useRevenueOverviewSuspenseQuery>;
+export type RevenueOverviewQueryResult = Apollo.QueryResult<RevenueOverviewQuery, RevenueOverviewQueryVariables>;
+export const PackagesDashboardDocument = gql`
+    query PackagesDashboard($networkId: String) {
+  commerceView(networkId: $networkId) {
+    networkId
+    plans {
+      error {
+        ...SectionErrorFields
+      }
+      mrr
+      arpu
+      plans {
+        packageId
+        name
+        amount
+        currency
+        active
+        attachCount
+        revenue
+        revenueSharePct
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}`;
+
+/**
+ * __usePackagesDashboardQuery__
+ *
+ * To run a query within a React component, call `usePackagesDashboardQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePackagesDashboardQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePackagesDashboardQuery({
+ *   variables: {
+ *      networkId: // value for 'networkId'
+ *   },
+ * });
+ */
+export function usePackagesDashboardQuery(baseOptions?: Apollo.QueryHookOptions<PackagesDashboardQuery, PackagesDashboardQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PackagesDashboardQuery, PackagesDashboardQueryVariables>(PackagesDashboardDocument, options);
+      }
+export function usePackagesDashboardLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PackagesDashboardQuery, PackagesDashboardQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PackagesDashboardQuery, PackagesDashboardQueryVariables>(PackagesDashboardDocument, options);
+        }
+// @ts-ignore
+export function usePackagesDashboardSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PackagesDashboardQuery, PackagesDashboardQueryVariables>): Apollo.UseSuspenseQueryResult<PackagesDashboardQuery, PackagesDashboardQueryVariables>;
+export function usePackagesDashboardSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PackagesDashboardQuery, PackagesDashboardQueryVariables>): Apollo.UseSuspenseQueryResult<PackagesDashboardQuery | undefined, PackagesDashboardQueryVariables>;
+export function usePackagesDashboardSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PackagesDashboardQuery, PackagesDashboardQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<PackagesDashboardQuery, PackagesDashboardQueryVariables>(PackagesDashboardDocument, options);
+        }
+export type PackagesDashboardQueryHookResult = ReturnType<typeof usePackagesDashboardQuery>;
+export type PackagesDashboardLazyQueryHookResult = ReturnType<typeof usePackagesDashboardLazyQuery>;
+export type PackagesDashboardSuspenseQueryHookResult = ReturnType<typeof usePackagesDashboardSuspenseQuery>;
+export type PackagesDashboardQueryResult = Apollo.QueryResult<PackagesDashboardQuery, PackagesDashboardQueryVariables>;
+export const BillingOverviewDocument = gql`
+    query BillingOverview($networkId: String, $invoiceLimit: Int! = 20) {
+  commerceView(networkId: $networkId) {
+    networkId
+    invoices(limit: $invoiceLimit) {
+      error {
+        ...SectionErrorFields
+      }
+      reports {
+        id
+        period
+        type
+        isPaid
+        networkId
+        createdAt
+      }
+    }
+    balance {
+      error {
+        ...SectionErrorFields
+      }
+      outstandingCount
+      latestUnpaidPeriod
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}`;
+
+/**
+ * __useBillingOverviewQuery__
+ *
+ * To run a query within a React component, call `useBillingOverviewQuery` and pass it any options that fit your needs.
+ * When your component renders, `useBillingOverviewQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useBillingOverviewQuery({
+ *   variables: {
+ *      networkId: // value for 'networkId'
+ *      invoiceLimit: // value for 'invoiceLimit'
+ *   },
+ * });
+ */
+export function useBillingOverviewQuery(baseOptions?: Apollo.QueryHookOptions<BillingOverviewQuery, BillingOverviewQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<BillingOverviewQuery, BillingOverviewQueryVariables>(BillingOverviewDocument, options);
+      }
+export function useBillingOverviewLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<BillingOverviewQuery, BillingOverviewQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<BillingOverviewQuery, BillingOverviewQueryVariables>(BillingOverviewDocument, options);
+        }
+// @ts-ignore
+export function useBillingOverviewSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<BillingOverviewQuery, BillingOverviewQueryVariables>): Apollo.UseSuspenseQueryResult<BillingOverviewQuery, BillingOverviewQueryVariables>;
+export function useBillingOverviewSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BillingOverviewQuery, BillingOverviewQueryVariables>): Apollo.UseSuspenseQueryResult<BillingOverviewQuery | undefined, BillingOverviewQueryVariables>;
+export function useBillingOverviewSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BillingOverviewQuery, BillingOverviewQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<BillingOverviewQuery, BillingOverviewQueryVariables>(BillingOverviewDocument, options);
+        }
+export type BillingOverviewQueryHookResult = ReturnType<typeof useBillingOverviewQuery>;
+export type BillingOverviewLazyQueryHookResult = ReturnType<typeof useBillingOverviewLazyQuery>;
+export type BillingOverviewSuspenseQueryHookResult = ReturnType<typeof useBillingOverviewSuspenseQuery>;
+export type BillingOverviewQueryResult = Apollo.QueryResult<BillingOverviewQuery, BillingOverviewQueryVariables>;

--- a/interfaces/ukama-console/src/client/graphql/commerce.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/commerce.generated.ts
@@ -1,7 +1,7 @@
 import * as Types from './types';
 
 import { gql } from '@apollo/client';
-import { SectionErrorFieldsFragmentDoc } from './views-shared.generated';
+import { ViewSiteFragmentDoc, SectionErrorFieldsFragmentDoc } from './views-shared.generated';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
 export type BizHomeRevenueQueryVariables = Types.Exact<{
@@ -16,7 +16,14 @@ export type RevenueOverviewQueryVariables = Types.Exact<{
 }>;
 
 
-export type RevenueOverviewQuery = { __typename?: 'Query', commerceView: { __typename?: 'CommerceView', networkId?: string | null, revenue: { __typename?: 'RevenueSection', totalPaid?: number | null, totalPending?: number | null, monthPaid?: number | null, prevMonthPaid?: number | null, momPct?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, invoices: { __typename?: 'InvoicesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, reports?: Array<{ __typename?: 'ReportDto', id: string, period: string, type: string, isPaid: boolean, networkId: string }> | null } } };
+export type RevenueOverviewQuery = { __typename?: 'Query', commerceView: { __typename?: 'CommerceView', networkId?: string | null, revenue: { __typename?: 'RevenueSection', totalPaid?: number | null, totalPending?: number | null, monthPaid?: number | null, prevMonthPaid?: number | null, momPct?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, plans: { __typename?: 'PlanStatsSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, plans?: Array<{ __typename?: 'PlanStatsDto', packageId: string, name: string, revenue: number, revenueSharePct: number }> | null }, invoices: { __typename?: 'InvoicesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, reports?: Array<{ __typename?: 'ReportDto', id: string, period: string, type: string, isPaid: boolean, networkId: string }> | null } } };
+
+export type BizHomeNetworkQueryVariables = Types.Exact<{
+  networkId: Types.Scalars['String']['input'];
+}>;
+
+
+export type BizHomeNetworkQuery = { __typename?: 'Query', networkOverview: { __typename?: 'NetworkOverview', networkId: string, subscriberStats: { __typename?: 'SubscriberStatsSection', total?: number | null, active?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, siteStats: { __typename?: 'SitesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, sites?: Array<{ __typename?: 'SiteDto', id: string, name: string, networkId: string, latitude: string, longitude: string, location: string, isDeactivated: boolean, installDate: string, createdAt: string }> | null } } };
 
 export type PackagesDashboardQueryVariables = Types.Exact<{
   networkId?: Types.InputMaybe<Types.Scalars['String']['input']>;
@@ -99,6 +106,17 @@ export const RevenueOverviewDocument = gql`
       prevMonthPaid
       momPct
     }
+    plans {
+      error {
+        ...SectionErrorFields
+      }
+      plans {
+        packageId
+        name
+        revenue
+        revenueSharePct
+      }
+    }
     invoices(limit: 10) {
       error {
         ...SectionErrorFields
@@ -150,6 +168,65 @@ export type RevenueOverviewQueryHookResult = ReturnType<typeof useRevenueOvervie
 export type RevenueOverviewLazyQueryHookResult = ReturnType<typeof useRevenueOverviewLazyQuery>;
 export type RevenueOverviewSuspenseQueryHookResult = ReturnType<typeof useRevenueOverviewSuspenseQuery>;
 export type RevenueOverviewQueryResult = Apollo.QueryResult<RevenueOverviewQuery, RevenueOverviewQueryVariables>;
+export const BizHomeNetworkDocument = gql`
+    query BizHomeNetwork($networkId: String!) {
+  networkOverview(networkId: $networkId) {
+    networkId
+    subscriberStats {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      active
+    }
+    siteStats {
+      error {
+        ...SectionErrorFields
+      }
+      sites {
+        ...ViewSite
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}
+${ViewSiteFragmentDoc}`;
+
+/**
+ * __useBizHomeNetworkQuery__
+ *
+ * To run a query within a React component, call `useBizHomeNetworkQuery` and pass it any options that fit your needs.
+ * When your component renders, `useBizHomeNetworkQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useBizHomeNetworkQuery({
+ *   variables: {
+ *      networkId: // value for 'networkId'
+ *   },
+ * });
+ */
+export function useBizHomeNetworkQuery(baseOptions: Apollo.QueryHookOptions<BizHomeNetworkQuery, BizHomeNetworkQueryVariables> & ({ variables: BizHomeNetworkQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<BizHomeNetworkQuery, BizHomeNetworkQueryVariables>(BizHomeNetworkDocument, options);
+      }
+export function useBizHomeNetworkLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<BizHomeNetworkQuery, BizHomeNetworkQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<BizHomeNetworkQuery, BizHomeNetworkQueryVariables>(BizHomeNetworkDocument, options);
+        }
+// @ts-ignore
+export function useBizHomeNetworkSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<BizHomeNetworkQuery, BizHomeNetworkQueryVariables>): Apollo.UseSuspenseQueryResult<BizHomeNetworkQuery, BizHomeNetworkQueryVariables>;
+export function useBizHomeNetworkSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BizHomeNetworkQuery, BizHomeNetworkQueryVariables>): Apollo.UseSuspenseQueryResult<BizHomeNetworkQuery | undefined, BizHomeNetworkQueryVariables>;
+export function useBizHomeNetworkSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BizHomeNetworkQuery, BizHomeNetworkQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<BizHomeNetworkQuery, BizHomeNetworkQueryVariables>(BizHomeNetworkDocument, options);
+        }
+export type BizHomeNetworkQueryHookResult = ReturnType<typeof useBizHomeNetworkQuery>;
+export type BizHomeNetworkLazyQueryHookResult = ReturnType<typeof useBizHomeNetworkLazyQuery>;
+export type BizHomeNetworkSuspenseQueryHookResult = ReturnType<typeof useBizHomeNetworkSuspenseQuery>;
+export type BizHomeNetworkQueryResult = Apollo.QueryResult<BizHomeNetworkQuery, BizHomeNetworkQueryVariables>;
 export const PackagesDashboardDocument = gql`
     query PackagesDashboard($networkId: String) {
   commerceView(networkId: $networkId) {

--- a/interfaces/ukama-console/src/client/graphql/commerce.graphql
+++ b/interfaces/ukama-console/src/client/graphql/commerce.graphql
@@ -34,6 +34,17 @@ query RevenueOverview($networkId: String) {
       prevMonthPaid
       momPct
     }
+    plans {
+      error {
+        ...SectionErrorFields
+      }
+      plans {
+        packageId
+        name
+        revenue
+        revenueSharePct
+      }
+    }
     invoices(limit: 10) {
       error {
         ...SectionErrorFields
@@ -44,6 +55,29 @@ query RevenueOverview($networkId: String) {
         type
         isPaid
         networkId
+      }
+    }
+  }
+}
+
+# Business home: subscriber/site stats over networkOverview (lean selection —
+# pairs with BizHomeRevenue on the same screen).
+query BizHomeNetwork($networkId: String!) {
+  networkOverview(networkId: $networkId) {
+    networkId
+    subscriberStats {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      active
+    }
+    siteStats {
+      error {
+        ...SectionErrorFields
+      }
+      sites {
+        ...ViewSite
       }
     }
   }

--- a/interfaces/ukama-console/src/client/graphql/commerce.graphql
+++ b/interfaces/ukama-console/src/client/graphql/commerce.graphql
@@ -1,0 +1,99 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# Business-lens commerce documents — four screens, one composite, four
+# selections (plan §3.1: breathing space via field selection).
+
+query BizHomeRevenue($networkId: String) {
+  commerceView(networkId: $networkId) {
+    networkId
+    revenue {
+      error {
+        ...SectionErrorFields
+      }
+      totalPaid
+      monthPaid
+      momPct
+    }
+  }
+}
+
+query RevenueOverview($networkId: String) {
+  commerceView(networkId: $networkId) {
+    networkId
+    revenue {
+      error {
+        ...SectionErrorFields
+      }
+      totalPaid
+      totalPending
+      monthPaid
+      prevMonthPaid
+      momPct
+    }
+    invoices(limit: 10) {
+      error {
+        ...SectionErrorFields
+      }
+      reports {
+        id
+        period
+        type
+        isPaid
+        networkId
+      }
+    }
+  }
+}
+
+query PackagesDashboard($networkId: String) {
+  commerceView(networkId: $networkId) {
+    networkId
+    plans {
+      error {
+        ...SectionErrorFields
+      }
+      mrr
+      arpu
+      plans {
+        packageId
+        name
+        amount
+        currency
+        active
+        attachCount
+        revenue
+        revenueSharePct
+      }
+    }
+  }
+}
+
+query BillingOverview($networkId: String, $invoiceLimit: Int! = 20) {
+  commerceView(networkId: $networkId) {
+    networkId
+    invoices(limit: $invoiceLimit) {
+      error {
+        ...SectionErrorFields
+      }
+      reports {
+        id
+        period
+        type
+        isPaid
+        networkId
+        createdAt
+      }
+    }
+    balance {
+      error {
+        ...SectionErrorFields
+      }
+      outstandingCount
+      latestUnpaidPeriod
+    }
+  }
+}

--- a/interfaces/ukama-console/src/client/graphql/invitations.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/invitations.generated.ts
@@ -25,7 +25,7 @@ export type DeleteInvitationMutationVariables = Types.Exact<{
 export type DeleteInvitationMutation = { __typename?: 'Mutation', deleteInvitation: { __typename?: 'DeleteInvitationResDto', id: string } };
 
 export type UpdateInvitationMutationVariables = Types.Exact<{
-  data: Types.UpateInvitationInputDto;
+  data: Types.UpdateInvitationInputDto;
 }>;
 
 
@@ -161,7 +161,7 @@ export type DeleteInvitationMutationHookResult = ReturnType<typeof useDeleteInvi
 export type DeleteInvitationMutationResult = Apollo.MutationResult<DeleteInvitationMutation>;
 export type DeleteInvitationMutationOptions = Apollo.BaseMutationOptions<DeleteInvitationMutation, DeleteInvitationMutationVariables>;
 export const UpdateInvitationDocument = gql`
-    mutation UpdateInvitation($data: UpateInvitationInputDto!) {
+    mutation UpdateInvitation($data: UpdateInvitationInputDto!) {
   updateInvitation(data: $data) {
     id
   }

--- a/interfaces/ukama-console/src/client/graphql/invitations.graphql
+++ b/interfaces/ukama-console/src/client/graphql/invitations.graphql
@@ -39,7 +39,7 @@ mutation DeleteInvitation($deleteInvitationId: String!) {
   }
 }
 
-mutation UpdateInvitation($data: UpateInvitationInputDto!) {
+mutation UpdateInvitation($data: UpdateInvitationInputDto!) {
   updateInvitation(data: $data) {
     id
   }

--- a/interfaces/ukama-console/src/client/graphql/network-customers.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/network-customers.generated.ts
@@ -1,0 +1,94 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+import { SectionErrorFieldsFragmentDoc } from './views-shared.generated';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type NetworkCustomersQueryVariables = Types.Exact<{
+  networkId: Types.Scalars['String']['input'];
+}>;
+
+
+export type NetworkCustomersQuery = { __typename?: 'Query', subscribersView: { __typename?: 'SubscribersView', networkId: string, subscribers: { __typename?: 'SubscribersSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, subscribers?: Array<{ __typename?: 'SubscriberDto', uuid: string, name: string, phone: string, email: string, networkId: string, sim?: Array<{ __typename?: 'SubscriberSimDto', id: string, iccid: string, msisdn: string, status: string, type: string, package?: { __typename?: 'SimPackageDto', package_id: string, is_active: boolean } | null }> | null }> | null }, plans: { __typename?: 'PlansSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, plans?: Array<{ __typename?: 'PlanNameDto', packageId: string, name: string }> | null }, usage: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+
+
+export const NetworkCustomersDocument = gql`
+    query NetworkCustomers($networkId: String!) {
+  subscribersView(networkId: $networkId) {
+    networkId
+    subscribers {
+      error {
+        ...SectionErrorFields
+      }
+      subscribers {
+        uuid
+        name
+        phone
+        email
+        networkId
+        sim {
+          id
+          iccid
+          msisdn
+          status
+          type
+          package {
+            package_id
+            is_active
+          }
+        }
+      }
+    }
+    plans {
+      error {
+        ...SectionErrorFields
+      }
+      plans {
+        packageId
+        name
+      }
+    }
+    usage {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}`;
+
+/**
+ * __useNetworkCustomersQuery__
+ *
+ * To run a query within a React component, call `useNetworkCustomersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNetworkCustomersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useNetworkCustomersQuery({
+ *   variables: {
+ *      networkId: // value for 'networkId'
+ *   },
+ * });
+ */
+export function useNetworkCustomersQuery(baseOptions: Apollo.QueryHookOptions<NetworkCustomersQuery, NetworkCustomersQueryVariables> & ({ variables: NetworkCustomersQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<NetworkCustomersQuery, NetworkCustomersQueryVariables>(NetworkCustomersDocument, options);
+      }
+export function useNetworkCustomersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NetworkCustomersQuery, NetworkCustomersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<NetworkCustomersQuery, NetworkCustomersQueryVariables>(NetworkCustomersDocument, options);
+        }
+// @ts-ignore
+export function useNetworkCustomersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<NetworkCustomersQuery, NetworkCustomersQueryVariables>): Apollo.UseSuspenseQueryResult<NetworkCustomersQuery, NetworkCustomersQueryVariables>;
+export function useNetworkCustomersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NetworkCustomersQuery, NetworkCustomersQueryVariables>): Apollo.UseSuspenseQueryResult<NetworkCustomersQuery | undefined, NetworkCustomersQueryVariables>;
+export function useNetworkCustomersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NetworkCustomersQuery, NetworkCustomersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<NetworkCustomersQuery, NetworkCustomersQueryVariables>(NetworkCustomersDocument, options);
+        }
+export type NetworkCustomersQueryHookResult = ReturnType<typeof useNetworkCustomersQuery>;
+export type NetworkCustomersLazyQueryHookResult = ReturnType<typeof useNetworkCustomersLazyQuery>;
+export type NetworkCustomersSuspenseQueryHookResult = ReturnType<typeof useNetworkCustomersSuspenseQuery>;
+export type NetworkCustomersQueryResult = Apollo.QueryResult<NetworkCustomersQuery, NetworkCustomersQueryVariables>;

--- a/interfaces/ukama-console/src/client/graphql/network-customers.graphql
+++ b/interfaces/ukama-console/src/client/graphql/network-customers.graphql
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# Network-lens customers screen — one query over the subscribersView
+# composite (read-only selection; business lens adds its own document).
+
+query NetworkCustomers($networkId: String!) {
+  subscribersView(networkId: $networkId) {
+    networkId
+    subscribers {
+      error {
+        ...SectionErrorFields
+      }
+      subscribers {
+        uuid
+        name
+        phone
+        email
+        networkId
+        sim {
+          id
+          iccid
+          msisdn
+          status
+          type
+          package {
+            package_id
+            is_active
+          }
+        }
+      }
+    }
+    plans {
+      error {
+        ...SectionErrorFields
+      }
+      plans {
+        packageId
+        name
+      }
+    }
+    usage {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}

--- a/interfaces/ukama-console/src/client/graphql/network-home.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/network-home.generated.ts
@@ -4,15 +4,78 @@ import { gql } from '@apollo/client';
 import { ViewSiteFragmentDoc, SectionErrorFieldsFragmentDoc } from './views-shared.generated';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
+export type TopBarAlertsQueryVariables = Types.Exact<{
+  networkId: Types.Scalars['String']['input'];
+}>;
+
+
+export type TopBarAlertsQuery = { __typename?: 'Query', networkOverview: { __typename?: 'NetworkOverview', networkId: string, latestAlerts: { __typename?: 'AlertsSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, notifications?: Array<{ __typename?: 'NotificationsDto', id: string, title: string, description: string, type: Types.Notification_Type, isRead: boolean, createdAt: string }> | null } } };
+
 export type NetworkHomeQueryVariables = Types.Exact<{
   networkId: Types.Scalars['String']['input'];
   alertLimit?: Types.Scalars['Int']['input'];
 }>;
 
 
-export type NetworkHomeQuery = { __typename?: 'Query', networkOverview: { __typename?: 'NetworkOverview', networkId: string, network: { __typename?: 'NetworkSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, network?: { __typename?: 'NetworkDto', id: string, name: string, isDefault: boolean } | null }, nodeStats: { __typename?: 'NodeStatsSection', total?: number | null, online?: number | null, offline?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, siteStats: { __typename?: 'SitesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, sites?: Array<{ __typename?: 'SiteDto', id: string, name: string, networkId: string, latitude: string, longitude: string, location: string, isDeactivated: boolean, installDate: string, createdAt: string }> | null }, subscriberStats: { __typename?: 'SubscriberStatsSection', total?: number | null, active?: number | null, inactive?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, latestAlerts: { __typename?: 'AlertsSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, notifications?: Array<{ __typename?: 'NotificationsDto', id: string, title: string, description: string, type: Types.Notification_Type, isRead: boolean, createdAt: string }> | null }, kpis: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+export type NetworkHomeQuery = { __typename?: 'Query', networkOverview: { __typename?: 'NetworkOverview', networkId: string, network: { __typename?: 'NetworkSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, network?: { __typename?: 'NetworkDto', id: string, name: string, isDefault: boolean } | null }, nodeStats: { __typename?: 'NodeStatsSection', total?: number | null, online?: number | null, offline?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, siteStats: { __typename?: 'SitesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, sites?: Array<{ __typename?: 'SiteDto', id: string, name: string, networkId: string, latitude: string, longitude: string, location: string, isDeactivated: boolean, installDate: string, createdAt: string }> | null }, subscriberStats: { __typename?: 'SubscriberStatsSection', total?: number | null, active?: number | null, inactive?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, latestAlerts: { __typename?: 'AlertsSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, notifications?: Array<{ __typename?: 'NotificationsDto', id: string, title: string, description: string, type: Types.Notification_Type, isRead: boolean, createdAt: string }> | null }, kpis: { __typename?: 'KpisSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, metrics?: Array<{ __typename?: 'KpiEntryDto', key: string, value: number, timestamp: number, success: boolean }> | null } } };
 
 
+export const TopBarAlertsDocument = gql`
+    query TopBarAlerts($networkId: String!) {
+  networkOverview(networkId: $networkId) {
+    networkId
+    latestAlerts(limit: 10) {
+      error {
+        ...SectionErrorFields
+      }
+      notifications {
+        id
+        title
+        description
+        type
+        isRead
+        createdAt
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}`;
+
+/**
+ * __useTopBarAlertsQuery__
+ *
+ * To run a query within a React component, call `useTopBarAlertsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTopBarAlertsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTopBarAlertsQuery({
+ *   variables: {
+ *      networkId: // value for 'networkId'
+ *   },
+ * });
+ */
+export function useTopBarAlertsQuery(baseOptions: Apollo.QueryHookOptions<TopBarAlertsQuery, TopBarAlertsQueryVariables> & ({ variables: TopBarAlertsQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TopBarAlertsQuery, TopBarAlertsQueryVariables>(TopBarAlertsDocument, options);
+      }
+export function useTopBarAlertsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TopBarAlertsQuery, TopBarAlertsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TopBarAlertsQuery, TopBarAlertsQueryVariables>(TopBarAlertsDocument, options);
+        }
+// @ts-ignore
+export function useTopBarAlertsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<TopBarAlertsQuery, TopBarAlertsQueryVariables>): Apollo.UseSuspenseQueryResult<TopBarAlertsQuery, TopBarAlertsQueryVariables>;
+export function useTopBarAlertsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TopBarAlertsQuery, TopBarAlertsQueryVariables>): Apollo.UseSuspenseQueryResult<TopBarAlertsQuery | undefined, TopBarAlertsQueryVariables>;
+export function useTopBarAlertsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TopBarAlertsQuery, TopBarAlertsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<TopBarAlertsQuery, TopBarAlertsQueryVariables>(TopBarAlertsDocument, options);
+        }
+export type TopBarAlertsQueryHookResult = ReturnType<typeof useTopBarAlertsQuery>;
+export type TopBarAlertsLazyQueryHookResult = ReturnType<typeof useTopBarAlertsLazyQuery>;
+export type TopBarAlertsSuspenseQueryHookResult = ReturnType<typeof useTopBarAlertsSuspenseQuery>;
+export type TopBarAlertsQueryResult = Apollo.QueryResult<TopBarAlertsQuery, TopBarAlertsQueryVariables>;
 export const NetworkHomeDocument = gql`
     query NetworkHome($networkId: String!, $alertLimit: Int! = 5) {
   networkOverview(networkId: $networkId) {
@@ -67,6 +130,12 @@ export const NetworkHomeDocument = gql`
     kpis {
       error {
         ...SectionErrorFields
+      }
+      metrics {
+        key
+        value
+        timestamp
+        success
       }
     }
   }

--- a/interfaces/ukama-console/src/client/graphql/network-home.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/network-home.generated.ts
@@ -1,0 +1,112 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+import { ViewSiteFragmentDoc, SectionErrorFieldsFragmentDoc } from './views-shared.generated';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type NetworkHomeQueryVariables = Types.Exact<{
+  networkId: Types.Scalars['String']['input'];
+  alertLimit?: Types.Scalars['Int']['input'];
+}>;
+
+
+export type NetworkHomeQuery = { __typename?: 'Query', networkOverview: { __typename?: 'NetworkOverview', networkId: string, network: { __typename?: 'NetworkSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, network?: { __typename?: 'NetworkDto', id: string, name: string, isDefault: boolean } | null }, nodeStats: { __typename?: 'NodeStatsSection', total?: number | null, online?: number | null, offline?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, siteStats: { __typename?: 'SitesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, sites?: Array<{ __typename?: 'SiteDto', id: string, name: string, networkId: string, latitude: string, longitude: string, location: string, isDeactivated: boolean, installDate: string, createdAt: string }> | null }, subscriberStats: { __typename?: 'SubscriberStatsSection', total?: number | null, active?: number | null, inactive?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, latestAlerts: { __typename?: 'AlertsSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, notifications?: Array<{ __typename?: 'NotificationsDto', id: string, title: string, description: string, type: Types.Notification_Type, isRead: boolean, createdAt: string }> | null }, kpis: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+
+
+export const NetworkHomeDocument = gql`
+    query NetworkHome($networkId: String!, $alertLimit: Int! = 5) {
+  networkOverview(networkId: $networkId) {
+    networkId
+    network {
+      error {
+        ...SectionErrorFields
+      }
+      network {
+        id
+        name
+        isDefault
+      }
+    }
+    nodeStats {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      online
+      offline
+    }
+    siteStats {
+      error {
+        ...SectionErrorFields
+      }
+      sites {
+        ...ViewSite
+      }
+    }
+    subscriberStats {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      active
+      inactive
+    }
+    latestAlerts(limit: $alertLimit) {
+      error {
+        ...SectionErrorFields
+      }
+      notifications {
+        id
+        title
+        description
+        type
+        isRead
+        createdAt
+      }
+    }
+    kpis {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}
+${ViewSiteFragmentDoc}`;
+
+/**
+ * __useNetworkHomeQuery__
+ *
+ * To run a query within a React component, call `useNetworkHomeQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNetworkHomeQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useNetworkHomeQuery({
+ *   variables: {
+ *      networkId: // value for 'networkId'
+ *      alertLimit: // value for 'alertLimit'
+ *   },
+ * });
+ */
+export function useNetworkHomeQuery(baseOptions: Apollo.QueryHookOptions<NetworkHomeQuery, NetworkHomeQueryVariables> & ({ variables: NetworkHomeQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<NetworkHomeQuery, NetworkHomeQueryVariables>(NetworkHomeDocument, options);
+      }
+export function useNetworkHomeLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NetworkHomeQuery, NetworkHomeQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<NetworkHomeQuery, NetworkHomeQueryVariables>(NetworkHomeDocument, options);
+        }
+// @ts-ignore
+export function useNetworkHomeSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<NetworkHomeQuery, NetworkHomeQueryVariables>): Apollo.UseSuspenseQueryResult<NetworkHomeQuery, NetworkHomeQueryVariables>;
+export function useNetworkHomeSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NetworkHomeQuery, NetworkHomeQueryVariables>): Apollo.UseSuspenseQueryResult<NetworkHomeQuery | undefined, NetworkHomeQueryVariables>;
+export function useNetworkHomeSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NetworkHomeQuery, NetworkHomeQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<NetworkHomeQuery, NetworkHomeQueryVariables>(NetworkHomeDocument, options);
+        }
+export type NetworkHomeQueryHookResult = ReturnType<typeof useNetworkHomeQuery>;
+export type NetworkHomeLazyQueryHookResult = ReturnType<typeof useNetworkHomeLazyQuery>;
+export type NetworkHomeSuspenseQueryHookResult = ReturnType<typeof useNetworkHomeSuspenseQuery>;
+export type NetworkHomeQueryResult = Apollo.QueryResult<NetworkHomeQuery, NetworkHomeQueryVariables>;

--- a/interfaces/ukama-console/src/client/graphql/network-home.graphql
+++ b/interfaces/ukama-console/src/client/graphql/network-home.graphql
@@ -6,6 +6,27 @@
 
 # Network home screen — one query over the networkOverview composite.
 
+# TopBar notifications menu — polled (~60s, visible tab) selection over the
+# same composite; shares the cache entry with NetworkHome.
+query TopBarAlerts($networkId: String!) {
+  networkOverview(networkId: $networkId) {
+    networkId
+    latestAlerts(limit: 10) {
+      error {
+        ...SectionErrorFields
+      }
+      notifications {
+        id
+        title
+        description
+        type
+        isRead
+        createdAt
+      }
+    }
+  }
+}
+
 query NetworkHome($networkId: String!, $alertLimit: Int! = 5) {
   networkOverview(networkId: $networkId) {
     networkId
@@ -59,6 +80,12 @@ query NetworkHome($networkId: String!, $alertLimit: Int! = 5) {
     kpis {
       error {
         ...SectionErrorFields
+      }
+      metrics {
+        key
+        value
+        timestamp
+        success
       }
     }
   }

--- a/interfaces/ukama-console/src/client/graphql/network-home.graphql
+++ b/interfaces/ukama-console/src/client/graphql/network-home.graphql
@@ -1,0 +1,65 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# Network home screen — one query over the networkOverview composite.
+
+query NetworkHome($networkId: String!, $alertLimit: Int! = 5) {
+  networkOverview(networkId: $networkId) {
+    networkId
+    network {
+      error {
+        ...SectionErrorFields
+      }
+      network {
+        id
+        name
+        isDefault
+      }
+    }
+    nodeStats {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      online
+      offline
+    }
+    siteStats {
+      error {
+        ...SectionErrorFields
+      }
+      sites {
+        ...ViewSite
+      }
+    }
+    subscriberStats {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      active
+      inactive
+    }
+    latestAlerts(limit: $alertLimit) {
+      error {
+        ...SectionErrorFields
+      }
+      notifications {
+        id
+        title
+        description
+        type
+        isRead
+        createdAt
+      }
+    }
+    kpis {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}

--- a/interfaces/ukama-console/src/client/graphql/node-detail.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/node-detail.generated.ts
@@ -9,7 +9,7 @@ export type NodeDetailQueryVariables = Types.Exact<{
 }>;
 
 
-export type NodeDetailQuery = { __typename?: 'Query', nodeView: { __typename?: 'NodeView', nodeId: string, node: { __typename?: 'NodeSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, node?: { __typename?: 'Node', latitude: string, longitude: string, id: string, name: string, type: Types.NodeTypeEnum, attached: Array<{ __typename?: 'AttachedNodes', id: string, name: string }>, site: { __typename?: 'NodeSite', siteId?: string | null, networkId?: string | null }, status: { __typename?: 'NodeStatus', connectivity: string, state: string } } | null }, health: { __typename?: 'HealthSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, health?: { __typename?: 'HealthInfo', timestamp: string, system: Array<{ __typename?: 'HealthSystemInfo', name: string, value: string }> } | null }, software: { __typename?: 'SoftwareSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, softwares?: { __typename?: 'Softwares', software: Array<{ __typename?: 'Software', name: string, status: Types.SoftwareStatusEnum, currentVersion: string, desiredVersion: string, releaseDate: string }> } | null }, stateHistory: { __typename?: 'NodeStateSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, stateHistory?: { __typename?: 'NodeStateRes', currentState: Types.NodeStateEnum, previousState?: Types.NodeStateEnum | null, createdAt: string } | null }, kpis: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, radioStatus: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+export type NodeDetailQuery = { __typename?: 'Query', nodeView: { __typename?: 'NodeView', nodeId: string, node: { __typename?: 'NodeSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, node?: { __typename?: 'Node', latitude: string, longitude: string, id: string, name: string, type: Types.NodeTypeEnum, attached: Array<{ __typename?: 'AttachedNodes', id: string, name: string }>, site: { __typename?: 'NodeSite', siteId?: string | null, networkId?: string | null }, status: { __typename?: 'NodeStatus', connectivity: string, state: string } } | null }, health: { __typename?: 'HealthSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, health?: { __typename?: 'HealthInfo', timestamp: string, system: Array<{ __typename?: 'HealthSystemInfo', name: string, value: string }> } | null }, software: { __typename?: 'SoftwareSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, softwares?: { __typename?: 'Softwares', software: Array<{ __typename?: 'Software', name: string, status: Types.SoftwareStatusEnum, currentVersion: string, desiredVersion: string, releaseDate: string }> } | null }, stateHistory: { __typename?: 'NodeStateSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, stateHistory?: { __typename?: 'NodeStateRes', currentState: Types.NodeStateEnum, previousState?: Types.NodeStateEnum | null, createdAt: string } | null }, kpis: { __typename?: 'KpisSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, metrics?: Array<{ __typename?: 'KpiEntryDto', key: string, value: number, timestamp: number, success: boolean }> | null }, radioStatus: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
 
 
 export const NodeDetailDocument = gql`
@@ -69,6 +69,12 @@ export const NodeDetailDocument = gql`
     kpis {
       error {
         ...SectionErrorFields
+      }
+      metrics {
+        key
+        value
+        timestamp
+        success
       }
     }
     radioStatus {

--- a/interfaces/ukama-console/src/client/graphql/node-detail.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/node-detail.generated.ts
@@ -1,0 +1,118 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+import { ViewNodeFragmentDoc, SectionErrorFieldsFragmentDoc } from './views-shared.generated';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type NodeDetailQueryVariables = Types.Exact<{
+  nodeId: Types.Scalars['String']['input'];
+}>;
+
+
+export type NodeDetailQuery = { __typename?: 'Query', nodeView: { __typename?: 'NodeView', nodeId: string, node: { __typename?: 'NodeSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, node?: { __typename?: 'Node', latitude: string, longitude: string, id: string, name: string, type: Types.NodeTypeEnum, attached: Array<{ __typename?: 'AttachedNodes', id: string, name: string }>, site: { __typename?: 'NodeSite', siteId?: string | null, networkId?: string | null }, status: { __typename?: 'NodeStatus', connectivity: string, state: string } } | null }, health: { __typename?: 'HealthSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, health?: { __typename?: 'HealthInfo', timestamp: string, system: Array<{ __typename?: 'HealthSystemInfo', name: string, value: string }> } | null }, software: { __typename?: 'SoftwareSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, softwares?: { __typename?: 'Softwares', software: Array<{ __typename?: 'Software', name: string, status: Types.SoftwareStatusEnum, currentVersion: string, desiredVersion: string, releaseDate: string }> } | null }, stateHistory: { __typename?: 'NodeStateSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, stateHistory?: { __typename?: 'NodeStateRes', currentState: Types.NodeStateEnum, previousState?: Types.NodeStateEnum | null, createdAt: string } | null }, kpis: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, radioStatus: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+
+
+export const NodeDetailDocument = gql`
+    query NodeDetail($nodeId: String!) {
+  nodeView(nodeId: $nodeId) {
+    nodeId
+    node {
+      error {
+        ...SectionErrorFields
+      }
+      node {
+        ...ViewNode
+        latitude
+        longitude
+        attached {
+          id
+          name
+        }
+      }
+    }
+    health {
+      error {
+        ...SectionErrorFields
+      }
+      health {
+        timestamp
+        system {
+          name
+          value
+        }
+      }
+    }
+    software {
+      error {
+        ...SectionErrorFields
+      }
+      softwares {
+        software {
+          name
+          status
+          currentVersion
+          desiredVersion
+          releaseDate
+        }
+      }
+    }
+    stateHistory {
+      error {
+        ...SectionErrorFields
+      }
+      stateHistory {
+        currentState
+        previousState
+        createdAt
+      }
+    }
+    kpis {
+      error {
+        ...SectionErrorFields
+      }
+    }
+    radioStatus {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}
+${ViewNodeFragmentDoc}`;
+
+/**
+ * __useNodeDetailQuery__
+ *
+ * To run a query within a React component, call `useNodeDetailQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNodeDetailQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useNodeDetailQuery({
+ *   variables: {
+ *      nodeId: // value for 'nodeId'
+ *   },
+ * });
+ */
+export function useNodeDetailQuery(baseOptions: Apollo.QueryHookOptions<NodeDetailQuery, NodeDetailQueryVariables> & ({ variables: NodeDetailQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<NodeDetailQuery, NodeDetailQueryVariables>(NodeDetailDocument, options);
+      }
+export function useNodeDetailLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NodeDetailQuery, NodeDetailQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<NodeDetailQuery, NodeDetailQueryVariables>(NodeDetailDocument, options);
+        }
+// @ts-ignore
+export function useNodeDetailSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<NodeDetailQuery, NodeDetailQueryVariables>): Apollo.UseSuspenseQueryResult<NodeDetailQuery, NodeDetailQueryVariables>;
+export function useNodeDetailSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NodeDetailQuery, NodeDetailQueryVariables>): Apollo.UseSuspenseQueryResult<NodeDetailQuery | undefined, NodeDetailQueryVariables>;
+export function useNodeDetailSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NodeDetailQuery, NodeDetailQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<NodeDetailQuery, NodeDetailQueryVariables>(NodeDetailDocument, options);
+        }
+export type NodeDetailQueryHookResult = ReturnType<typeof useNodeDetailQuery>;
+export type NodeDetailLazyQueryHookResult = ReturnType<typeof useNodeDetailLazyQuery>;
+export type NodeDetailSuspenseQueryHookResult = ReturnType<typeof useNodeDetailSuspenseQuery>;
+export type NodeDetailQueryResult = Apollo.QueryResult<NodeDetailQuery, NodeDetailQueryVariables>;

--- a/interfaces/ukama-console/src/client/graphql/node-detail.graphql
+++ b/interfaces/ukama-console/src/client/graphql/node-detail.graphql
@@ -63,6 +63,12 @@ query NodeDetail($nodeId: String!) {
       error {
         ...SectionErrorFields
       }
+      metrics {
+        key
+        value
+        timestamp
+        success
+      }
     }
     radioStatus {
       error {

--- a/interfaces/ukama-console/src/client/graphql/node-detail.graphql
+++ b/interfaces/ukama-console/src/client/graphql/node-detail.graphql
@@ -1,0 +1,73 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# Node detail screen — one query over the nodeView composite.
+
+query NodeDetail($nodeId: String!) {
+  nodeView(nodeId: $nodeId) {
+    nodeId
+    node {
+      error {
+        ...SectionErrorFields
+      }
+      node {
+        ...ViewNode
+        latitude
+        longitude
+        attached {
+          id
+          name
+        }
+      }
+    }
+    health {
+      error {
+        ...SectionErrorFields
+      }
+      health {
+        timestamp
+        system {
+          name
+          value
+        }
+      }
+    }
+    software {
+      error {
+        ...SectionErrorFields
+      }
+      softwares {
+        software {
+          name
+          status
+          currentVersion
+          desiredVersion
+          releaseDate
+        }
+      }
+    }
+    stateHistory {
+      error {
+        ...SectionErrorFields
+      }
+      stateHistory {
+        currentState
+        previousState
+        createdAt
+      }
+    }
+    kpis {
+      error {
+        ...SectionErrorFields
+      }
+    }
+    radioStatus {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}

--- a/interfaces/ukama-console/src/client/graphql/nodes-list.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/nodes-list.generated.ts
@@ -1,0 +1,127 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+import { ViewNodeFragmentDoc, SectionErrorFieldsFragmentDoc } from './views-shared.generated';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type NodesListQueryVariables = Types.Exact<{
+  networkId?: Types.InputMaybe<Types.Scalars['String']['input']>;
+}>;
+
+
+export type NodesListQuery = { __typename?: 'Query', nodesView: { __typename?: 'NodesView', networkId?: string | null, nodes: { __typename?: 'NodesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, nodes?: Array<{ __typename?: 'Node', id: string, name: string, type: Types.NodeTypeEnum, site: { __typename?: 'NodeSite', siteId?: string | null, networkId?: string | null }, status: { __typename?: 'NodeStatus', connectivity: string, state: string } }> | null }, health: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+
+export type NodePoolQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type NodePoolQuery = { __typename?: 'Query', nodesView: { __typename?: 'NodesView', networkId?: string | null, nodes: { __typename?: 'NodesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, nodes?: Array<{ __typename?: 'Node', id: string, name: string, type: Types.NodeTypeEnum, site: { __typename?: 'NodeSite', siteId?: string | null, networkId?: string | null }, status: { __typename?: 'NodeStatus', connectivity: string, state: string } }> | null } } };
+
+
+export const NodesListDocument = gql`
+    query NodesList($networkId: String) {
+  nodesView(networkId: $networkId) {
+    networkId
+    nodes {
+      error {
+        ...SectionErrorFields
+      }
+      nodes {
+        ...ViewNode
+      }
+    }
+    health {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}
+${ViewNodeFragmentDoc}`;
+
+/**
+ * __useNodesListQuery__
+ *
+ * To run a query within a React component, call `useNodesListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNodesListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useNodesListQuery({
+ *   variables: {
+ *      networkId: // value for 'networkId'
+ *   },
+ * });
+ */
+export function useNodesListQuery(baseOptions?: Apollo.QueryHookOptions<NodesListQuery, NodesListQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<NodesListQuery, NodesListQueryVariables>(NodesListDocument, options);
+      }
+export function useNodesListLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NodesListQuery, NodesListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<NodesListQuery, NodesListQueryVariables>(NodesListDocument, options);
+        }
+// @ts-ignore
+export function useNodesListSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<NodesListQuery, NodesListQueryVariables>): Apollo.UseSuspenseQueryResult<NodesListQuery, NodesListQueryVariables>;
+export function useNodesListSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NodesListQuery, NodesListQueryVariables>): Apollo.UseSuspenseQueryResult<NodesListQuery | undefined, NodesListQueryVariables>;
+export function useNodesListSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NodesListQuery, NodesListQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<NodesListQuery, NodesListQueryVariables>(NodesListDocument, options);
+        }
+export type NodesListQueryHookResult = ReturnType<typeof useNodesListQuery>;
+export type NodesListLazyQueryHookResult = ReturnType<typeof useNodesListLazyQuery>;
+export type NodesListSuspenseQueryHookResult = ReturnType<typeof useNodesListSuspenseQuery>;
+export type NodesListQueryResult = Apollo.QueryResult<NodesListQuery, NodesListQueryVariables>;
+export const NodePoolDocument = gql`
+    query NodePool {
+  nodesView {
+    networkId
+    nodes {
+      error {
+        ...SectionErrorFields
+      }
+      nodes {
+        ...ViewNode
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}
+${ViewNodeFragmentDoc}`;
+
+/**
+ * __useNodePoolQuery__
+ *
+ * To run a query within a React component, call `useNodePoolQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNodePoolQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useNodePoolQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useNodePoolQuery(baseOptions?: Apollo.QueryHookOptions<NodePoolQuery, NodePoolQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<NodePoolQuery, NodePoolQueryVariables>(NodePoolDocument, options);
+      }
+export function useNodePoolLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NodePoolQuery, NodePoolQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<NodePoolQuery, NodePoolQueryVariables>(NodePoolDocument, options);
+        }
+// @ts-ignore
+export function useNodePoolSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<NodePoolQuery, NodePoolQueryVariables>): Apollo.UseSuspenseQueryResult<NodePoolQuery, NodePoolQueryVariables>;
+export function useNodePoolSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NodePoolQuery, NodePoolQueryVariables>): Apollo.UseSuspenseQueryResult<NodePoolQuery | undefined, NodePoolQueryVariables>;
+export function useNodePoolSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NodePoolQuery, NodePoolQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<NodePoolQuery, NodePoolQueryVariables>(NodePoolDocument, options);
+        }
+export type NodePoolQueryHookResult = ReturnType<typeof useNodePoolQuery>;
+export type NodePoolLazyQueryHookResult = ReturnType<typeof useNodePoolLazyQuery>;
+export type NodePoolSuspenseQueryHookResult = ReturnType<typeof useNodePoolSuspenseQuery>;
+export type NodePoolQueryResult = Apollo.QueryResult<NodePoolQuery, NodePoolQueryVariables>;

--- a/interfaces/ukama-console/src/client/graphql/nodes-list.graphql
+++ b/interfaces/ukama-console/src/client/graphql/nodes-list.graphql
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# Nodes list screen + node pool screen — two operations over the nodesView
+# composite (node pool skips the `health` gap section entirely).
+
+query NodesList($networkId: String) {
+  nodesView(networkId: $networkId) {
+    networkId
+    nodes {
+      error {
+        ...SectionErrorFields
+      }
+      nodes {
+        ...ViewNode
+      }
+    }
+    health {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}
+
+query NodePool {
+  nodesView {
+    networkId
+    nodes {
+      error {
+        ...SectionErrorFields
+      }
+      nodes {
+        ...ViewNode
+      }
+    }
+  }
+}

--- a/interfaces/ukama-console/src/client/graphql/range-metrics.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/range-metrics.generated.ts
@@ -1,0 +1,64 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type MetricsRangeQueryVariables = Types.Exact<{
+  data: Types.MetricsRangeInput;
+}>;
+
+
+export type MetricsRangeQuery = { __typename?: 'Query', metricsRange: { __typename?: 'MetricsRes', metrics: Array<{ __typename?: 'MetricRes', type: string, success: boolean, nodeId?: string | null, siteId?: string | null, values: Array<Array<number>>, unit?: string | null, format?: string | null }> } };
+
+
+export const MetricsRangeDocument = gql`
+    query MetricsRange($data: MetricsRangeInput!) {
+  metricsRange(data: $data) {
+    metrics {
+      type
+      success
+      nodeId
+      siteId
+      values
+      unit
+      format
+    }
+  }
+}
+    `;
+
+/**
+ * __useMetricsRangeQuery__
+ *
+ * To run a query within a React component, call `useMetricsRangeQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMetricsRangeQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMetricsRangeQuery({
+ *   variables: {
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useMetricsRangeQuery(baseOptions: Apollo.QueryHookOptions<MetricsRangeQuery, MetricsRangeQueryVariables> & ({ variables: MetricsRangeQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MetricsRangeQuery, MetricsRangeQueryVariables>(MetricsRangeDocument, options);
+      }
+export function useMetricsRangeLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MetricsRangeQuery, MetricsRangeQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MetricsRangeQuery, MetricsRangeQueryVariables>(MetricsRangeDocument, options);
+        }
+// @ts-ignore
+export function useMetricsRangeSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<MetricsRangeQuery, MetricsRangeQueryVariables>): Apollo.UseSuspenseQueryResult<MetricsRangeQuery, MetricsRangeQueryVariables>;
+export function useMetricsRangeSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<MetricsRangeQuery, MetricsRangeQueryVariables>): Apollo.UseSuspenseQueryResult<MetricsRangeQuery | undefined, MetricsRangeQueryVariables>;
+export function useMetricsRangeSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<MetricsRangeQuery, MetricsRangeQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<MetricsRangeQuery, MetricsRangeQueryVariables>(MetricsRangeDocument, options);
+        }
+export type MetricsRangeQueryHookResult = ReturnType<typeof useMetricsRangeQuery>;
+export type MetricsRangeLazyQueryHookResult = ReturnType<typeof useMetricsRangeLazyQuery>;
+export type MetricsRangeSuspenseQueryHookResult = ReturnType<typeof useMetricsRangeSuspenseQuery>;
+export type MetricsRangeQueryResult = Apollo.QueryResult<MetricsRangeQuery, MetricsRangeQueryVariables>;

--- a/interfaces/ukama-console/src/client/graphql/range-metrics.graphql
+++ b/interfaces/ukama-console/src/client/graphql/range-metrics.graphql
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# Polled range metrics for charts (plan Phase 4 — polling only, no
+# subscriptions in v1). Poll with a screen-scoped, visibility-gated interval.
+
+query MetricsRange($data: MetricsRangeInput!) {
+  metricsRange(data: $data) {
+    metrics {
+      type
+      success
+      nodeId
+      siteId
+      values
+      unit
+      format
+    }
+  }
+}

--- a/interfaces/ukama-console/src/client/graphql/sim-pool.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/sim-pool.generated.ts
@@ -1,0 +1,87 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+import { SectionErrorFieldsFragmentDoc } from './views-shared.generated';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type SimPoolOverviewQueryVariables = Types.Exact<{
+  simType: Types.Scalars['String']['input'];
+  limit?: Types.Scalars['Int']['input'];
+}>;
+
+
+export type SimPoolOverviewQuery = { __typename?: 'Query', simPoolView: { __typename?: 'SimPoolView', simType: string, stats: { __typename?: 'SimPoolStatsSection', total?: number | null, available?: number | null, consumed?: number | null, failed?: number | null, esim?: number | null, physical?: number | null, pctAssigned?: number | null, lowStock?: boolean | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, sims: { __typename?: 'PoolSimsSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, sims?: Array<{ __typename?: 'SimPoolResDto', id: string, iccid: string, msisdn: string, isAllocated: boolean, isFailed: boolean, simType: string, isPhysical: boolean, createdAt: string }> | null } } };
+
+
+export const SimPoolOverviewDocument = gql`
+    query SimPoolOverview($simType: String!, $limit: Int! = 20) {
+  simPoolView(simType: $simType) {
+    simType
+    stats {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      available
+      consumed
+      failed
+      esim
+      physical
+      pctAssigned
+      lowStock
+    }
+    sims(limit: $limit) {
+      error {
+        ...SectionErrorFields
+      }
+      sims {
+        id
+        iccid
+        msisdn
+        isAllocated
+        isFailed
+        simType
+        isPhysical
+        createdAt
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}`;
+
+/**
+ * __useSimPoolOverviewQuery__
+ *
+ * To run a query within a React component, call `useSimPoolOverviewQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSimPoolOverviewQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSimPoolOverviewQuery({
+ *   variables: {
+ *      simType: // value for 'simType'
+ *      limit: // value for 'limit'
+ *   },
+ * });
+ */
+export function useSimPoolOverviewQuery(baseOptions: Apollo.QueryHookOptions<SimPoolOverviewQuery, SimPoolOverviewQueryVariables> & ({ variables: SimPoolOverviewQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SimPoolOverviewQuery, SimPoolOverviewQueryVariables>(SimPoolOverviewDocument, options);
+      }
+export function useSimPoolOverviewLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SimPoolOverviewQuery, SimPoolOverviewQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SimPoolOverviewQuery, SimPoolOverviewQueryVariables>(SimPoolOverviewDocument, options);
+        }
+// @ts-ignore
+export function useSimPoolOverviewSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<SimPoolOverviewQuery, SimPoolOverviewQueryVariables>): Apollo.UseSuspenseQueryResult<SimPoolOverviewQuery, SimPoolOverviewQueryVariables>;
+export function useSimPoolOverviewSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SimPoolOverviewQuery, SimPoolOverviewQueryVariables>): Apollo.UseSuspenseQueryResult<SimPoolOverviewQuery | undefined, SimPoolOverviewQueryVariables>;
+export function useSimPoolOverviewSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SimPoolOverviewQuery, SimPoolOverviewQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<SimPoolOverviewQuery, SimPoolOverviewQueryVariables>(SimPoolOverviewDocument, options);
+        }
+export type SimPoolOverviewQueryHookResult = ReturnType<typeof useSimPoolOverviewQuery>;
+export type SimPoolOverviewLazyQueryHookResult = ReturnType<typeof useSimPoolOverviewLazyQuery>;
+export type SimPoolOverviewSuspenseQueryHookResult = ReturnType<typeof useSimPoolOverviewSuspenseQuery>;
+export type SimPoolOverviewQueryResult = Apollo.QueryResult<SimPoolOverviewQuery, SimPoolOverviewQueryVariables>;

--- a/interfaces/ukama-console/src/client/graphql/sim-pool.graphql
+++ b/interfaces/ukama-console/src/client/graphql/sim-pool.graphql
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# SIM pool screen (network + business manage) — one query over the
+# simPoolView composite; both screens use this document.
+
+query SimPoolOverview($simType: String!, $limit: Int! = 20) {
+  simPoolView(simType: $simType) {
+    simType
+    stats {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      available
+      consumed
+      failed
+      esim
+      physical
+      pctAssigned
+      lowStock
+    }
+    sims(limit: $limit) {
+      error {
+        ...SectionErrorFields
+      }
+      sims {
+        id
+        iccid
+        msisdn
+        isAllocated
+        isFailed
+        simType
+        isPhysical
+        createdAt
+      }
+    }
+  }
+}

--- a/interfaces/ukama-console/src/client/graphql/site-detail.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/site-detail.generated.ts
@@ -9,7 +9,7 @@ export type NetworkSiteDetailQueryVariables = Types.Exact<{
 }>;
 
 
-export type NetworkSiteDetailQuery = { __typename?: 'Query', siteView: { __typename?: 'SiteView', siteId: string, site: { __typename?: 'SiteSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, site?: { __typename?: 'SiteDto', id: string, name: string, networkId: string, latitude: string, longitude: string, location: string, isDeactivated: boolean, installDate: string, createdAt: string } | null }, nodes: { __typename?: 'NodesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, nodes?: Array<{ __typename?: 'Node', id: string, name: string, type: Types.NodeTypeEnum, site: { __typename?: 'NodeSite', siteId?: string | null, networkId?: string | null }, status: { __typename?: 'NodeStatus', connectivity: string, state: string } }> | null }, components: { __typename?: 'SiteComponentsSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, components?: Array<{ __typename?: 'SiteComponentDto', elementType: string, componentId?: string | null, componentName?: string | null }> | null }, power: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, kpis: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+export type NetworkSiteDetailQuery = { __typename?: 'Query', siteView: { __typename?: 'SiteView', siteId: string, site: { __typename?: 'SiteSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, site?: { __typename?: 'SiteDto', id: string, name: string, networkId: string, latitude: string, longitude: string, location: string, isDeactivated: boolean, installDate: string, createdAt: string } | null }, nodes: { __typename?: 'NodesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, nodes?: Array<{ __typename?: 'Node', id: string, name: string, type: Types.NodeTypeEnum, site: { __typename?: 'NodeSite', siteId?: string | null, networkId?: string | null }, status: { __typename?: 'NodeStatus', connectivity: string, state: string } }> | null }, components: { __typename?: 'SiteComponentsSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, components?: Array<{ __typename?: 'SiteComponentDto', elementType: string, componentId?: string | null, componentName?: string | null }> | null }, power: { __typename?: 'KpisSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, metrics?: Array<{ __typename?: 'KpiEntryDto', key: string, value: number, timestamp: number, success: boolean }> | null }, kpis: { __typename?: 'KpisSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, metrics?: Array<{ __typename?: 'KpiEntryDto', key: string, value: number, timestamp: number, success: boolean }> | null } } };
 
 
 export const NetworkSiteDetailDocument = gql`
@@ -46,10 +46,22 @@ export const NetworkSiteDetailDocument = gql`
       error {
         ...SectionErrorFields
       }
+      metrics {
+        key
+        value
+        timestamp
+        success
+      }
     }
     kpis {
       error {
         ...SectionErrorFields
+      }
+      metrics {
+        key
+        value
+        timestamp
+        success
       }
     }
   }

--- a/interfaces/ukama-console/src/client/graphql/site-detail.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/site-detail.generated.ts
@@ -1,0 +1,95 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+import { ViewNodeFragmentDoc, ViewSiteFragmentDoc, SectionErrorFieldsFragmentDoc } from './views-shared.generated';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type NetworkSiteDetailQueryVariables = Types.Exact<{
+  siteId: Types.Scalars['String']['input'];
+}>;
+
+
+export type NetworkSiteDetailQuery = { __typename?: 'Query', siteView: { __typename?: 'SiteView', siteId: string, site: { __typename?: 'SiteSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, site?: { __typename?: 'SiteDto', id: string, name: string, networkId: string, latitude: string, longitude: string, location: string, isDeactivated: boolean, installDate: string, createdAt: string } | null }, nodes: { __typename?: 'NodesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, nodes?: Array<{ __typename?: 'Node', id: string, name: string, type: Types.NodeTypeEnum, site: { __typename?: 'NodeSite', siteId?: string | null, networkId?: string | null }, status: { __typename?: 'NodeStatus', connectivity: string, state: string } }> | null }, components: { __typename?: 'SiteComponentsSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, components?: Array<{ __typename?: 'SiteComponentDto', elementType: string, componentId?: string | null, componentName?: string | null }> | null }, power: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null }, kpis: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+
+
+export const NetworkSiteDetailDocument = gql`
+    query NetworkSiteDetail($siteId: String!) {
+  siteView(siteId: $siteId) {
+    siteId
+    site {
+      error {
+        ...SectionErrorFields
+      }
+      site {
+        ...ViewSite
+      }
+    }
+    nodes {
+      error {
+        ...SectionErrorFields
+      }
+      nodes {
+        ...ViewNode
+      }
+    }
+    components {
+      error {
+        ...SectionErrorFields
+      }
+      components {
+        elementType
+        componentId
+        componentName
+      }
+    }
+    power {
+      error {
+        ...SectionErrorFields
+      }
+    }
+    kpis {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}
+${ViewSiteFragmentDoc}
+${ViewNodeFragmentDoc}`;
+
+/**
+ * __useNetworkSiteDetailQuery__
+ *
+ * To run a query within a React component, call `useNetworkSiteDetailQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNetworkSiteDetailQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useNetworkSiteDetailQuery({
+ *   variables: {
+ *      siteId: // value for 'siteId'
+ *   },
+ * });
+ */
+export function useNetworkSiteDetailQuery(baseOptions: Apollo.QueryHookOptions<NetworkSiteDetailQuery, NetworkSiteDetailQueryVariables> & ({ variables: NetworkSiteDetailQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<NetworkSiteDetailQuery, NetworkSiteDetailQueryVariables>(NetworkSiteDetailDocument, options);
+      }
+export function useNetworkSiteDetailLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NetworkSiteDetailQuery, NetworkSiteDetailQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<NetworkSiteDetailQuery, NetworkSiteDetailQueryVariables>(NetworkSiteDetailDocument, options);
+        }
+// @ts-ignore
+export function useNetworkSiteDetailSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<NetworkSiteDetailQuery, NetworkSiteDetailQueryVariables>): Apollo.UseSuspenseQueryResult<NetworkSiteDetailQuery, NetworkSiteDetailQueryVariables>;
+export function useNetworkSiteDetailSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NetworkSiteDetailQuery, NetworkSiteDetailQueryVariables>): Apollo.UseSuspenseQueryResult<NetworkSiteDetailQuery | undefined, NetworkSiteDetailQueryVariables>;
+export function useNetworkSiteDetailSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NetworkSiteDetailQuery, NetworkSiteDetailQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<NetworkSiteDetailQuery, NetworkSiteDetailQueryVariables>(NetworkSiteDetailDocument, options);
+        }
+export type NetworkSiteDetailQueryHookResult = ReturnType<typeof useNetworkSiteDetailQuery>;
+export type NetworkSiteDetailLazyQueryHookResult = ReturnType<typeof useNetworkSiteDetailLazyQuery>;
+export type NetworkSiteDetailSuspenseQueryHookResult = ReturnType<typeof useNetworkSiteDetailSuspenseQuery>;
+export type NetworkSiteDetailQueryResult = Apollo.QueryResult<NetworkSiteDetailQuery, NetworkSiteDetailQueryVariables>;

--- a/interfaces/ukama-console/src/client/graphql/site-detail.graphql
+++ b/interfaces/ukama-console/src/client/graphql/site-detail.graphql
@@ -40,10 +40,22 @@ query NetworkSiteDetail($siteId: String!) {
       error {
         ...SectionErrorFields
       }
+      metrics {
+        key
+        value
+        timestamp
+        success
+      }
     }
     kpis {
       error {
         ...SectionErrorFields
+      }
+      metrics {
+        key
+        value
+        timestamp
+        success
       }
     }
   }

--- a/interfaces/ukama-console/src/client/graphql/site-detail.graphql
+++ b/interfaces/ukama-console/src/client/graphql/site-detail.graphql
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# Network site detail screen — one query over the siteView composite
+# (network lens selection: skips `financials`).
+
+query NetworkSiteDetail($siteId: String!) {
+  siteView(siteId: $siteId) {
+    siteId
+    site {
+      error {
+        ...SectionErrorFields
+      }
+      site {
+        ...ViewSite
+      }
+    }
+    nodes {
+      error {
+        ...SectionErrorFields
+      }
+      nodes {
+        ...ViewNode
+      }
+    }
+    components {
+      error {
+        ...SectionErrorFields
+      }
+      components {
+        elementType
+        componentId
+        componentName
+      }
+    }
+    power {
+      error {
+        ...SectionErrorFields
+      }
+    }
+    kpis {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}

--- a/interfaces/ukama-console/src/client/graphql/sites-list.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/sites-list.generated.ts
@@ -1,0 +1,82 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+import { ViewSiteFragmentDoc, SectionErrorFieldsFragmentDoc } from './views-shared.generated';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type SitesListQueryVariables = Types.Exact<{
+  networkId: Types.Scalars['String']['input'];
+}>;
+
+
+export type SitesListQuery = { __typename?: 'Query', sitesView: { __typename?: 'SitesView', networkId: string, sites: { __typename?: 'SitesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, sites?: Array<{ __typename?: 'SiteDto', id: string, name: string, networkId: string, latitude: string, longitude: string, location: string, isDeactivated: boolean, installDate: string, createdAt: string }> | null }, nodeCounts: { __typename?: 'SiteNodeCountsSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, counts?: Array<{ __typename?: 'SiteNodeCountDto', siteId: string, total: number, online: number, offline: number }> | null }, kpis: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+
+
+export const SitesListDocument = gql`
+    query SitesList($networkId: String!) {
+  sitesView(networkId: $networkId) {
+    networkId
+    sites {
+      error {
+        ...SectionErrorFields
+      }
+      sites {
+        ...ViewSite
+      }
+    }
+    nodeCounts {
+      error {
+        ...SectionErrorFields
+      }
+      counts {
+        siteId
+        total
+        online
+        offline
+      }
+    }
+    kpis {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}
+${ViewSiteFragmentDoc}`;
+
+/**
+ * __useSitesListQuery__
+ *
+ * To run a query within a React component, call `useSitesListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSitesListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSitesListQuery({
+ *   variables: {
+ *      networkId: // value for 'networkId'
+ *   },
+ * });
+ */
+export function useSitesListQuery(baseOptions: Apollo.QueryHookOptions<SitesListQuery, SitesListQueryVariables> & ({ variables: SitesListQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SitesListQuery, SitesListQueryVariables>(SitesListDocument, options);
+      }
+export function useSitesListLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SitesListQuery, SitesListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SitesListQuery, SitesListQueryVariables>(SitesListDocument, options);
+        }
+// @ts-ignore
+export function useSitesListSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<SitesListQuery, SitesListQueryVariables>): Apollo.UseSuspenseQueryResult<SitesListQuery, SitesListQueryVariables>;
+export function useSitesListSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SitesListQuery, SitesListQueryVariables>): Apollo.UseSuspenseQueryResult<SitesListQuery | undefined, SitesListQueryVariables>;
+export function useSitesListSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SitesListQuery, SitesListQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<SitesListQuery, SitesListQueryVariables>(SitesListDocument, options);
+        }
+export type SitesListQueryHookResult = ReturnType<typeof useSitesListQuery>;
+export type SitesListLazyQueryHookResult = ReturnType<typeof useSitesListLazyQuery>;
+export type SitesListSuspenseQueryHookResult = ReturnType<typeof useSitesListSuspenseQuery>;
+export type SitesListQueryResult = Apollo.QueryResult<SitesListQuery, SitesListQueryVariables>;

--- a/interfaces/ukama-console/src/client/graphql/sites-list.graphql
+++ b/interfaces/ukama-console/src/client/graphql/sites-list.graphql
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# Sites list screen — one query over the sitesView composite (network lens
+# selection: skips `financials`).
+
+query SitesList($networkId: String!) {
+  sitesView(networkId: $networkId) {
+    networkId
+    sites {
+      error {
+        ...SectionErrorFields
+      }
+      sites {
+        ...ViewSite
+      }
+    }
+    nodeCounts {
+      error {
+        ...SectionErrorFields
+      }
+      counts {
+        siteId
+        total
+        online
+        offline
+      }
+    }
+    kpis {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}

--- a/interfaces/ukama-console/src/client/graphql/team.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/team.generated.ts
@@ -1,0 +1,240 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+import { ViewNodeFragmentDoc, SectionErrorFieldsFragmentDoc } from './views-shared.generated';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type TeamListQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type TeamListQuery = { __typename?: 'Query', membersView: { __typename?: 'MembersView', orgName: string, team: { __typename?: 'TeamSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, rows?: Array<{ __typename?: 'TeamMemberDto', id: string, name?: string | null, email?: string | null, role: string, status: string, memberSince?: string | null, inviteExpiresAt?: string | null }> | null } } };
+
+export type InventoryOverviewQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type InventoryOverviewQuery = { __typename?: 'Query', inventoryView: { __typename?: 'InventoryView', orgName: string, components: { __typename?: 'ComponentStatsSection', total?: number | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, byCategory?: Array<{ __typename?: 'CategoryCountDto', category: string, count: number }> | null }, unassignedNodes: { __typename?: 'NodesSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, nodes?: Array<{ __typename?: 'Node', id: string, name: string, type: Types.NodeTypeEnum, site: { __typename?: 'NodeSite', siteId?: string | null, networkId?: string | null }, status: { __typename?: 'NodeStatus', connectivity: string, state: string } }> | null }, simStock: { __typename?: 'SimPoolStatsSection', total?: number | null, available?: number | null, consumed?: number | null, pctAssigned?: number | null, lowStock?: boolean | null, error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+
+export type SubscriberDetailQueryVariables = Types.Exact<{
+  subscriberId: Types.Scalars['String']['input'];
+}>;
+
+
+export type SubscriberDetailQuery = { __typename?: 'Query', subscriberView: { __typename?: 'SubscriberView', subscriberId: string, subscriber: { __typename?: 'SubscriberSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, subscriber?: { __typename?: 'SubscriberDto', uuid: string, name: string, email: string, phone: string, networkId: string, sim?: Array<{ __typename?: 'SubscriberSimDto', id: string, iccid: string, msisdn: string, status: string, type: string }> | null } | null }, plans: { __typename?: 'SubscriberPlansSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, plans?: Array<{ __typename?: 'PlanNameDto', packageId: string, name: string }> | null }, billing: { __typename?: 'SubscriberBillingSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null, payments?: Array<{ __typename?: 'PaymentDto', id: string, amount: string, currency: string, status: string, paidAt: string, paymentMethod: string }> | null }, usage: { __typename?: 'GapSection', error?: { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string } | null } } };
+
+
+export const TeamListDocument = gql`
+    query TeamList {
+  membersView {
+    orgName
+    team {
+      error {
+        ...SectionErrorFields
+      }
+      rows {
+        id
+        name
+        email
+        role
+        status
+        memberSince
+        inviteExpiresAt
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}`;
+
+/**
+ * __useTeamListQuery__
+ *
+ * To run a query within a React component, call `useTeamListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTeamListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTeamListQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useTeamListQuery(baseOptions?: Apollo.QueryHookOptions<TeamListQuery, TeamListQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TeamListQuery, TeamListQueryVariables>(TeamListDocument, options);
+      }
+export function useTeamListLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TeamListQuery, TeamListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TeamListQuery, TeamListQueryVariables>(TeamListDocument, options);
+        }
+// @ts-ignore
+export function useTeamListSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<TeamListQuery, TeamListQueryVariables>): Apollo.UseSuspenseQueryResult<TeamListQuery, TeamListQueryVariables>;
+export function useTeamListSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TeamListQuery, TeamListQueryVariables>): Apollo.UseSuspenseQueryResult<TeamListQuery | undefined, TeamListQueryVariables>;
+export function useTeamListSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TeamListQuery, TeamListQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<TeamListQuery, TeamListQueryVariables>(TeamListDocument, options);
+        }
+export type TeamListQueryHookResult = ReturnType<typeof useTeamListQuery>;
+export type TeamListLazyQueryHookResult = ReturnType<typeof useTeamListLazyQuery>;
+export type TeamListSuspenseQueryHookResult = ReturnType<typeof useTeamListSuspenseQuery>;
+export type TeamListQueryResult = Apollo.QueryResult<TeamListQuery, TeamListQueryVariables>;
+export const InventoryOverviewDocument = gql`
+    query InventoryOverview {
+  inventoryView {
+    orgName
+    components {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      byCategory {
+        category
+        count
+      }
+    }
+    unassignedNodes {
+      error {
+        ...SectionErrorFields
+      }
+      nodes {
+        ...ViewNode
+      }
+    }
+    simStock {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      available
+      consumed
+      pctAssigned
+      lowStock
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}
+${ViewNodeFragmentDoc}`;
+
+/**
+ * __useInventoryOverviewQuery__
+ *
+ * To run a query within a React component, call `useInventoryOverviewQuery` and pass it any options that fit your needs.
+ * When your component renders, `useInventoryOverviewQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useInventoryOverviewQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useInventoryOverviewQuery(baseOptions?: Apollo.QueryHookOptions<InventoryOverviewQuery, InventoryOverviewQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<InventoryOverviewQuery, InventoryOverviewQueryVariables>(InventoryOverviewDocument, options);
+      }
+export function useInventoryOverviewLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<InventoryOverviewQuery, InventoryOverviewQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<InventoryOverviewQuery, InventoryOverviewQueryVariables>(InventoryOverviewDocument, options);
+        }
+// @ts-ignore
+export function useInventoryOverviewSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<InventoryOverviewQuery, InventoryOverviewQueryVariables>): Apollo.UseSuspenseQueryResult<InventoryOverviewQuery, InventoryOverviewQueryVariables>;
+export function useInventoryOverviewSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<InventoryOverviewQuery, InventoryOverviewQueryVariables>): Apollo.UseSuspenseQueryResult<InventoryOverviewQuery | undefined, InventoryOverviewQueryVariables>;
+export function useInventoryOverviewSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<InventoryOverviewQuery, InventoryOverviewQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<InventoryOverviewQuery, InventoryOverviewQueryVariables>(InventoryOverviewDocument, options);
+        }
+export type InventoryOverviewQueryHookResult = ReturnType<typeof useInventoryOverviewQuery>;
+export type InventoryOverviewLazyQueryHookResult = ReturnType<typeof useInventoryOverviewLazyQuery>;
+export type InventoryOverviewSuspenseQueryHookResult = ReturnType<typeof useInventoryOverviewSuspenseQuery>;
+export type InventoryOverviewQueryResult = Apollo.QueryResult<InventoryOverviewQuery, InventoryOverviewQueryVariables>;
+export const SubscriberDetailDocument = gql`
+    query SubscriberDetail($subscriberId: String!) {
+  subscriberView(subscriberId: $subscriberId) {
+    subscriberId
+    subscriber {
+      error {
+        ...SectionErrorFields
+      }
+      subscriber {
+        uuid
+        name
+        email
+        phone
+        networkId
+        sim {
+          id
+          iccid
+          msisdn
+          status
+          type
+        }
+      }
+    }
+    plans {
+      error {
+        ...SectionErrorFields
+      }
+      plans {
+        packageId
+        name
+      }
+    }
+    billing {
+      error {
+        ...SectionErrorFields
+      }
+      payments {
+        id
+        amount
+        currency
+        status
+        paidAt
+        paymentMethod
+      }
+    }
+    usage {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}
+    ${SectionErrorFieldsFragmentDoc}`;
+
+/**
+ * __useSubscriberDetailQuery__
+ *
+ * To run a query within a React component, call `useSubscriberDetailQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSubscriberDetailQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSubscriberDetailQuery({
+ *   variables: {
+ *      subscriberId: // value for 'subscriberId'
+ *   },
+ * });
+ */
+export function useSubscriberDetailQuery(baseOptions: Apollo.QueryHookOptions<SubscriberDetailQuery, SubscriberDetailQueryVariables> & ({ variables: SubscriberDetailQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SubscriberDetailQuery, SubscriberDetailQueryVariables>(SubscriberDetailDocument, options);
+      }
+export function useSubscriberDetailLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SubscriberDetailQuery, SubscriberDetailQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SubscriberDetailQuery, SubscriberDetailQueryVariables>(SubscriberDetailDocument, options);
+        }
+// @ts-ignore
+export function useSubscriberDetailSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<SubscriberDetailQuery, SubscriberDetailQueryVariables>): Apollo.UseSuspenseQueryResult<SubscriberDetailQuery, SubscriberDetailQueryVariables>;
+export function useSubscriberDetailSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SubscriberDetailQuery, SubscriberDetailQueryVariables>): Apollo.UseSuspenseQueryResult<SubscriberDetailQuery | undefined, SubscriberDetailQueryVariables>;
+export function useSubscriberDetailSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SubscriberDetailQuery, SubscriberDetailQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<SubscriberDetailQuery, SubscriberDetailQueryVariables>(SubscriberDetailDocument, options);
+        }
+export type SubscriberDetailQueryHookResult = ReturnType<typeof useSubscriberDetailQuery>;
+export type SubscriberDetailLazyQueryHookResult = ReturnType<typeof useSubscriberDetailLazyQuery>;
+export type SubscriberDetailSuspenseQueryHookResult = ReturnType<typeof useSubscriberDetailSuspenseQuery>;
+export type SubscriberDetailQueryResult = Apollo.QueryResult<SubscriberDetailQuery, SubscriberDetailQueryVariables>;

--- a/interfaces/ukama-console/src/client/graphql/team.graphql
+++ b/interfaces/ukama-console/src/client/graphql/team.graphql
@@ -1,0 +1,116 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# Members & admin screen — members + pending invitations as one merged team
+# list (membersView composite).
+
+query TeamList {
+  membersView {
+    orgName
+    team {
+      error {
+        ...SectionErrorFields
+      }
+      rows {
+        id
+        name
+        email
+        role
+        status
+        memberSince
+        inviteExpiresAt
+      }
+    }
+  }
+}
+
+# Business inventory screen — inventoryView composite.
+query InventoryOverview {
+  inventoryView {
+    orgName
+    components {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      byCategory {
+        category
+        count
+      }
+    }
+    unassignedNodes {
+      error {
+        ...SectionErrorFields
+      }
+      nodes {
+        ...ViewNode
+      }
+    }
+    simStock {
+      error {
+        ...SectionErrorFields
+      }
+      total
+      available
+      consumed
+      pctAssigned
+      lowStock
+    }
+  }
+}
+
+# Customer home / subscriber drawer — subscriberView composite.
+query SubscriberDetail($subscriberId: String!) {
+  subscriberView(subscriberId: $subscriberId) {
+    subscriberId
+    subscriber {
+      error {
+        ...SectionErrorFields
+      }
+      subscriber {
+        uuid
+        name
+        email
+        phone
+        networkId
+        sim {
+          id
+          iccid
+          msisdn
+          status
+          type
+        }
+      }
+    }
+    plans {
+      error {
+        ...SectionErrorFields
+      }
+      plans {
+        packageId
+        name
+      }
+    }
+    billing {
+      error {
+        ...SectionErrorFields
+      }
+      payments {
+        id
+        amount
+        currency
+        status
+        paidAt
+        paymentMethod
+      }
+    }
+    usage {
+      error {
+        ...SectionErrorFields
+      }
+    }
+  }
+}

--- a/interfaces/ukama-console/src/client/graphql/types.ts
+++ b/interfaces/ukama-console/src/client/graphql/types.ts
@@ -40,7 +40,9 @@ export type AddNodeToSiteInput = {
 
 export type AddPackagSimResDto = {
   __typename?: 'AddPackagSimResDto';
+  error?: Maybe<Scalars['String']['output']>;
   packageId?: Maybe<Scalars['String']['output']>;
+  success?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type AddPackageInputDto = {
@@ -75,6 +77,12 @@ export type AddSiteInputDto = {
   power_id: Scalars['String']['input'];
   spectrum_id: Scalars['String']['input'];
   switch_id: Scalars['String']['input'];
+};
+
+export type AlertsSection = {
+  __typename?: 'AlertsSection';
+  error?: Maybe<SectionError>;
+  notifications?: Maybe<Array<NotificationsDto>>;
 };
 
 export type AllocateSimApiDto = {
@@ -289,6 +297,11 @@ export type FeeDto = {
   units: Scalars['Float']['output'];
 };
 
+export type GapSection = {
+  __typename?: 'GapSection';
+  error?: Maybe<SectionError>;
+};
+
 export type GetHealthReportInputDto = {
   id: Scalars['String']['input'];
   nodeId: Scalars['String']['input'];
@@ -396,6 +409,12 @@ export type HealthResourceInfo = {
   value: Scalars['String']['output'];
 };
 
+export type HealthSection = {
+  __typename?: 'HealthSection';
+  error?: Maybe<SectionError>;
+  health?: Maybe<HealthInfo>;
+};
+
 export type HealthSystemInfo = {
   __typename?: 'HealthSystemInfo';
   healthId: Scalars['String']['output'];
@@ -499,7 +518,7 @@ export type Mutation = {
   toggleRFStatus: CBooleanResponse;
   toggleService: CBooleanResponse;
   toggleSimStatus: SimStatusResDto;
-  updateFirstVisit: UserFistVisitResDto;
+  updateFirstVisit: UserFirstVisitResDto;
   updateInvitation: UpdateInvitationResDto;
   updateMember: CBooleanResponse;
   updateNode: Node;
@@ -665,12 +684,12 @@ export type MutationToggleSimStatusArgs = {
 
 
 export type MutationUpdateFirstVisitArgs = {
-  data: UserFistVisitInputDto;
+  data: UserFirstVisitInputDto;
 };
 
 
 export type MutationUpdateInvitationArgs = {
-  data: UpateInvitationInputDto;
+  data: UpdateInvitationInputDto;
 };
 
 
@@ -779,6 +798,28 @@ export type NetworkDto = {
   trafficPolicy: Scalars['Float']['output'];
 };
 
+export type NetworkOverview = {
+  __typename?: 'NetworkOverview';
+  kpis: GapSection;
+  latestAlerts: AlertsSection;
+  network: NetworkSection;
+  networkId: Scalars['String']['output'];
+  nodeStats: NodeStatsSection;
+  siteStats: SitesSection;
+  subscriberStats: SubscriberStatsSection;
+};
+
+
+export type NetworkOverviewLatestAlertsArgs = {
+  limit?: Scalars['Int']['input'];
+};
+
+export type NetworkSection = {
+  __typename?: 'NetworkSection';
+  error?: Maybe<SectionError>;
+  network?: Maybe<NetworkDto>;
+};
+
 export type NetworkStats = {
   __typename?: 'NetworkStats';
   activeSubscriber: Scalars['Float']['output'];
@@ -844,6 +885,12 @@ export type NodeLatestMetric = {
   value: Array<Scalars['Float']['output']>;
 };
 
+export type NodeSection = {
+  __typename?: 'NodeSection';
+  error?: Maybe<SectionError>;
+  node?: Maybe<Node>;
+};
+
 export type NodeSite = {
   __typename?: 'NodeSite';
   addedAt?: Maybe<Scalars['String']['output']>;
@@ -870,6 +917,20 @@ export type NodeStateRes = {
   previousStateId?: Maybe<Scalars['String']['output']>;
 };
 
+export type NodeStateSection = {
+  __typename?: 'NodeStateSection';
+  error?: Maybe<SectionError>;
+  stateHistory?: Maybe<NodeStateRes>;
+};
+
+export type NodeStatsSection = {
+  __typename?: 'NodeStatsSection';
+  error?: Maybe<SectionError>;
+  offline?: Maybe<Scalars['Int']['output']>;
+  online?: Maybe<Scalars['Int']['output']>;
+  total?: Maybe<Scalars['Int']['output']>;
+};
+
 export type NodeStatus = {
   __typename?: 'NodeStatus';
   connectivity: Scalars['String']['output'];
@@ -884,6 +945,17 @@ export enum NodeTypeEnum {
   Tnode = 'tnode'
 }
 
+export type NodeView = {
+  __typename?: 'NodeView';
+  health: HealthSection;
+  kpis: GapSection;
+  node: NodeSection;
+  nodeId: Scalars['String']['output'];
+  radioStatus: GapSection;
+  software: SoftwareSection;
+  stateHistory: NodeStateSection;
+};
+
 export type Nodes = {
   __typename?: 'Nodes';
   nodes: Array<Node>;
@@ -896,6 +968,25 @@ export type NodesFilterInput = {
   siteId?: InputMaybe<Scalars['String']['input']>;
   state?: InputMaybe<Scalars['String']['input']>;
   type?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type NodesSection = {
+  __typename?: 'NodesSection';
+  error?: Maybe<SectionError>;
+  nodes?: Maybe<Array<Node>>;
+};
+
+export type NodesView = {
+  __typename?: 'NodesView';
+  health: GapSection;
+  networkId?: Maybe<Scalars['String']['output']>;
+  nodes: NodesSection;
+};
+
+export type NotificationRedirectDto = {
+  __typename?: 'NotificationRedirectDto';
+  action: Scalars['String']['output'];
+  title: Scalars['String']['output'];
 };
 
 export type NotificationResDto = {
@@ -917,8 +1008,11 @@ export type NotificationsDto = {
   __typename?: 'NotificationsDto';
   createdAt: Scalars['String']['output'];
   description: Scalars['String']['output'];
+  eventKey: Scalars['String']['output'];
   id: Scalars['String']['output'];
   isRead: Scalars['Boolean']['output'];
+  redirect?: Maybe<NotificationRedirectDto>;
+  resourceId: Scalars['String']['output'];
   scope: Notification_Scope;
   title: Scalars['String']['output'];
   type: Notification_Type;
@@ -1052,6 +1146,24 @@ export type PaymentsDto = {
   payments: Array<PaymentDto>;
 };
 
+export type PlanNameDto = {
+  __typename?: 'PlanNameDto';
+  name: Scalars['String']['output'];
+  packageId: Scalars['String']['output'];
+};
+
+export type PlansSection = {
+  __typename?: 'PlansSection';
+  error?: Maybe<SectionError>;
+  plans?: Maybe<Array<PlanNameDto>>;
+};
+
+export type PoolSimsSection = {
+  __typename?: 'PoolSimsSection';
+  error?: Maybe<SectionError>;
+  sims?: Maybe<Array<SimPoolResDto>>;
+};
+
 export type ProcessPaymentDto = {
   __typename?: 'ProcessPaymentDto';
   payment: PaymentDto;
@@ -1124,6 +1236,13 @@ export type Query = {
   getTimezones: TimezoneRes;
   getToken: TokenResDto;
   getUser: UserResDto;
+  networkOverview: NetworkOverview;
+  nodeView: NodeView;
+  nodesView: NodesView;
+  simPoolView: SimPoolView;
+  siteView: SiteView;
+  sitesView: SitesView;
+  subscribersView: SubscribersView;
   whoami: WhoamiDto;
 };
 
@@ -1347,6 +1466,41 @@ export type QueryGetUserArgs = {
   userId: Scalars['String']['input'];
 };
 
+
+export type QueryNetworkOverviewArgs = {
+  networkId: Scalars['String']['input'];
+};
+
+
+export type QueryNodeViewArgs = {
+  nodeId: Scalars['String']['input'];
+};
+
+
+export type QueryNodesViewArgs = {
+  networkId?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QuerySimPoolViewArgs = {
+  simType: Scalars['String']['input'];
+};
+
+
+export type QuerySiteViewArgs = {
+  siteId: Scalars['String']['input'];
+};
+
+
+export type QuerySitesViewArgs = {
+  networkId: Scalars['String']['input'];
+};
+
+
+export type QuerySubscribersViewArgs = {
+  networkId: Scalars['String']['input'];
+};
+
 export enum Role_Type {
   RoleAdmin = 'ROLE_ADMIN',
   RoleInvalid = 'ROLE_INVALID',
@@ -1426,6 +1580,24 @@ export enum Sim_Types {
   Test = 'test',
   UkamaData = 'ukama_data',
   Unknown = 'unknown'
+}
+
+/** Typed failure of one section of a composite query. The section's data field resolves to null and a SectionError describes why, so the UI can distinguish 'failed' from 'genuinely empty'. */
+export type SectionError = {
+  __typename?: 'SectionError';
+  code: SectionErrorCode;
+  message: Scalars['String']['output'];
+  section: Scalars['String']['output'];
+};
+
+/** Machine-readable failure code for a composite query section. UI branches on this code; `message` is for display/logs only. */
+export enum SectionErrorCode {
+  Forbidden = 'FORBIDDEN',
+  Internal = 'INTERNAL',
+  NotFound = 'NOT_FOUND',
+  NotImplemented = 'NOT_IMPLEMENTED',
+  UpstreamError = 'UPSTREAM_ERROR',
+  UpstreamTimeout = 'UPSTREAM_TIMEOUT'
 }
 
 export type SetDefaultNetworkInputDto = {
@@ -1522,6 +1694,31 @@ export type SimPoolStatsDto = {
   total: Scalars['Float']['output'];
 };
 
+export type SimPoolStatsSection = {
+  __typename?: 'SimPoolStatsSection';
+  available?: Maybe<Scalars['Int']['output']>;
+  consumed?: Maybe<Scalars['Int']['output']>;
+  error?: Maybe<SectionError>;
+  esim?: Maybe<Scalars['Int']['output']>;
+  failed?: Maybe<Scalars['Int']['output']>;
+  lowStock?: Maybe<Scalars['Boolean']['output']>;
+  pctAssigned?: Maybe<Scalars['Int']['output']>;
+  physical?: Maybe<Scalars['Int']['output']>;
+  total?: Maybe<Scalars['Int']['output']>;
+};
+
+export type SimPoolView = {
+  __typename?: 'SimPoolView';
+  simType: Scalars['String']['output'];
+  sims: PoolSimsSection;
+  stats: SimPoolStatsSection;
+};
+
+
+export type SimPoolViewSimsArgs = {
+  limit?: Scalars['Int']['input'];
+};
+
 export type SimStatusResDto = {
   __typename?: 'SimStatusResDto';
   simId?: Maybe<Scalars['String']['output']>;
@@ -1572,6 +1769,19 @@ export type Site = {
   siteName: Scalars['String']['output'];
 };
 
+export type SiteComponentDto = {
+  __typename?: 'SiteComponentDto';
+  componentId?: Maybe<Scalars['String']['output']>;
+  componentName?: Maybe<Scalars['String']['output']>;
+  elementType: Scalars['String']['output'];
+};
+
+export type SiteComponentsSection = {
+  __typename?: 'SiteComponentsSection';
+  components?: Maybe<Array<SiteComponentDto>>;
+  error?: Maybe<SectionError>;
+};
+
 export type SiteDto = {
   __typename?: 'SiteDto';
   accessId: Scalars['String']['output'];
@@ -1590,6 +1800,37 @@ export type SiteDto = {
   switchId: Scalars['String']['output'];
 };
 
+export type SiteNodeCountDto = {
+  __typename?: 'SiteNodeCountDto';
+  offline: Scalars['Int']['output'];
+  online: Scalars['Int']['output'];
+  siteId: Scalars['String']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type SiteNodeCountsSection = {
+  __typename?: 'SiteNodeCountsSection';
+  counts?: Maybe<Array<SiteNodeCountDto>>;
+  error?: Maybe<SectionError>;
+};
+
+export type SiteSection = {
+  __typename?: 'SiteSection';
+  error?: Maybe<SectionError>;
+  site?: Maybe<SiteDto>;
+};
+
+export type SiteView = {
+  __typename?: 'SiteView';
+  components: SiteComponentsSection;
+  financials: GapSection;
+  kpis: GapSection;
+  nodes: NodesSection;
+  power: GapSection;
+  site: SiteSection;
+  siteId: Scalars['String']['output'];
+};
+
 export type SitesInputDto = {
   networkId?: InputMaybe<Scalars['String']['input']>;
 };
@@ -1597,6 +1838,21 @@ export type SitesInputDto = {
 export type SitesResDto = {
   __typename?: 'SitesResDto';
   sites: Array<SiteDto>;
+};
+
+export type SitesSection = {
+  __typename?: 'SitesSection';
+  error?: Maybe<SectionError>;
+  sites?: Maybe<Array<SiteDto>>;
+};
+
+export type SitesView = {
+  __typename?: 'SitesView';
+  financials: GapSection;
+  kpis: GapSection;
+  networkId: Scalars['String']['output'];
+  nodeCounts: SiteNodeCountsSection;
+  sites: SitesSection;
 };
 
 export type Software = {
@@ -1614,6 +1870,12 @@ export type Software = {
   space: Scalars['String']['output'];
   status: SoftwareStatusEnum;
   updatedAt: Scalars['String']['output'];
+};
+
+export type SoftwareSection = {
+  __typename?: 'SoftwareSection';
+  error?: Maybe<SectionError>;
+  softwares?: Maybe<Softwares>;
 };
 
 /** Software status enums */
@@ -1702,6 +1964,14 @@ export type SubscriberSimsResDto = {
   sims: Array<SubscriberSimDto>;
 };
 
+export type SubscriberStatsSection = {
+  __typename?: 'SubscriberStatsSection';
+  active?: Maybe<Scalars['Int']['output']>;
+  error?: Maybe<SectionError>;
+  inactive?: Maybe<Scalars['Int']['output']>;
+  total?: Maybe<Scalars['Int']['output']>;
+};
+
 export type SubscriberToSimsDto = {
   __typename?: 'SubscriberToSimsDto';
   sims: Array<SubscriberSimsDto>;
@@ -1718,6 +1988,20 @@ export type Subscribers = {
 export type SubscribersResDto = {
   __typename?: 'SubscribersResDto';
   subscribers: Array<SubscriberDto>;
+};
+
+export type SubscribersSection = {
+  __typename?: 'SubscribersSection';
+  error?: Maybe<SectionError>;
+  subscribers?: Maybe<Array<SubscriberDto>>;
+};
+
+export type SubscribersView = {
+  __typename?: 'SubscribersView';
+  networkId: Scalars['String']['output'];
+  plans: PlansSection;
+  subscribers: SubscribersSection;
+  usage: GapSection;
 };
 
 export type SubscriptionDto = {
@@ -1775,7 +2059,7 @@ export type TokenResDto = {
   token: Scalars['String']['output'];
 };
 
-export type UpateInvitationInputDto = {
+export type UpdateInvitationInputDto = {
   email: Scalars['String']['input'];
   id: Scalars['String']['input'];
   status: Invitation_Status;
@@ -1849,15 +2133,15 @@ export type UploadSimsResDto = {
   iccid: Array<Scalars['String']['output']>;
 };
 
-export type UserFistVisitInputDto = {
+export type UserFirstVisitInputDto = {
   email: Scalars['String']['input'];
   firstVisit: Scalars['Boolean']['input'];
   name: Scalars['String']['input'];
   userId: Scalars['String']['input'];
 };
 
-export type UserFistVisitResDto = {
-  __typename?: 'UserFistVisitResDto';
+export type UserFirstVisitResDto = {
+  __typename?: 'UserFirstVisitResDto';
   firstVisit: Scalars['Boolean']['output'];
 };
 

--- a/interfaces/ukama-console/src/client/graphql/types.ts
+++ b/interfaces/ukama-console/src/client/graphql/types.ts
@@ -506,6 +506,20 @@ export type ItemResDto = {
   type: Scalars['String']['output'];
 };
 
+export type KpiEntryDto = {
+  __typename?: 'KpiEntryDto';
+  key: Scalars['String']['output'];
+  success: Scalars['Boolean']['output'];
+  timestamp: Scalars['Float']['output'];
+  value: Scalars['Float']['output'];
+};
+
+export type KpisSection = {
+  __typename?: 'KpisSection';
+  error?: Maybe<SectionError>;
+  metrics?: Maybe<Array<KpiEntryDto>>;
+};
+
 export type ListSimsInput = {
   networkId: Scalars['String']['input'];
   status: Scalars['String']['input'];
@@ -538,6 +552,44 @@ export type MembersView = {
   __typename?: 'MembersView';
   orgName: Scalars['String']['output'];
   team: TeamSection;
+};
+
+export type MetricRes = {
+  __typename?: 'MetricRes';
+  dataPlanId?: Maybe<Scalars['String']['output']>;
+  format?: Maybe<Scalars['String']['output']>;
+  msg: Scalars['String']['output'];
+  networkId?: Maybe<Scalars['String']['output']>;
+  nodeId?: Maybe<Scalars['String']['output']>;
+  packageId?: Maybe<Scalars['String']['output']>;
+  siteId?: Maybe<Scalars['String']['output']>;
+  success: Scalars['Boolean']['output'];
+  threshold?: Maybe<MetricThreshold>;
+  tickInterval?: Maybe<Scalars['Float']['output']>;
+  tickPositions?: Maybe<Array<Scalars['Float']['output']>>;
+  type: Scalars['String']['output'];
+  unit?: Maybe<Scalars['String']['output']>;
+  values: Array<Array<Scalars['Float']['output']>>;
+};
+
+export type MetricThreshold = {
+  __typename?: 'MetricThreshold';
+  max: Scalars['Float']['output'];
+  min: Scalars['Float']['output'];
+  normal: Scalars['Float']['output'];
+};
+
+export type MetricsRangeInput = {
+  from: Scalars['Int']['input'];
+  keys: Array<Scalars['String']['input']>;
+  nodeId?: InputMaybe<Scalars['String']['input']>;
+  operation?: InputMaybe<Scalars['String']['input']>;
+  to?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type MetricsRes = {
+  __typename?: 'MetricsRes';
+  metrics: Array<MetricRes>;
 };
 
 export type Mutation = {
@@ -854,7 +906,7 @@ export type NetworkDto = {
 
 export type NetworkOverview = {
   __typename?: 'NetworkOverview';
-  kpis: GapSection;
+  kpis: KpisSection;
   latestAlerts: AlertsSection;
   network: NetworkSection;
   networkId: Scalars['String']['output'];
@@ -1002,7 +1054,7 @@ export enum NodeTypeEnum {
 export type NodeView = {
   __typename?: 'NodeView';
   health: HealthSection;
-  kpis: GapSection;
+  kpis: KpisSection;
   node: NodeSection;
   nodeId: Scalars['String']['output'];
   radioStatus: GapSection;
@@ -1313,6 +1365,7 @@ export type Query = {
   getUser: UserResDto;
   inventoryView: InventoryView;
   membersView: MembersView;
+  metricsRange: MetricsRes;
   networkOverview: NetworkOverview;
   nodeView: NodeView;
   nodesView: NodesView;
@@ -1547,6 +1600,11 @@ export type QueryGetTokenArgs = {
 
 export type QueryGetUserArgs = {
   userId: Scalars['String']['input'];
+};
+
+
+export type QueryMetricsRangeArgs = {
+  data: MetricsRangeInput;
 };
 
 
@@ -1922,9 +1980,9 @@ export type SiteView = {
   __typename?: 'SiteView';
   components: SiteComponentsSection;
   financials: GapSection;
-  kpis: GapSection;
+  kpis: KpisSection;
   nodes: NodesSection;
-  power: GapSection;
+  power: KpisSection;
   site: SiteSection;
   siteId: Scalars['String']['output'];
 };

--- a/interfaces/ukama-console/src/client/graphql/types.ts
+++ b/interfaces/ukama-console/src/client/graphql/types.ts
@@ -153,6 +153,13 @@ export type AttachedNodes = {
   type: NodeTypeEnum;
 };
 
+export type BalanceSection = {
+  __typename?: 'BalanceSection';
+  error?: Maybe<SectionError>;
+  latestUnpaidPeriod?: Maybe<Scalars['String']['output']>;
+  outstandingCount?: Maybe<Scalars['Int']['output']>;
+};
+
 export type CBooleanResponse = {
   __typename?: 'CBooleanResponse';
   success: Scalars['Boolean']['output'];
@@ -166,6 +173,26 @@ export enum Component_Type {
   Spectrum = 'spectrum',
   Switch = 'switch'
 }
+
+export type CategoryCountDto = {
+  __typename?: 'CategoryCountDto';
+  category: Scalars['String']['output'];
+  count: Scalars['Int']['output'];
+};
+
+export type CommerceView = {
+  __typename?: 'CommerceView';
+  balance: BalanceSection;
+  invoices: InvoicesSection;
+  networkId?: Maybe<Scalars['String']['output']>;
+  plans: PlanStatsSection;
+  revenue: RevenueSection;
+};
+
+
+export type CommerceViewInvoicesArgs = {
+  limit?: Scalars['Int']['input'];
+};
 
 export type Component = {
   __typename?: 'Component';
@@ -189,6 +216,13 @@ export type ComponentDto = {
   type: Scalars['String']['output'];
   userId: Scalars['String']['output'];
   warranty: Scalars['Float']['output'];
+};
+
+export type ComponentStatsSection = {
+  __typename?: 'ComponentStatsSection';
+  byCategory?: Maybe<Array<CategoryCountDto>>;
+  error?: Maybe<SectionError>;
+  total?: Maybe<Scalars['Int']['output']>;
 };
 
 export type ComponentTypeInputDto = {
@@ -434,6 +468,14 @@ export type IdResponse = {
   uuid: Scalars['String']['output'];
 };
 
+export type InventoryView = {
+  __typename?: 'InventoryView';
+  components: ComponentStatsSection;
+  orgName: Scalars['String']['output'];
+  simStock: SimPoolStatsSection;
+  unassignedNodes: NodesSection;
+};
+
 export type InvitationDto = {
   __typename?: 'InvitationDto';
   email: Scalars['String']['output'];
@@ -449,6 +491,12 @@ export type InvitationDto = {
 export type InvitationsResDto = {
   __typename?: 'InvitationsResDto';
   invitations: Array<InvitationDto>;
+};
+
+export type InvoicesSection = {
+  __typename?: 'InvoicesSection';
+  error?: Maybe<SectionError>;
+  reports?: Maybe<Array<ReportDto>>;
 };
 
 export type ItemResDto = {
@@ -484,6 +532,12 @@ export type Members = {
 export type MembersResDto = {
   __typename?: 'MembersResDto';
   members: Array<MemberDto>;
+};
+
+export type MembersView = {
+  __typename?: 'MembersView';
+  orgName: Scalars['String']['output'];
+  team: TeamSection;
 };
 
 export type Mutation = {
@@ -1152,6 +1206,26 @@ export type PlanNameDto = {
   packageId: Scalars['String']['output'];
 };
 
+export type PlanStatsDto = {
+  __typename?: 'PlanStatsDto';
+  active: Scalars['Boolean']['output'];
+  amount: Scalars['Float']['output'];
+  attachCount?: Maybe<Scalars['Int']['output']>;
+  currency: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  packageId: Scalars['String']['output'];
+  revenue: Scalars['Float']['output'];
+  revenueSharePct: Scalars['Int']['output'];
+};
+
+export type PlanStatsSection = {
+  __typename?: 'PlanStatsSection';
+  arpu?: Maybe<Scalars['Float']['output']>;
+  error?: Maybe<SectionError>;
+  mrr?: Maybe<Scalars['Float']['output']>;
+  plans?: Maybe<Array<PlanStatsDto>>;
+};
+
 export type PlansSection = {
   __typename?: 'PlansSection';
   error?: Maybe<SectionError>;
@@ -1177,6 +1251,7 @@ export type ProcessPaymentInputDto = {
 
 export type Query = {
   __typename?: 'Query';
+  commerceView: CommerceView;
   example?: Maybe<Scalars['String']['output']>;
   getApps?: Maybe<Apps>;
   getAppsChangeLog: AppChangeLogs;
@@ -1236,14 +1311,22 @@ export type Query = {
   getTimezones: TimezoneRes;
   getToken: TokenResDto;
   getUser: UserResDto;
+  inventoryView: InventoryView;
+  membersView: MembersView;
   networkOverview: NetworkOverview;
   nodeView: NodeView;
   nodesView: NodesView;
   simPoolView: SimPoolView;
   siteView: SiteView;
   sitesView: SitesView;
+  subscriberView: SubscriberView;
   subscribersView: SubscribersView;
   whoami: WhoamiDto;
+};
+
+
+export type QueryCommerceViewArgs = {
+  networkId?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1497,6 +1580,11 @@ export type QuerySitesViewArgs = {
 };
 
 
+export type QuerySubscriberViewArgs = {
+  subscriberId: Scalars['String']['input'];
+};
+
+
 export type QuerySubscribersViewArgs = {
   networkId: Scalars['String']['input'];
 };
@@ -1567,6 +1655,16 @@ export type RestartNodesInputDto = {
 export type RestartSiteInputDto = {
   networkId: Scalars['String']['input'];
   siteId: Scalars['String']['input'];
+};
+
+export type RevenueSection = {
+  __typename?: 'RevenueSection';
+  error?: Maybe<SectionError>;
+  momPct?: Maybe<Scalars['Int']['output']>;
+  monthPaid?: Maybe<Scalars['Float']['output']>;
+  prevMonthPaid?: Maybe<Scalars['Float']['output']>;
+  totalPaid?: Maybe<Scalars['Float']['output']>;
+  totalPending?: Maybe<Scalars['Float']['output']>;
 };
 
 export enum Sim_Status {
@@ -1897,6 +1995,12 @@ export type StringResponse = {
   message: Scalars['String']['output'];
 };
 
+export type SubscriberBillingSection = {
+  __typename?: 'SubscriberBillingSection';
+  error?: Maybe<SectionError>;
+  payments?: Maybe<Array<PaymentDto>>;
+};
+
 export type SubscriberDto = {
   __typename?: 'SubscriberDto';
   address: Scalars['String']['output'];
@@ -1925,6 +2029,18 @@ export type SubscriberMetricsByNetworkDto = {
   inactive: Scalars['Float']['output'];
   terminated: Scalars['Float']['output'];
   total: Scalars['Float']['output'];
+};
+
+export type SubscriberPlansSection = {
+  __typename?: 'SubscriberPlansSection';
+  error?: Maybe<SectionError>;
+  plans?: Maybe<Array<PlanNameDto>>;
+};
+
+export type SubscriberSection = {
+  __typename?: 'SubscriberSection';
+  error?: Maybe<SectionError>;
+  subscriber?: Maybe<SubscriberDto>;
 };
 
 export type SubscriberSimDto = {
@@ -1978,6 +2094,15 @@ export type SubscriberToSimsDto = {
   subscriberId: Scalars['String']['output'];
 };
 
+export type SubscriberView = {
+  __typename?: 'SubscriberView';
+  billing: SubscriberBillingSection;
+  plans: SubscriberPlansSection;
+  subscriber: SubscriberSection;
+  subscriberId: Scalars['String']['output'];
+  usage: GapSection;
+};
+
 export type Subscribers = {
   __typename?: 'Subscribers';
   activeSubscribers: Scalars['String']['output'];
@@ -2022,6 +2147,23 @@ export enum Timeframe_Filter {
   Latest = 'LATEST',
   Unknown = 'UNKNOWN'
 }
+
+export type TeamMemberDto = {
+  __typename?: 'TeamMemberDto';
+  email?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  inviteExpiresAt?: Maybe<Scalars['String']['output']>;
+  memberSince?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  role: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+};
+
+export type TeamSection = {
+  __typename?: 'TeamSection';
+  error?: Maybe<SectionError>;
+  rows?: Maybe<Array<TeamMemberDto>>;
+};
 
 export type TimezoneDto = {
   __typename?: 'TimezoneDto';

--- a/interfaces/ukama-console/src/client/graphql/views-shared.generated.ts
+++ b/interfaces/ukama-console/src/client/graphql/views-shared.generated.ts
@@ -1,0 +1,44 @@
+import * as Types from './types';
+
+import { gql } from '@apollo/client';
+export type SectionErrorFieldsFragment = { __typename?: 'SectionError', section: string, code: Types.SectionErrorCode, message: string };
+
+export type ViewNodeFragment = { __typename?: 'Node', id: string, name: string, type: Types.NodeTypeEnum, site: { __typename?: 'NodeSite', siteId?: string | null, networkId?: string | null }, status: { __typename?: 'NodeStatus', connectivity: string, state: string } };
+
+export type ViewSiteFragment = { __typename?: 'SiteDto', id: string, name: string, networkId: string, latitude: string, longitude: string, location: string, isDeactivated: boolean, installDate: string, createdAt: string };
+
+export const SectionErrorFieldsFragmentDoc = gql`
+    fragment SectionErrorFields on SectionError {
+  section
+  code
+  message
+}
+    `;
+export const ViewNodeFragmentDoc = gql`
+    fragment ViewNode on Node {
+  id
+  name
+  type
+  site {
+    siteId
+    networkId
+  }
+  status {
+    connectivity
+    state
+  }
+}
+    `;
+export const ViewSiteFragmentDoc = gql`
+    fragment ViewSite on SiteDto {
+  id
+  name
+  networkId
+  latitude
+  longitude
+  location
+  isDeactivated
+  installDate
+  createdAt
+}
+    `;

--- a/interfaces/ukama-console/src/client/graphql/views-shared.graphql
+++ b/interfaces/ukama-console/src/client/graphql/views-shared.graphql
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2026-present, Ukama Inc.
+
+# Shared fragments for the view-domain composite queries (plan §3).
+# Every section embeds `error` — UI branches on `code` (§4.5 contract):
+# data null + error set = failed; code NOT_IMPLEMENTED = backend gap ("—",
+# no retry); data null + error null = genuinely empty.
+
+fragment SectionErrorFields on SectionError {
+  section
+  code
+  message
+}
+
+fragment ViewNode on Node {
+  id
+  name
+  type
+  site {
+    siteId
+    networkId
+  }
+  status {
+    connectivity
+    state
+  }
+}
+
+fragment ViewSite on SiteDto {
+  id
+  name
+  networkId
+  latitude
+  longitude
+  location
+  isDeactivated
+  installDate
+  createdAt
+}

--- a/interfaces/ukama-console/src/components/SectionFallback.tsx
+++ b/interfaces/ukama-console/src/components/SectionFallback.tsx
@@ -1,0 +1,71 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+'use client';
+
+/**
+ * Three-way section contract for composite queries (BFF plan §4.5):
+ * - data null + error set            → failed: "—" / chip, retry if offered
+ * - error.code === NOT_IMPLEMENTED   → backend gap: "—", NO retry
+ * - data null/empty + error null     → genuinely empty: empty state
+ *
+ * Branch on `error.code`, never on message text.
+ */
+import ReplayRoundedIcon from '@mui/icons-material/ReplayRounded';
+import { Box, IconButton, Tooltip, Typography } from '@mui/material';
+
+import { SectionErrorCode } from '@/client/graphql/types';
+
+export interface SectionErrorLike {
+  code: SectionErrorCode;
+  message: string;
+}
+
+/** True when a section value should render as data (no error, value set). */
+export function sectionReady<T>(
+  value: T | null | undefined,
+  error?: SectionErrorLike | null
+): value is T {
+  return value != null && !error;
+}
+
+/**
+ * Inline placeholder for a failed or not-implemented section value.
+ * Renders "—" with a tooltip; failed (non-gap) sections may offer retry.
+ */
+export function SectionFallback({
+  error,
+  onRetry,
+}: {
+  error: SectionErrorLike;
+  onRetry?: () => void;
+}) {
+  const isGap = error.code === SectionErrorCode.NotImplemented;
+  return (
+    <Tooltip title={isGap ? 'Not available yet' : error.message}>
+      <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+        <Typography component="span" color="text.disabled">
+          —
+        </Typography>
+        {!isGap && onRetry && (
+          <IconButton size="small" aria-label="Retry" onClick={onRetry}>
+            <ReplayRoundedIcon sx={{ fontSize: 14 }} />
+          </IconButton>
+        )}
+      </Box>
+    </Tooltip>
+  );
+}
+
+/** "—" or the formatted value, per the §4.5 contract. */
+export function sectionValue(
+  value: string | number | null | undefined,
+  error?: SectionErrorLike | null
+): string {
+  if (error || value == null) return '—';
+  return String(value);
+}

--- a/interfaces/ukama-console/src/components/data-table/DataTable.tsx
+++ b/interfaces/ukama-console/src/components/data-table/DataTable.tsx
@@ -173,9 +173,13 @@ export default function DataTable<T>({
   initialSorting?: SortingState;
   skeleton?: { cols?: number; rows?: number; lead?: boolean };
 }) {
+  'use no memo';
+
   const [sorting, setSorting] = useState<SortingState>(initialSorting ?? []);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
+  // TanStack Table uses interior mutability; opt this component out of React Compiler memoization.
+  // eslint-disable-next-line react-hooks/incompatible-library -- useReactTable is intentionally incompatible
   const table = useReactTable({
     data,
     columns,

--- a/interfaces/ukama-console/src/features/customers/SubscribersScreen.tsx
+++ b/interfaces/ukama-console/src/features/customers/SubscribersScreen.tsx
@@ -35,10 +35,11 @@ import PageHeader from '@/components/PageHeader';
 import SearchField from '@/components/SearchField';
 import StatusBadge from '@/components/StatusBadge';
 import { useToast } from '@/components/ToastProvider';
-import { PLANS, SUBSCRIBERS } from '@/data';
+import { useNetworkCustomersQuery } from '@/client/graphql/network-customers.generated';
 import type { Subscriber } from '@/data';
 import { parseSeen } from '@/lib/parsers';
-import { useFirstLoad } from '@/lib/useFirstLoad';
+import { useUiPrefs } from '@/lib/store';
+import { toSubscriber } from '@/lib/mappers/subscribers';
 import AddCustomerDialog from './AddCustomerDialog';
 import DeleteCustomerDialog from './DeleteCustomerDialog';
 import SubscriberDrawer from './SubscriberDrawer';
@@ -121,7 +122,7 @@ export default function SubscribersScreen({ mode }: { mode: CustomersMode }) {
   const agent = mode === 'agent';
   const showSite = mode === 'network';
   const clickRow = mode !== 'network';
-  const loading = useFirstLoad('subscribers');
+  const networkId = useUiPrefs((s) => s.networkId);
   const toast = useToast();
 
   const [q, setQ] = useState('');
@@ -130,9 +131,25 @@ export default function SubscribersScreen({ mode }: { mode: CustomersMode }) {
   const [showAdd, setShowAdd] = useState(false);
   const [deleteSub, setDeleteSub] = useState<Subscriber | null>(null);
 
+  const { data, loading } = useNetworkCustomersQuery({
+    variables: { networkId },
+    skip: !networkId,
+  });
+  const subsSection = data?.subscribersView.subscribers;
+  const plansSection = data?.subscribersView.plans;
+
+  const subscribers: Subscriber[] = useMemo(() => {
+    const plansById = new Map(
+      (plansSection?.plans ?? []).map((p) => [p.packageId, p])
+    );
+    return (subsSection?.subscribers ?? []).map((s) =>
+      toSubscriber(s, plansById)
+    );
+  }, [subsSection?.subscribers, plansSection?.plans]);
+
   const planNames = useMemo(
-    () => [...PLANS.map((p) => p.name), 'No plan'],
-    [],
+    () => [...(plansSection?.plans ?? []).map((p) => p.name), 'No plan'],
+    [plansSection?.plans],
   );
 
   const columns = useMemo<ColumnDef<Subscriber, unknown>[]>(() => {
@@ -186,7 +203,9 @@ export default function SubscribersScreen({ mode }: { mode: CustomersMode }) {
       enableSorting: true,
       cell: ({ row }) => {
         const s = row.original;
-        if (s.plan === 'No plan') return <span className="muted">—</span>;
+        // usage < 0 = unknown (subscribersView.usage backend gap) → "—"
+        if (s.plan === 'No plan' || s.usage < 0)
+          return <span className="muted">—</span>;
         const pct = s.cap ? Math.min(100, (s.usage / s.cap) * 100) : 60;
         const over = !!s.cap && s.usage / s.cap > 0.9;
         return (
@@ -257,7 +276,7 @@ export default function SubscribersScreen({ mode }: { mode: CustomersMode }) {
     <div className="page">
       <PageHeader
         title="Customers"
-        count="1,284"
+        count={subscribers.length.toLocaleString()}
         sub={SUBS[mode]}
         actions={
           agent ? (
@@ -285,7 +304,7 @@ export default function SubscribersScreen({ mode }: { mode: CustomersMode }) {
         >
           <SearchField value={q} onChange={setQ} placeholder="Search name or phone" />
           <div style={{ marginLeft: 'auto', fontSize: 13, color: 'var(--uk-ink-3)' }}>
-            {SUBSCRIBERS.length} of {SUBSCRIBERS.length}
+            {subscribers.length} of {subscribers.length}
           </div>
         </div>
 
@@ -333,13 +352,15 @@ export default function SubscribersScreen({ mode }: { mode: CustomersMode }) {
         <div className="tbl-wrap" style={{ overflowX: 'auto' }}>
           <DataTable<Subscriber>
             columns={columns}
-            data={SUBSCRIBERS}
-            status={loading ? 'loading' : 'ready'}
+            data={subscribers}
+            status={loading ? 'loading' : subsSection?.error ? 'error' : 'ready'}
             skeleton={{ cols: agent ? 7 : 5, rows: 6, lead: true }}
             empty={{
               art: 'search',
-              title: 'No customers match',
-              sub: 'Try a different filter or search term.',
+              title: subsSection?.error ? "Couldn't load customers" : 'No customers match',
+              sub: subsSection?.error
+                ? subsSection.error.message
+                : 'Try a different filter or search term.',
             }}
             globalFilter={q}
             initialSorting={[{ id: 'name', desc: false }]}
@@ -352,23 +373,7 @@ export default function SubscribersScreen({ mode }: { mode: CustomersMode }) {
         </div>
 
         {!loading && (
-          <TableFooter showing={SUBSCRIBERS.length} total={1284}>
-            <Button size="small" disabled sx={{ minWidth: 34 }}>
-              ‹
-            </Button>
-            <Button size="small" variant="outlined" sx={{ minWidth: 34 }}>
-              1
-            </Button>
-            <Button size="small" sx={{ minWidth: 34, color: 'var(--uk-ink-3)' }}>
-              2
-            </Button>
-            <Button size="small" sx={{ minWidth: 34, color: 'var(--uk-ink-3)' }}>
-              …
-            </Button>
-            <Button size="small" sx={{ minWidth: 34 }}>
-              ›
-            </Button>
-          </TableFooter>
+          <TableFooter showing={subscribers.length} total={subscribers.length} />
         )}
       </div>
 

--- a/interfaces/ukama-console/src/features/sims/SimPoolScreen.tsx
+++ b/interfaces/ukama-console/src/features/sims/SimPoolScreen.tsx
@@ -6,11 +6,11 @@
  * Copyright (c) 2026-present, Ukama Inc.
  */
 'use client';
-import Meter from '@/components/Meter';
 
 /**
- * SIM pool — inventory cockpit with stock levels and proactive low-stock
- * nudge (screens-manage.jsx). Business can act; Network is view-only.
+ * SIM pool — inventory cockpit wired to the `simPoolView` composite. Stats
+ * (incl. pctAssigned / lowStock) are derived server-side; the table lists
+ * pool SIMs. Business can act; Network is view-only.
  */
 import { useState } from 'react';
 import Button from '@mui/material/Button';
@@ -28,17 +28,22 @@ import MoreVertRounded from '@mui/icons-material/MoreVertRounded';
 import ShoppingCartRounded from '@mui/icons-material/ShoppingCartRounded';
 import UploadFileRounded from '@mui/icons-material/UploadFileRounded';
 import VisibilityRounded from '@mui/icons-material/VisibilityRounded';
-import SkeletonTable from '@/components/data-table/SkeletonTable';
-import TableFooter from '@/components/data-table/TableFooter';
+
+import { useSimPoolOverviewQuery } from '@/client/graphql/sim-pool.generated';
+import { EmptyState } from '@/components/EmptyState';
 import { KpiRow } from '@/components/Kpi';
 import PageHeader from '@/components/PageHeader';
+import { sectionValue } from '@/components/SectionFallback';
+import StatusBadge from '@/components/StatusBadge';
+import SkeletonTable from '@/components/data-table/SkeletonTable';
+import TableFooter from '@/components/data-table/TableFooter';
 import { useToast } from '@/components/ToastProvider';
-import { SIM_BATCHES, SIMS_SUMMARY } from '@/data';
-import type { SimBatch } from '@/data';
-import { useFirstLoad } from '@/lib/useFirstLoad';
 import UploadSimsDialog from './UploadSimsDialog';
 
-function BatchMenu({ batch }: { batch: SimBatch }) {
+const SIM_TYPE = 'ukama_data';
+const LIST_LIMIT = 50;
+
+function SimMenu({ iccid }: { iccid: string }) {
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const toast = useToast();
   return (
@@ -56,41 +61,52 @@ function BatchMenu({ batch }: { batch: SimBatch }) {
           sx={{ fontSize: 13.5, gap: 1.25 }}
           onClick={() => {
             setAnchor(null);
-            toast(`Viewing SIMs in ${batch.batch}`);
+            toast(`Viewing SIM ${iccid}`);
           }}
         >
-          <VisibilityRounded sx={{ fontSize: 18 }} /> View SIMs
+          <VisibilityRounded sx={{ fontSize: 18 }} /> View SIM
         </MenuItem>
         <MenuItem
           sx={{ fontSize: 13.5, gap: 1.25 }}
           onClick={() => {
             setAnchor(null);
-            toast(`Exported ${batch.batch}`);
+            toast(`Exported ${iccid}`);
           }}
         >
-          <DownloadRounded sx={{ fontSize: 18 }} /> Export batch
+          <DownloadRounded sx={{ fontSize: 18 }} /> Export
         </MenuItem>
       </Menu>
     </>
   );
 }
 
+const simStatus = (sim: { isAllocated: boolean; isFailed: boolean }) =>
+  sim.isFailed ? 'offline' : sim.isAllocated ? 'online' : 'configuring';
+
+const simStatusLabel = (sim: { isAllocated: boolean; isFailed: boolean }) =>
+  sim.isFailed ? 'Faulty' : sim.isAllocated ? 'Assigned' : 'Available';
+
 export default function SimPoolScreen({ canAct }: { canAct: boolean }) {
-  const s = SIMS_SUMMARY;
-  const loading = useFirstLoad('simpool');
   const toast = useToast();
   const [showUpload, setShowUpload] = useState(false);
+
+  const { data, loading, refetch } = useSimPoolOverviewQuery({
+    variables: { simType: SIM_TYPE, limit: LIST_LIMIT },
+  });
+  const stats = data?.simPoolView.stats;
+  const simsSection = data?.simPoolView.sims;
+  const sims = simsSection?.sims ?? [];
 
   return (
     <div className="page">
       <PageHeader
         crumb={['Manage', 'SIM pool']}
         title="SIM pool"
-        count={s.total.toLocaleString()}
+        count={sectionValue(stats?.total, stats?.error)}
         sub={
           canAct
             ? 'Inventory of SIMs available to assign to customers.'
-            : 'SIM batches uploaded for this network (view-only).'
+            : 'SIMs uploaded for this network (view-only).'
         }
         actions={
           canAct ? (
@@ -115,97 +131,121 @@ export default function SimPoolScreen({ canAct }: { canAct: boolean }) {
       />
       <KpiRow
         items={[
-          { icon: 'sim_card', label: 'Assigned', value: s.assigned.toLocaleString(), color: 'var(--uk-ac)' },
-          { icon: 'info', label: 'Available', value: s.available, color: 'var(--uk-success-bright)' },
-          { icon: 'warning', label: 'Suspended', value: s.suspended, color: 'var(--uk-orange)' },
-          { icon: 'error', label: 'Faulty', value: s.faulty, color: 'var(--uk-error)' },
+          {
+            icon: 'sim_card',
+            label: 'Assigned',
+            value: sectionValue(stats?.consumed, stats?.error),
+            sub: stats?.pctAssigned != null ? `${stats.pctAssigned}% of pool` : undefined,
+            color: 'var(--uk-ac)',
+          },
+          {
+            icon: 'info',
+            label: 'Available',
+            value: sectionValue(stats?.available, stats?.error),
+            color: 'var(--uk-success-bright)',
+          },
+          {
+            icon: 'error',
+            label: 'Faulty',
+            value: sectionValue(stats?.failed, stats?.error),
+            color: 'var(--uk-error)',
+          },
+          {
+            icon: 'sim_card',
+            label: 'eSIM / physical',
+            value: stats?.error
+              ? '—'
+              : `${stats?.esim ?? 0} / ${stats?.physical ?? 0}`,
+            color: 'var(--uk-secondary)',
+          },
         ]}
       />
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 11,
-          background: 'rgba(226,116,41,.09)',
-          border: '1px solid rgba(226,116,41,.22)',
-          borderRadius: 10,
-          padding: '12px 16px',
-          marginBottom: 'var(--uk-gap)',
-        }}
-      >
-        <InfoRounded sx={{ color: '#b5591b', fontSize: 20 }} />
-        <span style={{ fontSize: 13, color: 'var(--uk-ink-2)', flex: 1 }}>
-          <b style={{ color: 'var(--uk-ink)' }}>Stock is getting low.</b> {s.available} SIMs
-          available — below your 700 reorder threshold.
-        </span>
-        {canAct && (
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<ShoppingCartRounded />}
-            onClick={() => toast('Order placed with Ukama supply')}
-          >
-            Order SIMs
-          </Button>
-        )}
-      </div>
+      {stats?.lowStock && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 11,
+            background: 'rgba(226,116,41,.09)',
+            border: '1px solid rgba(226,116,41,.22)',
+            borderRadius: 10,
+            padding: '12px 16px',
+            marginBottom: 'var(--uk-gap)',
+          }}
+        >
+          <InfoRounded sx={{ color: '#b5591b', fontSize: 20 }} />
+          <span style={{ fontSize: 13, color: 'var(--uk-ink-2)', flex: 1 }}>
+            <b style={{ color: 'var(--uk-ink)' }}>Stock is getting low.</b>{' '}
+            {stats.available} SIMs available — below the reorder threshold.
+          </span>
+          {canAct && (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<ShoppingCartRounded />}
+              onClick={() => toast('Order placed with Ukama supply')}
+            >
+              Order SIMs
+            </Button>
+          )}
+        </div>
+      )}
 
       <div className="card card-pad">
         <div className="sec-head">
           <div className="sec-title">
-            Batches <span className="cnt tnum">{SIM_BATCHES.length}</span>
+            SIMs <span className="cnt tnum">{sims.length}</span>
           </div>
         </div>
         <div className="tbl-wrap">
           {loading ? (
-            <SkeletonTable cols={6} rows={4} />
+            <SkeletonTable cols={5} rows={4} />
+          ) : simsSection?.error ? (
+            <EmptyState
+              art="error"
+              title="Couldn't load SIMs"
+              sub={simsSection.error.message}
+              cta="Try again"
+              onCta={() => refetch()}
+            />
+          ) : sims.length === 0 ? (
+            <EmptyState art="sim" title="No SIMs" sub="Upload a SIM batch to get started." />
           ) : (
             <Table>
               <TableHead>
                 <TableRow>
-                  <TableCell>Batch</TableCell>
+                  <TableCell>ICCID</TableCell>
                   <TableCell>Type</TableCell>
-                  <TableCell align="right">Quantity</TableCell>
-                  <TableCell>Assigned</TableCell>
-                  <TableCell>Uploaded</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Added</TableCell>
                   {canAct && <TableCell sx={{ width: 44 }} />}
                 </TableRow>
               </TableHead>
               <TableBody>
-                {SIM_BATCHES.map((b) => {
-                  const pct = Math.round((b.assigned / b.qty) * 100);
-                  return (
-                    <TableRow key={b.id}>
-                      <TableCell className="tnum" style={{ fontWeight: 600 }}>
-                        {b.batch}
-                      </TableCell>
-                      <TableCell>{b.type}</TableCell>
-                      <TableCell align="right" className="tnum">{b.qty.toLocaleString()}</TableCell>
+                {sims.map((sim) => (
+                  <TableRow key={sim.id}>
+                    <TableCell className="tnum" style={{ fontWeight: 600 }}>
+                      {sim.iccid}
+                    </TableCell>
+                    <TableCell>{sim.isPhysical ? 'Physical' : 'eSIM'}</TableCell>
+                    <TableCell>
+                      <StatusBadge status={simStatus(sim)}>{simStatusLabel(sim)}</StatusBadge>
+                    </TableCell>
+                    <TableCell className="muted">{sim.createdAt}</TableCell>
+                    {canAct && (
                       <TableCell>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 10, width: 184 }}>
-                          <Meter value={pct} sx={{ flex: 1, minWidth: 60 }} />
-                          <span
-                            className="tnum"
-                            style={{ fontSize: 12, color: 'var(--uk-ink-2)', whiteSpace: 'nowrap' }}
-                          >
-                            {b.assigned} · {pct}%
-                          </span>
-                        </div>
+                        <SimMenu iccid={sim.iccid} />
                       </TableCell>
-                      <TableCell className="muted">{b.uploaded}</TableCell>
-                      {canAct && (
-                        <TableCell>
-                          <BatchMenu batch={b} />
-                        </TableCell>
-                      )}
-                    </TableRow>
-                  );
-                })}
+                    )}
+                  </TableRow>
+                ))}
               </TableBody>
             </Table>
           )}
         </div>
-        {!loading && <TableFooter count={SIM_BATCHES.length} noun="batches" />}
+        {!loading && !simsSection?.error && (
+          <TableFooter count={sims.length} noun="SIMs" />
+        )}
       </div>
       {showUpload && <UploadSimsDialog onClose={() => setShowUpload(false)} />}
     </div>

--- a/interfaces/ukama-console/src/features/sims/SimPoolScreen.tsx
+++ b/interfaces/ukama-console/src/features/sims/SimPoolScreen.tsx
@@ -38,6 +38,7 @@ import StatusBadge from '@/components/StatusBadge';
 import SkeletonTable from '@/components/data-table/SkeletonTable';
 import TableFooter from '@/components/data-table/TableFooter';
 import { useToast } from '@/components/ToastProvider';
+import { POLL_OVERVIEW_MS, visiblePoll } from '@/lib/polling';
 import UploadSimsDialog from './UploadSimsDialog';
 
 const SIM_TYPE = 'ukama_data';
@@ -92,6 +93,7 @@ export default function SimPoolScreen({ canAct }: { canAct: boolean }) {
 
   const { data, loading, refetch } = useSimPoolOverviewQuery({
     variables: { simType: SIM_TYPE, limit: LIST_LIMIT },
+    ...visiblePoll(POLL_OVERVIEW_MS),
   });
   const stats = data?.simPoolView.stats;
   const simsSection = data?.simPoolView.sims;

--- a/interfaces/ukama-console/src/lib/mappers/nodes.ts
+++ b/interfaces/ukama-console/src/lib/mappers/nodes.ts
@@ -1,0 +1,50 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * Maps BFF composite Node data onto the existing UkamaNode view-model so the
+ * card/drawer/table components stay unchanged. cpu/mem/temp/fw/up are
+ * metrics-phase data (backend gaps #6) — zero/null placeholders until then;
+ * the screens render them as "—" via the §4.5 contract.
+ */
+import type { ViewNodeFragment } from '@/client/graphql/views-shared.generated';
+import type { UkamaNode } from '@/data';
+
+const NODE_TYPE_LABEL: Record<string, UkamaNode['type']> = {
+  tnode: 'Tower node',
+  anode: 'Amplifier node',
+  hnode: 'Tower node',
+  cnode: 'Tower node',
+};
+
+export const toNodeStatus = (node: ViewNodeFragment): UkamaNode['status'] => {
+  const connectivity = node.status.connectivity.toLowerCase();
+  const state = node.status.state.toLowerCase();
+  if (connectivity !== 'online') return 'offline';
+  if (state === 'faulty') return 'degraded';
+  if (state === 'configured' || state === 'unknown') return 'configuring';
+  return 'online';
+};
+
+export const toUkamaNode = (
+  node: ViewNodeFragment,
+  siteName?: string
+): UkamaNode => ({
+  id: node.id,
+  serial: node.id,
+  type: NODE_TYPE_LABEL[node.type] ?? 'Tower node',
+  site: siteName ?? node.site?.siteId ?? '—',
+  status: toNodeStatus(node),
+  // TODO(metrics-phase): cpu/mem/temp/fw/up come from nodeView.kpis —
+  // backend gap #6 (docs in systems/console-bff/docs/backend-gaps.md)
+  cpu: 0,
+  mem: 0,
+  temp: null,
+  fw: '—',
+  up: '—',
+});

--- a/interfaces/ukama-console/src/lib/mappers/sites.ts
+++ b/interfaces/ukama-console/src/lib/mappers/sites.ts
@@ -1,0 +1,52 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * Maps BFF composite SiteDto (+ per-site node counts) onto the existing Site
+ * view-model so cards/drawers/map stay unchanged. uptime/subs/battery/signal
+ * are metrics-phase data (backend gaps #7/#8) — placeholders until then.
+ */
+import type { ViewSiteFragment } from '@/client/graphql/views-shared.generated';
+import type { Site } from '@/data';
+
+export interface SiteNodeCounts {
+  total: number;
+  online: number;
+}
+
+export const toSiteStatus = (
+  site: Pick<ViewSiteFragment, 'isDeactivated'>,
+  counts?: SiteNodeCounts
+): Site['status'] => {
+  if (site.isDeactivated) return 'offline';
+  if (!counts || counts.total === 0) return 'online';
+  if (counts.online === 0) return 'offline';
+  if (counts.online < counts.total) return 'degraded';
+  return 'online';
+};
+
+export const toSite = (
+  dto: ViewSiteFragment,
+  counts?: SiteNodeCounts
+): Site => ({
+  id: dto.id,
+  name: dto.name,
+  area: dto.location || '—',
+  status: toSiteStatus(dto, counts),
+  subs: 0,
+  nodes: counts?.total ?? 0,
+  // TODO(metrics-phase): uptime/battery/signal/data from siteView.kpis and
+  // siteView.power — backend gaps #7/#8
+  uptime: 0,
+  battery: 0,
+  signal: null,
+  data: '',
+  lat: parseFloat(dto.latitude) || 0,
+  lng: parseFloat(dto.longitude) || 0,
+  plan: '',
+});

--- a/interfaces/ukama-console/src/lib/mappers/subscribers.ts
+++ b/interfaces/ukama-console/src/lib/mappers/subscribers.ts
@@ -1,0 +1,57 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * Maps subscribersView composite data onto the Subscriber view-model so the
+ * shared customers table stays unchanged. Usage figures are a backend gap
+ * (subscribersView.usage, gap #2): `usage: -1` is the "unknown" sentinel the
+ * table renders as "—". Site attribution and last-seen are also
+ * metrics-phase data.
+ */
+import type { NetworkCustomersQuery } from '@/client/graphql/network-customers.generated';
+import type { Subscriber } from '@/data';
+
+type QuerySubscriber = NonNullable<
+  NonNullable<NetworkCustomersQuery['subscribersView']['subscribers']['subscribers']>
+>[number];
+type QueryPlan = NonNullable<
+  NonNullable<NetworkCustomersQuery['subscribersView']['plans']['plans']>
+>[number];
+
+const toSimStatus = (status?: string): Subscriber['sim'] => {
+  const s = (status ?? '').toLowerCase();
+  if (s === 'active') return 'active';
+  if (s === 'suspended') return 'suspended';
+  return 'inactive';
+};
+
+export const toSubscriber = (
+  sub: QuerySubscriber,
+  plansById: Map<string, QueryPlan>
+): Subscriber => {
+  const firstSim = sub.sim?.[0];
+  const activePackage = sub.sim
+    ?.flatMap((s) => (s.package ? [s.package] : []))
+    .find((p) => p.is_active);
+  const planName = activePackage
+    ? (plansById.get(activePackage.package_id)?.name ?? 'No plan')
+    : 'No plan';
+  return {
+    id: sub.uuid,
+    name: sub.name,
+    phone: sub.phone || (firstSim?.msisdn ?? '—'),
+    site: '—',
+    plan: planName,
+    // TODO(metrics-phase): subscribersView.usage — backend gap #2
+    usage: -1,
+    cap: null,
+    sim: toSimStatus(firstSim?.status),
+    iccid: firstSim?.iccid ?? '—',
+    seen: '—',
+  };
+};

--- a/interfaces/ukama-console/src/lib/polling.ts
+++ b/interfaces/ukama-console/src/lib/polling.ts
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * v1 freshness mechanism = screen-scoped polling, paused on hidden tabs
+ * (BUILD-PLAN §5.1·4). No WebSockets/subscriptions in version 1.
+ *
+ * POLLING IS CURRENTLY DISABLED GLOBALLY: queries fetch on mount (subject to
+ * the Apollo TTL cache) and on demand (refetch). The plumbing stays in place
+ * at every call site — enable per screen by passing `enabled: true`, or
+ * globally via NEXT_PUBLIC_ENABLE_POLLING=true, when we turn screens live
+ * case by case.
+ *
+ * Usage: useFooQuery({ variables, ...visiblePoll(POLL_OVERVIEW_MS) })
+ * Opt-in later: useFooQuery({ variables, ...visiblePoll(POLL_OVERVIEW_MS, true) })
+ */
+export const POLL_LIVE_MS = 30_000; // node/site detail health & KPIs
+export const POLL_OVERVIEW_MS = 60_000; // home/list status screens
+
+const POLLING_ENABLED = process.env.NEXT_PUBLIC_ENABLE_POLLING === 'true';
+
+export const visiblePoll = (
+  pollInterval: number,
+  enabled: boolean = POLLING_ENABLED
+): { pollInterval?: number; skipPollAttempt?: () => boolean } => {
+  if (!enabled) return {};
+  return {
+    pollInterval,
+    /** Apollo skips the tick entirely while the tab is hidden. */
+    skipPollAttempt: () =>
+      typeof document !== 'undefined' && document.visibilityState === 'hidden',
+  };
+};

--- a/systems/console-bff/billing/datasource/billing_api.ts
+++ b/systems/console-bff/billing/datasource/billing_api.ts
@@ -21,26 +21,26 @@ class BillingAPI extends BaseRESTDataSource {
   ): Promise<GetReportsDto> => {
     this.logger.info(`GetReports [GET] ${baseURL}/${VERSION}/reports`);
     this.baseURL = baseURL;
-    const params = "sort=true";
+    const params = new URLSearchParams({ sort: "true" });
     if (req.networkId) {
-      params.concat(`&network_id=${req.networkId}`);
+      params.append("network_id", req.networkId);
     }
     if (req.ownerId) {
-      params.concat(`&owner_id=${req.ownerId}`);
+      params.append("owner_id", req.ownerId);
     }
     if (req.ownerType) {
-      params.concat(`&owner_type=${req.ownerType}`);
+      params.append("owner_type", req.ownerType);
     }
     if (req.report_type) {
-      params.concat(`&report_type=${req.report_type}`);
+      params.append("report_type", req.report_type);
     }
     if (req.count) {
-      params.concat(`&count=${req.count}`);
+      params.append("count", `${req.count}`);
     }
-    if (req.isPaid) {
-      params.concat(`&is_paid=${req.isPaid}`);
+    if (req.isPaid !== undefined && req.isPaid !== null) {
+      params.append("is_paid", `${req.isPaid}`);
     }
-    return this.get(`/${VERSION}/reports?${params}`).then(res =>
+    return this.get(`/${VERSION}/reports?${params.toString()}`).then(res =>
       dtoToReportsDto(res)
     );
   };

--- a/systems/console-bff/common/middleware/compression.ts
+++ b/systems/console-bff/common/middleware/compression.ts
@@ -1,0 +1,62 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * Zero-dependency gzip middleware for buffered JSON responses.
+ *
+ * Apollo's express4 integration (and express `res.json`) deliver complete
+ * responses through `res.send`, so intercepting `send` covers all GraphQL
+ * payloads — the case that matters for composite queries. Streaming/chunked
+ * responses (`res.write`) intentionally pass through uncompressed.
+ */
+import type { NextFunction, Request, Response } from "express";
+import { gzipSync } from "zlib";
+
+/** Don't burn CPU compressing tiny payloads. */
+export const COMPRESSION_THRESHOLD_BYTES = parseInt(
+  process.env.COMPRESSION_THRESHOLD_BYTES ?? "1024"
+);
+
+const acceptsGzip = (req: Request): boolean => {
+  const acceptEncoding = req.headers["accept-encoding"];
+  return (
+    typeof acceptEncoding === "string" &&
+    /(^|,)\s*gzip\s*(;|,|$)/i.test(acceptEncoding)
+  );
+};
+
+export const compression =
+  () =>
+  (req: Request, res: Response, next: NextFunction): void => {
+    if (!acceptsGzip(req)) {
+      next();
+      return;
+    }
+    const originalSend = res.send.bind(res);
+    res.send = (body?: unknown): Response => {
+      const raw =
+        typeof body === "string"
+          ? Buffer.from(body)
+          : Buffer.isBuffer(body)
+            ? body
+            : undefined;
+      if (
+        raw === undefined ||
+        raw.length < COMPRESSION_THRESHOLD_BYTES ||
+        res.getHeader("content-encoding") !== undefined
+      ) {
+        return originalSend(body as never);
+      }
+      res.setHeader("content-encoding", "gzip");
+      res.setHeader("vary", "Accept-Encoding");
+      const compressed = gzipSync(raw);
+      res.setHeader("content-length", compressed.length);
+      return originalSend(compressed);
+    };
+    next();
+  };

--- a/systems/console-bff/common/middleware/expressApp.ts
+++ b/systems/console-bff/common/middleware/expressApp.ts
@@ -15,6 +15,7 @@ import express, { type Request } from "express";
 import expressWinston from "express-winston";
 
 import { runWithRequestId } from "../logger/requestContext";
+import { compression } from "./compression";
 import { REQUEST_ID_HEADER, requestId } from "./requestId";
 import { rateLimit, securityHeaders } from "./security";
 
@@ -32,6 +33,8 @@ function configureExpress(logger: any) {
   );
   app.use(securityHeaders());
   app.use(rateLimit());
+  // Gzip buffered JSON responses (GraphQL payloads) above the size threshold.
+  app.use(compression());
   app.use(
     expressWinston.logger({
       winstonInstance: logger,

--- a/systems/console-bff/common/middleware/persistedOperations.ts
+++ b/systems/console-bff/common/middleware/persistedOperations.ts
@@ -1,0 +1,98 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * Persisted-operations allowlist (docs/bff-screen-api-plan.md §3.3).
+ *
+ * The console is the BFF's only client, so production accepts only the
+ * operation documents the console actually ships. The console build emits a
+ * manifest (graphql-codegen persisted-documents format:
+ * `{ "<sha256-of-document>": "<document>" }`); this middleware hashes each
+ * incoming query and rejects unknown documents.
+ *
+ * Disabled unless PERSISTED_OPS_ENFORCED=true (dev and codegen stay open).
+ * Introspection is governed separately by INTROSPECTION_ENABLED.
+ */
+import { createHash } from "crypto";
+import type { NextFunction, Request, Response } from "express";
+import { existsSync, readFileSync } from "fs";
+
+import { logger } from "../logger";
+
+export const PERSISTED_OPS_ENFORCED =
+  process.env.PERSISTED_OPS_ENFORCED === "true";
+export const PERSISTED_OPS_MANIFEST =
+  process.env.PERSISTED_OPS_MANIFEST ?? "persisted-operations.json";
+
+export const sha256 = (document: string): string =>
+  createHash("sha256").update(document).digest("hex");
+
+export const loadManifest = (path: string): Set<string> => {
+  if (!existsSync(path)) {
+    throw new Error(`Persisted operations manifest not found: ${path}`);
+  }
+  const manifest = JSON.parse(readFileSync(path, "utf8")) as Record<
+    string,
+    string
+  >;
+  return new Set(Object.keys(manifest));
+};
+
+const isIntrospectionOperation = (query: unknown): boolean =>
+  typeof query === "string" && query.includes("__schema");
+
+/**
+ * Express middleware guarding /graphql. Mount after body parsing, before
+ * the Apollo middleware. No-op factory result when enforcement is off.
+ */
+export const persistedOperations = (
+  options: {
+    enforced?: boolean;
+    manifestPath?: string;
+    allowIntrospection?: boolean;
+  } = {}
+) => {
+  const enforced = options.enforced ?? PERSISTED_OPS_ENFORCED;
+  const allowIntrospection = options.allowIntrospection ?? false;
+  if (!enforced) {
+    return (_req: Request, _res: Response, next: NextFunction) => next();
+  }
+
+  // Fail fast at startup if enforcement is on but the manifest is missing.
+  const allowedHashes = loadManifest(
+    options.manifestPath ?? PERSISTED_OPS_MANIFEST
+  );
+  logger.info(
+    `Persisted operations enforced: ${allowedHashes.size} known operations`
+  );
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const ops = Array.isArray(req.body) ? req.body : [req.body];
+    for (const op of ops) {
+      const query = (op as { query?: unknown })?.query;
+      if (allowIntrospection && isIntrospectionOperation(query)) {
+        continue;
+      }
+      if (typeof query !== "string" || !allowedHashes.has(sha256(query))) {
+        logger.warn("Rejected non-persisted GraphQL operation", {
+          operationName: (op as { operationName?: string })?.operationName,
+        });
+        res.status(403).json({
+          errors: [
+            {
+              message: "Operation not allowed",
+              extensions: { code: "PERSISTED_OPERATION_NOT_FOUND" },
+            },
+          ],
+        });
+        return;
+      }
+    }
+    next();
+  };
+};

--- a/systems/console-bff/common/tests/compression.test.ts
+++ b/systems/console-bff/common/tests/compression.test.ts
@@ -1,0 +1,76 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import type { Request, Response } from "express";
+import { gunzipSync } from "zlib";
+
+import { compression } from "../middleware/compression";
+
+type SentBody = string | Buffer | undefined;
+
+const makeRes = () => {
+  const headers = new Map<string, unknown>();
+  let sent: SentBody;
+  const res = {
+    send: (body?: SentBody) => {
+      sent = body;
+      return res;
+    },
+    setHeader: (name: string, value: unknown) => {
+      headers.set(name.toLowerCase(), value);
+    },
+    getHeader: (name: string) => headers.get(name.toLowerCase()),
+  } as unknown as Response;
+  return { res, headers, getSent: () => sent };
+};
+
+const makeReq = (acceptEncoding?: string) =>
+  ({
+    headers: acceptEncoding ? { "accept-encoding": acceptEncoding } : {},
+  }) as unknown as Request;
+
+const run = (req: Request, res: Response) =>
+  new Promise<void>(resolve => compression()(req, res, () => resolve()));
+
+describe("compression middleware", () => {
+  const bigBody = JSON.stringify({ data: "x".repeat(5000) });
+
+  it("gzips large responses when the client accepts gzip", async () => {
+    const { res, headers, getSent } = makeRes();
+    await run(makeReq("gzip, deflate"), res);
+    res.send(bigBody);
+    expect(headers.get("content-encoding")).toBe("gzip");
+    expect(headers.get("vary")).toBe("Accept-Encoding");
+    const sent = getSent();
+    expect(Buffer.isBuffer(sent)).toBe(true);
+    expect(gunzipSync(sent as Buffer).toString()).toBe(bigBody);
+  });
+
+  it("skips small payloads", async () => {
+    const { res, headers, getSent } = makeRes();
+    await run(makeReq("gzip"), res);
+    res.send("tiny");
+    expect(headers.get("content-encoding")).toBeUndefined();
+    expect(getSent()).toBe("tiny");
+  });
+
+  it("skips clients that do not accept gzip", async () => {
+    const { res, headers, getSent } = makeRes();
+    await run(makeReq(), res);
+    res.send(bigBody);
+    expect(headers.get("content-encoding")).toBeUndefined();
+    expect(getSent()).toBe(bigBody);
+  });
+
+  it("does not double-encode already-encoded responses", async () => {
+    const { res, getSent } = makeRes();
+    await run(makeReq("gzip"), res);
+    res.setHeader("content-encoding", "br");
+    res.send(bigBody);
+    expect(getSent()).toBe(bigBody);
+  });
+});

--- a/systems/console-bff/common/tests/concurrency.test.ts
+++ b/systems/console-bff/common/tests/concurrency.test.ts
@@ -1,0 +1,65 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import {
+  mapWithConcurrency,
+  mapWithConcurrencySettled,
+} from "../utils/concurrency";
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe("mapWithConcurrency", () => {
+  it("returns results in input order", async () => {
+    const items = [30, 10, 20];
+    const results = await mapWithConcurrency(items, async item => {
+      await sleep(item);
+      return item * 2;
+    });
+    expect(results).toEqual([60, 20, 40]);
+  });
+
+  it("never exceeds the concurrency limit", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    await mapWithConcurrency(
+      Array.from({ length: 20 }, (_, i) => i),
+      async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await sleep(5);
+        inFlight--;
+      },
+      3
+    );
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+  });
+
+  it("handles empty input", async () => {
+    await expect(mapWithConcurrency([], async () => 1)).resolves.toEqual([]);
+  });
+
+  it("propagates rejections", async () => {
+    await expect(
+      mapWithConcurrency([1, 2], async item => {
+        if (item === 2) throw new Error("boom");
+        return item;
+      })
+    ).rejects.toThrow("boom");
+  });
+});
+
+describe("mapWithConcurrencySettled", () => {
+  it("returns per-item settled results without rejecting", async () => {
+    const results = await mapWithConcurrencySettled([1, 2, 3], async item => {
+      if (item === 2) throw new Error("boom");
+      return item * 10;
+    });
+    expect(results[0]).toEqual({ status: "fulfilled", value: 10 });
+    expect(results[1].status).toBe("rejected");
+    expect(results[2]).toEqual({ status: "fulfilled", value: 30 });
+  });
+});

--- a/systems/console-bff/common/tests/datasourceDedup.test.ts
+++ b/systems/console-bff/common/tests/datasourceDedup.test.ts
@@ -1,0 +1,69 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * Verifies the assumption in docs/bff-screen-api-plan.md §4.2: Apollo's
+ * RESTDataSource deduplicates identical concurrent GETs within one
+ * (per-request) datasource instance, so composite sections sharing an
+ * upstream call don't multiply upstream load. If an upgrade ever changes
+ * this default, this test fails and the plan's caching strategy must be
+ * revisited.
+ */
+import { BaseRESTDataSource } from "../datasource";
+
+class TestDataSource extends BaseRESTDataSource {
+  override baseURL = "http://upstream.test";
+
+  fetchThing(): Promise<unknown> {
+    return this.get("/v1/thing");
+  }
+}
+
+describe("RESTDataSource GET deduplication", () => {
+  const originalFetch = global.fetch;
+  let fetchCount: number;
+
+  beforeEach(() => {
+    fetchCount = 0;
+    global.fetch = jest.fn(async () => {
+      fetchCount++;
+      await new Promise(resolve => setTimeout(resolve, 10));
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("collapses identical concurrent GETs into one upstream call", async () => {
+    const ds = new TestDataSource();
+    const [a, b, c] = await Promise.all([
+      ds.fetchThing(),
+      ds.fetchThing(),
+      ds.fetchThing(),
+    ]);
+    expect(a).toEqual({ ok: true });
+    expect(b).toEqual({ ok: true });
+    expect(c).toEqual({ ok: true });
+    expect(fetchCount).toBe(1);
+  });
+
+  it("does not dedupe across instances (per-request isolation)", async () => {
+    const [r1, r2] = await Promise.all([
+      new TestDataSource().fetchThing(),
+      new TestDataSource().fetchThing(),
+    ]);
+    expect(r1).toEqual({ ok: true });
+    expect(r2).toEqual({ ok: true });
+    expect(fetchCount).toBe(2);
+  });
+});

--- a/systems/console-bff/common/tests/derive.test.ts
+++ b/systems/console-bff/common/tests/derive.test.ts
@@ -1,0 +1,103 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import "reflect-metadata";
+
+import {
+  countNodes,
+  deriveSimPool,
+  groupBy,
+  groupNodeCountsBySite,
+  subscriberActivity,
+} from "../../dashboard/derive";
+import { notImplementedSection, runSection } from "../../dashboard/section";
+import { SectionErrorCode } from "../../dashboard/types";
+
+const node = (connectivity: string, siteId?: string) =>
+  ({
+    status: { connectivity, state: "onboarded" },
+    site: siteId ? { siteId } : undefined,
+  }) as never;
+
+describe("derive helpers", () => {
+  it("countNodes counts online/offline by connectivity", () => {
+    const counts = countNodes([
+      node("Online"),
+      node("online"),
+      node("offline"),
+    ]);
+    expect(counts).toEqual({ total: 3, online: 2, offline: 1 });
+  });
+
+  it("groupNodeCountsBySite groups and counts per site", () => {
+    const counts = groupNodeCountsBySite([
+      node("online", "site-a"),
+      node("offline", "site-a"),
+      node("online", "site-b"),
+      node("online"), // unassigned — excluded
+    ]);
+    expect(counts).toEqual([
+      { siteId: "site-a", total: 2, online: 1, offline: 1 },
+      { siteId: "site-b", total: 1, online: 1, offline: 0 },
+    ]);
+  });
+
+  it("subscriberActivity derives active by attached sims", () => {
+    expect(
+      subscriberActivity([
+        { sim: [{} as never] },
+        { sim: [] },
+        { sim: undefined },
+      ])
+    ).toEqual({ total: 3, active: 1, inactive: 2 });
+  });
+
+  it("deriveSimPool computes pctAssigned and lowStock", () => {
+    expect(
+      deriveSimPool({ total: 200, available: 5, consumed: 150 }, 10)
+    ).toEqual({ pctAssigned: 75, lowStock: true });
+    expect(deriveSimPool({ total: 0, available: 50, consumed: 0 }, 10)).toEqual(
+      { pctAssigned: 0, lowStock: false }
+    );
+  });
+
+  it("groupBy skips items without a key", () => {
+    const groups = groupBy(
+      [{ k: "a" }, { k: "a" }, { k: undefined }],
+      item => item.k
+    );
+    expect(groups.get("a")).toHaveLength(2);
+    expect(groups.size).toBe(1);
+  });
+});
+
+describe("runSection / notImplementedSection", () => {
+  it("returns value with null error on success", async () => {
+    expect(await runSection("s", async () => 5)).toEqual({
+      value: 5,
+      error: null,
+    });
+  });
+
+  it("returns typed error with null value on failure", async () => {
+    const { value, error } = await runSection("kpis", async () => {
+      throw { code: 404 };
+    });
+    expect(value).toBeNull();
+    expect(error).toMatchObject({
+      section: "kpis",
+      code: SectionErrorCode.NOT_FOUND,
+    });
+  });
+
+  it("notImplementedSection marks backend gaps", () => {
+    expect(notImplementedSection("usage").error).toMatchObject({
+      section: "usage",
+      code: SectionErrorCode.NOT_IMPLEMENTED,
+    });
+  });
+});

--- a/systems/console-bff/common/tests/derive.test.ts
+++ b/systems/console-bff/common/tests/derive.test.ts
@@ -8,11 +8,14 @@
 import "reflect-metadata";
 
 import {
+  countByCategory,
   countNodes,
+  derivePlanStats,
   deriveSimPool,
   groupBy,
   groupNodeCountsBySite,
   subscriberActivity,
+  summarizeRevenue,
 } from "../../dashboard/derive";
 import { notImplementedSection, runSection } from "../../dashboard/section";
 import { SectionErrorCode } from "../../dashboard/types";
@@ -72,6 +75,103 @@ describe("derive helpers", () => {
     );
     expect(groups.get("a")).toHaveLength(2);
     expect(groups.size).toBe(1);
+  });
+});
+
+describe("commerce derivations (Phase 3)", () => {
+  const pay = (
+    amount: string,
+    status: string,
+    paidAt: string,
+    itemType = "invoice",
+    itemId = "x"
+  ) => ({ amount, status, paidAt, itemType, itemId });
+
+  it("summarizeRevenue splits paid/pending and computes MoM", () => {
+    const now = new Date("2026-06-04T00:00:00Z");
+    const summary = summarizeRevenue(
+      [
+        pay("100", "success", "2026-06-01"),
+        pay("50", "paid", "2026-05-20"),
+        pay("25", "pending", "2026-06-02"),
+        pay("10", "completed", "2026-04-01"),
+      ],
+      now
+    );
+    expect(summary).toEqual({
+      totalPaid: 160,
+      totalPending: 25,
+      monthPaid: 100,
+      prevMonthPaid: 50,
+      momPct: 100,
+    });
+  });
+
+  it("summarizeRevenue returns null MoM without a base month", () => {
+    const now = new Date("2026-06-04T00:00:00Z");
+    expect(
+      summarizeRevenue([pay("100", "success", "2026-06-01")], now).momPct
+    ).toBeNull();
+  });
+
+  it("derivePlanStats attributes package revenue and attach counts", () => {
+    const plans = [
+      {
+        uuid: "p1",
+        name: "Standard",
+        active: true,
+        amount: 10,
+        currency: "USD",
+      },
+      { uuid: "p2", name: "Starter", active: true, amount: 5, currency: "USD" },
+    ];
+    const payments = [
+      pay("30", "success", "2026-06-01", "package", "p1"),
+      pay("10", "success", "2026-06-01", "package", "p2"),
+      pay("99", "pending", "2026-06-01", "package", "p1"), // unpaid: excluded
+      pay("70", "success", "2026-06-01", "invoice", "p1"), // not a package
+    ];
+    const sims = [
+      { packageId: "p1", isActive: true },
+      { packageId: "p1", isActive: true },
+      { packageId: "p2", isActive: false },
+    ];
+    const stats = derivePlanStats(plans, payments, sims);
+    expect(stats[0]).toMatchObject({
+      packageId: "p1",
+      attachCount: 2,
+      revenue: 30,
+      revenueSharePct: 75,
+    });
+    expect(stats[1]).toMatchObject({
+      packageId: "p2",
+      attachCount: 0,
+      revenue: 10,
+      revenueSharePct: 25,
+    });
+  });
+
+  it("derivePlanStats keeps attachCount null without network scope", () => {
+    const stats = derivePlanStats(
+      [{ uuid: "p1", name: "S", active: true, amount: 1, currency: "USD" }],
+      [],
+      null
+    );
+    expect(stats[0].attachCount).toBeNull();
+    expect(stats[0].revenueSharePct).toBe(0);
+  });
+
+  it("countByCategory groups components", () => {
+    expect(
+      countByCategory([
+        { category: "ACCESS" },
+        { category: "ACCESS" },
+        { category: undefined },
+      ])
+    ).toEqual([
+      { category: "ACCESS", count: 2 },
+      { category: "uncategorized", count: 1 },
+    ]);
   });
 });
 

--- a/systems/console-bff/common/tests/persistedOperations.test.ts
+++ b/systems/console-bff/common/tests/persistedOperations.test.ts
@@ -1,0 +1,98 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import type { Request, Response } from "express";
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { persistedOperations, sha256 } from "../middleware/persistedOperations";
+
+const KNOWN_QUERY = "query Ping { ping }";
+
+const writeManifest = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "persisted-ops-"));
+  const path = join(dir, "manifest.json");
+  writeFileSync(path, JSON.stringify({ [sha256(KNOWN_QUERY)]: KNOWN_QUERY }));
+  return path;
+};
+
+const makeRes = () => {
+  let statusCode = 200;
+  let body: unknown;
+  const res = {
+    status: (code: number) => {
+      statusCode = code;
+      return res;
+    },
+    json: (payload: unknown) => {
+      body = payload;
+      return res;
+    },
+  } as unknown as Response;
+  return { res, getStatus: () => statusCode, getBody: () => body };
+};
+
+const makeReq = (query: string) =>
+  ({ body: { query, operationName: "X" } }) as unknown as Request;
+
+describe("persistedOperations middleware", () => {
+  it("is a no-op when enforcement is off", () => {
+    const middleware = persistedOperations({ enforced: false });
+    const { res } = makeRes();
+    const next = jest.fn();
+    middleware(makeReq("query Evil { __typename }"), res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("allows operations present in the manifest", () => {
+    const middleware = persistedOperations({
+      enforced: true,
+      manifestPath: writeManifest(),
+    });
+    const { res } = makeRes();
+    const next = jest.fn();
+    middleware(makeReq(KNOWN_QUERY), res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("rejects unknown operations with 403", () => {
+    const middleware = persistedOperations({
+      enforced: true,
+      manifestPath: writeManifest(),
+    });
+    const { res, getStatus, getBody } = makeRes();
+    const next = jest.fn();
+    middleware(makeReq("query Evil { secrets }"), res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(getStatus()).toBe(403);
+    expect(getBody()).toMatchObject({
+      errors: [{ extensions: { code: "PERSISTED_OPERATION_NOT_FOUND" } }],
+    });
+  });
+
+  it("optionally lets introspection through", () => {
+    const middleware = persistedOperations({
+      enforced: true,
+      manifestPath: writeManifest(),
+      allowIntrospection: true,
+    });
+    const { res } = makeRes();
+    const next = jest.fn();
+    middleware(makeReq("query I { __schema { types { name } } }"), res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("fails fast when the manifest is missing", () => {
+    expect(() =>
+      persistedOperations({
+        enforced: true,
+        manifestPath: "/does/not/exist.json",
+      })
+    ).toThrow("manifest not found");
+  });
+});

--- a/systems/console-bff/common/tests/section.test.ts
+++ b/systems/console-bff/common/tests/section.test.ts
@@ -1,0 +1,75 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import "reflect-metadata";
+
+import { SectionErrorCollector, withSection } from "../../dashboard/section";
+import { SectionErrorCode } from "../../dashboard/types";
+
+describe("withSection", () => {
+  it("returns the value and records nothing on success", async () => {
+    const collector = new SectionErrorCollector();
+    const result = await withSection(collector, "kpis", async () => 42);
+    expect(result).toBe(42);
+    expect(collector.list()).toEqual([]);
+  });
+
+  it("returns null and records a typed error on failure", async () => {
+    const collector = new SectionErrorCollector();
+    const result = await withSection(collector, "kpis", async () => {
+      throw new Error("upstream exploded");
+    });
+    expect(result).toBeNull();
+    expect(collector.list()).toEqual([
+      {
+        section: "kpis",
+        code: SectionErrorCode.INTERNAL,
+        message: "Failed to load kpis",
+      },
+    ]);
+  });
+
+  it("maps HTTP-like status codes", async () => {
+    const collector = new SectionErrorCollector();
+    await withSection(collector, "a", async () => {
+      throw { code: 404, message: "not found" };
+    });
+    await withSection(collector, "b", async () => {
+      throw { extensions: { response: { status: 403 } } };
+    });
+    await withSection(collector, "c", async () => {
+      throw { code: 500, message: "internal upstream" };
+    });
+    expect(collector.list().map(e => e.code)).toEqual([
+      SectionErrorCode.NOT_FOUND,
+      SectionErrorCode.FORBIDDEN,
+      SectionErrorCode.UPSTREAM_ERROR,
+    ]);
+  });
+
+  it("times out slow sections with UPSTREAM_TIMEOUT", async () => {
+    const collector = new SectionErrorCollector();
+    const result = await withSection(
+      collector,
+      "slow",
+      () => new Promise(resolve => setTimeout(resolve, 1000)),
+      20
+    );
+    expect(result).toBeNull();
+    expect(collector.list()[0].code).toBe(SectionErrorCode.UPSTREAM_TIMEOUT);
+  });
+
+  it("keeps errors isolated per collector instance (request-scoped)", async () => {
+    const a = new SectionErrorCollector();
+    const b = new SectionErrorCollector();
+    await withSection(a, "x", async () => {
+      throw new Error("fail");
+    });
+    expect(a.list()).toHaveLength(1);
+    expect(b.list()).toHaveLength(0);
+  });
+});

--- a/systems/console-bff/common/tests/subscriberJoin.test.ts
+++ b/systems/console-bff/common/tests/subscriberJoin.test.ts
@@ -1,0 +1,70 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import "reflect-metadata";
+
+import { GetSubscribersByNetworkResolver } from "../../subscriber/resolver/getSubscribersByNetwork";
+
+const makeSub = (uuid: string) => ({
+  uuid,
+  name: `sub-${uuid}`,
+  dob: "",
+  phone: "",
+  email: "",
+  gender: "",
+  address: "",
+  idSerial: "",
+  networkId: "net-1",
+  proofOfIdentification: "",
+});
+
+const makeSim = (id: string, subscriberId: string) => ({
+  id,
+  subscriberId,
+});
+
+describe("getSubscribersByNetwork sim join", () => {
+  it("attaches each subscriber's sims and parallel-fetches upstreams", async () => {
+    const getSimsByNetwork = jest.fn().mockResolvedValue({
+      sims: [
+        makeSim("sim-1", "sub-a"),
+        makeSim("sim-2", "sub-b"),
+        makeSim("sim-3", "sub-a"),
+      ],
+    });
+    const getSubscribersByNetwork = jest.fn().mockResolvedValue({
+      subscribers: [makeSub("sub-a"), makeSub("sub-b"), makeSub("sub-c")],
+    });
+    const ctx = {
+      baseURL: "http://subscriber.test",
+      dataSources: {
+        subscriber: { getSimsByNetwork, getSubscribersByNetwork },
+      },
+    };
+
+    const resolver = new GetSubscribersByNetworkResolver();
+    const result = await resolver.getSubscribersByNetwork(
+      "net-1",
+      ctx as never
+    );
+
+    const byUuid = Object.fromEntries(
+      result.subscribers.map(s => [s.uuid, s.sim])
+    );
+    expect(byUuid["sub-a"]?.map(sim => sim.id)).toEqual(["sim-1", "sim-3"]);
+    expect(byUuid["sub-b"]?.map(sim => sim.id)).toEqual(["sim-2"]);
+    expect(byUuid["sub-c"]).toEqual([]);
+    expect(getSimsByNetwork).toHaveBeenCalledWith(
+      "http://subscriber.test",
+      "net-1"
+    );
+    expect(getSubscribersByNetwork).toHaveBeenCalledWith(
+      "http://subscriber.test",
+      "net-1"
+    );
+  });
+});

--- a/systems/console-bff/common/utils/concurrency.ts
+++ b/systems/console-bff/common/utils/concurrency.ts
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2023-present, Ukama Inc.
+ */
+
+export const DEFAULT_FANOUT_CONCURRENCY = 10;
+
+/**
+ * Map over `items` with `fn`, keeping at most `concurrency` promises in
+ * flight. Results preserve input order. Rejections propagate (use
+ * `mapWithConcurrencySettled` for per-item results).
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  fn: (item: T, index: number) => Promise<R>,
+  concurrency: number = DEFAULT_FANOUT_CONCURRENCY
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const limit = Math.max(1, Math.min(concurrency, items.length));
+  const results: R[] = new Array(items.length);
+  let next = 0;
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const index = next++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index], index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: limit }, worker));
+  return results;
+}
+
+/**
+ * Like `mapWithConcurrency`, but never rejects: returns a
+ * PromiseSettledResult per item, preserving input order.
+ */
+export async function mapWithConcurrencySettled<T, R>(
+  items: readonly T[],
+  fn: (item: T, index: number) => Promise<R>,
+  concurrency: number = DEFAULT_FANOUT_CONCURRENCY
+): Promise<PromiseSettledResult<R>[]> {
+  return mapWithConcurrency(
+    items,
+    async (item, index): Promise<PromiseSettledResult<R>> => {
+      try {
+        return { status: "fulfilled", value: await fn(item, index) };
+      } catch (reason) {
+        return { status: "rejected", reason };
+      }
+    },
+    concurrency
+  );
+}

--- a/systems/console-bff/dashboard/baseUrls.ts
+++ b/systems/console-bff/dashboard/baseUrls.ts
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * Per-request service base-URL resolution for composite resolvers.
+ *
+ * NOTE: the consolidated AppContext does not carry `ctx.baseURL` (each
+ * domain's legacy Context interface declares it, but the runtime context
+ * never sets it). Composites therefore resolve base URLs explicitly — same
+ * pattern as getOrgTree — memoized per request so multiple sections hitting
+ * the same upstream system cost one lookup.
+ */
+import { getBaseURL } from "../common/utils";
+
+export class ServiceUrlResolver {
+  private readonly cache = new Map<string, Promise<string>>();
+
+  constructor(private readonly orgName: string) {}
+
+  /** Resolve (and memoize) the API-gateway base URL for a SUB_GRAPHS service
+   *  name (e.g. "network", "sim", "health"). Throws on lookup failure —
+   *  callers run inside runSection, which maps it to a SectionError. */
+  url(service: string): Promise<string> {
+    let cached = this.cache.get(service);
+    if (!cached) {
+      cached = getBaseURL(service, this.orgName).then(res => {
+        if (res.status !== 200 || !res.message) {
+          throw new Error(`Base URL lookup failed for service '${service}'`);
+        }
+        return res.message;
+      });
+      this.cache.set(service, cached);
+    }
+    return cached;
+  }
+}

--- a/systems/console-bff/dashboard/derive.ts
+++ b/systems/console-bff/dashboard/derive.ts
@@ -89,6 +89,141 @@ export const deriveSimPool = (
   lowStock: stats.available < lowStockThreshold,
 });
 
+/* ------------------------- commerce (Phase 3) ---------------------------- */
+
+export interface PaymentLike {
+  amount: string;
+  status: string;
+  paidAt: string;
+  itemType: string;
+  itemId: string;
+}
+
+const PAID_STATUSES = new Set(["success", "paid", "completed", "processed"]);
+
+export const isPaidPayment = (payment: Pick<PaymentLike, "status">): boolean =>
+  PAID_STATUSES.has(payment.status.toLowerCase());
+
+const monthKey = (iso: string): string => iso.slice(0, 7); // YYYY-MM
+
+export interface RevenueSummary {
+  totalPaid: number;
+  totalPending: number;
+  monthPaid: number;
+  prevMonthPaid: number;
+  /** Month-over-month change of paid revenue, percent (null if no base). */
+  momPct: number | null;
+}
+
+export const summarizeRevenue = (
+  payments: readonly PaymentLike[],
+  now: Date = new Date()
+): RevenueSummary => {
+  const thisMonth = now.toISOString().slice(0, 7);
+  const prev = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1));
+  const prevMonth = prev.toISOString().slice(0, 7);
+  let totalPaid = 0;
+  let totalPending = 0;
+  let monthPaid = 0;
+  let prevMonthPaid = 0;
+  for (const payment of payments) {
+    const amount = parseFloat(payment.amount) || 0;
+    if (isPaidPayment(payment)) {
+      totalPaid += amount;
+      const key = monthKey(payment.paidAt ?? "");
+      if (key === thisMonth) monthPaid += amount;
+      else if (key === prevMonth) prevMonthPaid += amount;
+    } else {
+      totalPending += amount;
+    }
+  }
+  const momPct =
+    prevMonthPaid > 0
+      ? Math.round(((monthPaid - prevMonthPaid) / prevMonthPaid) * 100)
+      : null;
+  return { totalPaid, totalPending, monthPaid, prevMonthPaid, momPct };
+};
+
+export interface PlanLike {
+  uuid: string;
+  name: string;
+  active: boolean;
+  amount: number;
+  currency: string;
+}
+
+export interface SimPackageLike {
+  packageId?: string;
+  isActive?: boolean;
+}
+
+export interface PlanStats {
+  packageId: string;
+  name: string;
+  amount: number;
+  currency: string;
+  active: boolean;
+  /** Active attachments (null when no network scope was given). */
+  attachCount: number | null;
+  /** Paid revenue attributed to this plan (payments with itemType=package). */
+  revenue: number;
+  revenueSharePct: number;
+}
+
+export const derivePlanStats = (
+  plans: readonly PlanLike[],
+  payments: readonly PaymentLike[],
+  activeSimPackages: readonly SimPackageLike[] | null
+): PlanStats[] => {
+  const revenueByPlan = new Map<string, number>();
+  let totalRevenue = 0;
+  for (const payment of payments) {
+    if (payment.itemType?.toLowerCase() !== "package") continue;
+    if (!isPaidPayment(payment)) continue;
+    const amount = parseFloat(payment.amount) || 0;
+    revenueByPlan.set(
+      payment.itemId,
+      (revenueByPlan.get(payment.itemId) ?? 0) + amount
+    );
+    totalRevenue += amount;
+  }
+  const attachByPlan = activeSimPackages
+    ? groupBy(
+        activeSimPackages.filter(p => p.isActive),
+        p => p.packageId
+      )
+    : null;
+  return plans.map(plan => {
+    const revenue = revenueByPlan.get(plan.uuid) ?? 0;
+    return {
+      packageId: plan.uuid,
+      name: plan.name,
+      amount: plan.amount,
+      currency: plan.currency,
+      active: plan.active,
+      attachCount: attachByPlan
+        ? (attachByPlan.get(plan.uuid)?.length ?? 0)
+        : null,
+      revenue,
+      revenueSharePct:
+        totalRevenue > 0 ? Math.round((revenue / totalRevenue) * 100) : 0,
+    };
+  });
+};
+
+export interface CategoryCount {
+  category: string;
+  count: number;
+}
+
+export const countByCategory = (
+  items: readonly { category?: string }[]
+): CategoryCount[] =>
+  Array.from(
+    groupBy(items, item => item.category || "uncategorized").entries(),
+    ([category, group]) => ({ category, count: group.length })
+  );
+
 /** O(n+m) group-join of sims onto their owner, keyed by `subscriberId`. */
 export const groupBy = <T>(
   items: readonly T[],

--- a/systems/console-bff/dashboard/derive.ts
+++ b/systems/console-bff/dashboard/derive.ts
@@ -1,0 +1,106 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * Pure derivation helpers for composite sections (plan §2.6: UI-ready DTOs —
+ * the console renders, it does not compute). Kept dependency-free so they
+ * are trivially unit-testable.
+ */
+import { Node } from "../node/resolvers/types";
+import { SimPoolStatsDto } from "../sim/resolver/types";
+import { SubscriberDto } from "../subscriber/resolver/types";
+
+export const SIM_POOL_LOW_STOCK_THRESHOLD = parseInt(
+  process.env.SIM_POOL_LOW_STOCK_THRESHOLD ?? "10"
+);
+
+export interface NodeCounts {
+  total: number;
+  online: number;
+  offline: number;
+}
+
+export const countNodes = (nodes: readonly Node[]): NodeCounts => {
+  let online = 0;
+  for (const node of nodes) {
+    if (node.status?.connectivity?.toLowerCase() === "online") online++;
+  }
+  return { total: nodes.length, online, offline: nodes.length - online };
+};
+
+export interface SiteNodeCount extends NodeCounts {
+  siteId: string;
+}
+
+export const groupNodeCountsBySite = (
+  nodes: readonly Node[]
+): SiteNodeCount[] => {
+  const bySite = new Map<string, Node[]>();
+  for (const node of nodes) {
+    const siteId = node.site?.siteId;
+    if (!siteId) continue;
+    const group = bySite.get(siteId);
+    if (group) group.push(node);
+    else bySite.set(siteId, [node]);
+  }
+  return Array.from(bySite.entries(), ([siteId, siteNodes]) => ({
+    siteId,
+    ...countNodes(siteNodes),
+  }));
+};
+
+export interface SubscriberActivity {
+  total: number;
+  active: number;
+  inactive: number;
+}
+
+/** A subscriber is "active" when at least one SIM is attached. */
+export const subscriberActivity = (
+  subscribers: readonly Pick<SubscriberDto, "sim">[]
+): SubscriberActivity => {
+  let active = 0;
+  for (const sub of subscribers) {
+    if ((sub.sim?.length ?? 0) > 0) active++;
+  }
+  return {
+    total: subscribers.length,
+    active,
+    inactive: subscribers.length - active,
+  };
+};
+
+export interface SimPoolDerived {
+  pctAssigned: number;
+  lowStock: boolean;
+}
+
+export const deriveSimPool = (
+  stats: Pick<SimPoolStatsDto, "total" | "available" | "consumed">,
+  lowStockThreshold: number = SIM_POOL_LOW_STOCK_THRESHOLD
+): SimPoolDerived => ({
+  pctAssigned:
+    stats.total > 0 ? Math.round((stats.consumed / stats.total) * 100) : 0,
+  lowStock: stats.available < lowStockThreshold,
+});
+
+/** O(n+m) group-join of sims onto their owner, keyed by `subscriberId`. */
+export const groupBy = <T>(
+  items: readonly T[],
+  key: (item: T) => string | undefined
+): Map<string, T[]> => {
+  const groups = new Map<string, T[]>();
+  for (const item of items) {
+    const k = key(item);
+    if (!k) continue;
+    const group = groups.get(k);
+    if (group) group.push(item);
+    else groups.set(k, [item]);
+  }
+  return groups;
+};

--- a/systems/console-bff/dashboard/index.ts
+++ b/systems/console-bff/dashboard/index.ts
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * Dashboard module: view-domain composite queries for ukama-console
+ * (docs/bff-screen-api-plan.md §3). Phase 1 ships the shared error layer;
+ * composite resolvers land in phase 2+.
+ */
+export {
+  SECTION_TIMEOUT_MS,
+  SectionErrorCollector,
+  sectionNotImplemented,
+  withSection,
+} from "./section";
+export { SectionError, SectionErrorCode, UserError } from "./types";

--- a/systems/console-bff/dashboard/kpis.ts
+++ b/systems/console-bff/dashboard/kpis.ts
@@ -1,0 +1,60 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * KPI fan-out for composite sections (plan Phase 4): latest value per metric
+ * key from the metric service, bounded concurrency, polled by the console —
+ * no subscriptions/WS in v1 (BUILD-PLAN §5.1·4).
+ */
+import { mapWithConcurrency } from "../common/utils/concurrency";
+import type MetricAPI from "../metric/datasource/metric_api";
+
+/** Metric keys per KPI section (see common/utils TYPE_KEYS_GROUPS). */
+export const NETWORK_KPI_KEYS = [
+  "network_uptime",
+  "data_usage",
+  "package_sales",
+  "node_active_subscribers",
+] as const;
+
+export const SITE_KPI_KEYS = [
+  "backhaul_latency",
+  "backhaul_downlink",
+  "controller_temperature",
+  "load_current",
+] as const;
+
+export const SITE_POWER_KEYS = [
+  "battery_charge",
+  "solar_panel_voltage",
+  "solar_panel_current",
+  "solar_panel_power",
+] as const;
+
+export interface KpiEntry {
+  key: string;
+  value: number;
+  timestamp: number;
+  success: boolean;
+}
+
+export const fetchLatestKpis = async (
+  metricApi: MetricAPI,
+  baseURL: string,
+  keys: readonly string[]
+): Promise<KpiEntry[]> => {
+  const results = await mapWithConcurrency(keys, key =>
+    metricApi.getLatestMetric(baseURL, key)
+  );
+  return results.map(result => ({
+    key: result.type,
+    timestamp: result.value[0],
+    value: result.value[1],
+    success: result.success,
+  }));
+};

--- a/systems/console-bff/dashboard/resolvers/commerceView.ts
+++ b/systems/console-bff/dashboard/resolvers/commerceView.ts
@@ -1,0 +1,173 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import {
+  Arg,
+  Ctx,
+  FieldResolver,
+  Int,
+  Query,
+  Resolver,
+  Root,
+} from "type-graphql";
+
+import { PaymentsDto } from "../../payment/resolver/types";
+import type { AppContext } from "../../server/context";
+import { ServiceUrlResolver } from "../baseUrls";
+import { derivePlanStats, summarizeRevenue } from "../derive";
+import { runSection } from "../section";
+import {
+  BalanceSection,
+  CommerceView,
+  InvoicesSection,
+  PlanStatsSection,
+  RevenueSection,
+} from "./types";
+
+const MAX_INVOICES = 100;
+
+type CommerceRoot = CommerceView & {
+  _urls: ServiceUrlResolver;
+  /** payments memo — `revenue` and `plans` share one upstream list. */
+  _payments?: Promise<PaymentsDto>;
+};
+
+/**
+ * Business-lens commerce composite (plan §3.1). Serves: Business home
+ * (revenue summary), Revenue screen, Packages screen (plans), Billing screen
+ * (invoices + balance) — each through its own selection.
+ */
+@Resolver(() => CommerceView)
+export class CommerceViewResolver {
+  @Query(() => CommerceView)
+  commerceView(
+    @Ctx() ctx: AppContext,
+    @Arg("networkId", { nullable: true }) networkId?: string
+  ): CommerceView {
+    return Object.assign(new CommerceView(), {
+      networkId,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+  }
+
+  private fetchPayments(
+    root: CommerceRoot,
+    ctx: AppContext
+  ): Promise<PaymentsDto> {
+    if (!root._payments) {
+      root._payments = root._urls
+        .url("payments")
+        .then(url => ctx.dataSources.payment.getPayments(url, {}));
+    }
+    return root._payments;
+  }
+
+  @FieldResolver(() => RevenueSection)
+  async revenue(
+    @Root() root: CommerceRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<RevenueSection> {
+    const { value, error } = await runSection("revenue", async () => {
+      const payments = await this.fetchPayments(root, ctx);
+      return summarizeRevenue(payments.payments);
+    });
+    return { ...value, error };
+  }
+
+  @FieldResolver(() => PlanStatsSection)
+  async plans(
+    @Root() root: CommerceRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<PlanStatsSection> {
+    const { value, error } = await runSection("plans", async () => {
+      const [packagesUrl, payments] = await Promise.all([
+        root._urls.url("package"),
+        this.fetchPayments(root, ctx),
+      ]);
+      const packagesPromise = ctx.dataSources.package.getPackages(packagesUrl);
+      // Attach counts need a network scope; without one they stay null.
+      const simsPromise = root.networkId
+        ? root._urls
+            .url("subscriber")
+            .then(url =>
+              ctx.dataSources.subscriber.getSimsByNetwork(
+                url,
+                root.networkId as string
+              )
+            )
+        : Promise.resolve(null);
+      const [packages, sims] = await Promise.all([
+        packagesPromise,
+        simsPromise,
+      ]);
+      const simPackages = sims
+        ? sims.sims.map(sim => ({
+            packageId: sim.package?.package_id,
+            isActive: sim.package?.is_active,
+          }))
+        : null;
+      const plans = derivePlanStats(
+        packages.packages,
+        payments.payments,
+        simPackages
+      );
+      const revenue = summarizeRevenue(payments.payments);
+      const attachTotal = simPackages
+        ? plans.reduce((acc, plan) => acc + (plan.attachCount ?? 0), 0)
+        : null;
+      return {
+        plans,
+        mrr: revenue.monthPaid,
+        arpu:
+          attachTotal && attachTotal > 0
+            ? Math.round((revenue.monthPaid / attachTotal) * 100) / 100
+            : null,
+      };
+    });
+    return { ...value, error };
+  }
+
+  @FieldResolver(() => InvoicesSection)
+  async invoices(
+    @Root() root: CommerceRoot,
+    @Ctx() ctx: AppContext,
+    @Arg("limit", () => Int, { defaultValue: 20 }) limit: number
+  ): Promise<InvoicesSection> {
+    const capped = Math.min(Math.max(limit, 1), MAX_INVOICES);
+    const { value, error } = await runSection("invoices", async () => {
+      const url = await root._urls.url("billing");
+      const res = await ctx.dataSources.billing.getReports(url, {
+        networkId: root.networkId,
+      });
+      return res.reports.slice(0, capped);
+    });
+    return { reports: value, error };
+  }
+
+  @FieldResolver(() => BalanceSection)
+  async balance(
+    @Root() root: CommerceRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<BalanceSection> {
+    const { value, error } = await runSection("balance", async () => {
+      const url = await root._urls.url("billing");
+      const res = await ctx.dataSources.billing.getReports(url, {
+        networkId: root.networkId,
+        isPaid: false,
+      });
+      const unpaid = res.reports.filter(report => !report.isPaid);
+      // TODO(backend-gap): billing — outstanding *amount* needs an invoice
+      // amount/balance field on the reports list (today only count/period are
+      // derivable) — unblocks: commerceView.balance.outstandingAmount
+      return {
+        outstandingCount: unpaid.length,
+        latestUnpaidPeriod: unpaid[0]?.period ?? null,
+      };
+    });
+    return { ...value, error };
+  }
+}

--- a/systems/console-bff/dashboard/resolvers/index.ts
+++ b/systems/console-bff/dashboard/resolvers/index.ts
@@ -5,14 +5,23 @@
  *
  * Copyright (c) 2026-present, Ukama Inc.
  */
+import { CommerceViewResolver } from "./commerceView";
+import { InventoryViewResolver } from "./inventoryView";
+import { MembersViewResolver } from "./membersView";
 import { NetworkOverviewResolver } from "./networkOverview";
 import { NodeViewResolver, NodesViewResolver } from "./nodeViews";
 import { SimPoolViewResolver } from "./simPoolView";
 import { SiteViewResolver, SitesViewResolver } from "./siteViews";
+import { SubscriberViewResolver } from "./subscriberView";
 import { SubscribersViewResolver } from "./subscribersView";
 
-/** View-domain composite resolvers (plan §3) — network lens, Phase 2. */
+/** View-domain composite resolvers (plan §3) — Phase 2 (network lens) +
+ *  Phase 3 (business/customer lens). */
 const dashboardResolvers = [
+  CommerceViewResolver,
+  MembersViewResolver,
+  InventoryViewResolver,
+  SubscriberViewResolver,
   NetworkOverviewResolver,
   NodesViewResolver,
   NodeViewResolver,

--- a/systems/console-bff/dashboard/resolvers/index.ts
+++ b/systems/console-bff/dashboard/resolvers/index.ts
@@ -8,6 +8,7 @@
 import { CommerceViewResolver } from "./commerceView";
 import { InventoryViewResolver } from "./inventoryView";
 import { MembersViewResolver } from "./membersView";
+import { MetricsRangeResolver } from "./metricsRange";
 import { NetworkOverviewResolver } from "./networkOverview";
 import { NodeViewResolver, NodesViewResolver } from "./nodeViews";
 import { SimPoolViewResolver } from "./simPoolView";
@@ -18,6 +19,7 @@ import { SubscribersViewResolver } from "./subscribersView";
 /** View-domain composite resolvers (plan §3) — Phase 2 (network lens) +
  *  Phase 3 (business/customer lens). */
 const dashboardResolvers = [
+  MetricsRangeResolver,
   CommerceViewResolver,
   MembersViewResolver,
   InventoryViewResolver,

--- a/systems/console-bff/dashboard/resolvers/index.ts
+++ b/systems/console-bff/dashboard/resolvers/index.ts
@@ -1,0 +1,25 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import { NetworkOverviewResolver } from "./networkOverview";
+import { NodeViewResolver, NodesViewResolver } from "./nodeViews";
+import { SimPoolViewResolver } from "./simPoolView";
+import { SiteViewResolver, SitesViewResolver } from "./siteViews";
+import { SubscribersViewResolver } from "./subscribersView";
+
+/** View-domain composite resolvers (plan §3) — network lens, Phase 2. */
+const dashboardResolvers = [
+  NetworkOverviewResolver,
+  NodesViewResolver,
+  NodeViewResolver,
+  SitesViewResolver,
+  SiteViewResolver,
+  SubscribersViewResolver,
+  SimPoolViewResolver,
+];
+
+export default dashboardResolvers;

--- a/systems/console-bff/dashboard/resolvers/inventoryView.ts
+++ b/systems/console-bff/dashboard/resolvers/inventoryView.ts
@@ -1,0 +1,84 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import { Ctx, FieldResolver, Query, Resolver, Root } from "type-graphql";
+
+import { SIM_TYPES } from "../../common/enums";
+import type { AppContext } from "../../server/context";
+import { ServiceUrlResolver } from "../baseUrls";
+import { countByCategory, deriveSimPool } from "../derive";
+import { runSection } from "../section";
+import {
+  ComponentStatsSection,
+  InventoryView,
+  NodesSection,
+  SimPoolStatsSection,
+} from "./types";
+
+type InventoryRoot = InventoryView & { _urls: ServiceUrlResolver };
+
+/**
+ * Business inventory composite (plan §3.2): component counts by category,
+ * nodes not yet assigned to a site, and SIM stock.
+ */
+@Resolver(() => InventoryView)
+export class InventoryViewResolver {
+  @Query(() => InventoryView)
+  inventoryView(@Ctx() ctx: AppContext): InventoryView {
+    return Object.assign(new InventoryView(), {
+      orgName: ctx.headers.orgName,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+  }
+
+  @FieldResolver(() => ComponentStatsSection)
+  async components(
+    @Root() root: InventoryRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<ComponentStatsSection> {
+    const { value, error } = await runSection("components", async () => {
+      const res = await ctx.dataSources.component.getComponentsByUserId(
+        ctx.headers,
+        "ALL"
+      );
+      return {
+        total: res.components.length,
+        byCategory: countByCategory(res.components),
+      };
+    });
+    return { ...value, error };
+  }
+
+  @FieldResolver(() => NodesSection)
+  async unassignedNodes(
+    @Root() root: InventoryRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<NodesSection> {
+    const { value, error } = await runSection("unassignedNodes", async () => {
+      const url = await root._urls.url("node");
+      const res = await ctx.dataSources.node.getNodes(url, {});
+      return res.nodes.filter(node => !node.site?.siteId);
+    });
+    return { nodes: value, error };
+  }
+
+  @FieldResolver(() => SimPoolStatsSection)
+  async simStock(
+    @Root() root: InventoryRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SimPoolStatsSection> {
+    const { value, error } = await runSection("simStock", async () => {
+      const url = await root._urls.url("sim");
+      const stats = await ctx.dataSources.sim.getSimPoolStats(
+        url,
+        SIM_TYPES.ukama_data
+      );
+      return { ...stats, ...deriveSimPool(stats) };
+    });
+    return { ...value, error };
+  }
+}

--- a/systems/console-bff/dashboard/resolvers/membersView.ts
+++ b/systems/console-bff/dashboard/resolvers/membersView.ts
@@ -1,0 +1,68 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import { Ctx, FieldResolver, Query, Resolver, Root } from "type-graphql";
+
+import type { AppContext } from "../../server/context";
+import { ServiceUrlResolver } from "../baseUrls";
+import { runSection } from "../section";
+import { MembersView, TeamMemberDto, TeamSection } from "./types";
+
+type MembersRoot = MembersView & { _urls: ServiceUrlResolver };
+
+/**
+ * Members & admin composite (plan §3.2): org members and pending
+ * invitations merged into one team list (status: Active | Deactivated |
+ * Invited) so the screen renders a single table.
+ */
+@Resolver(() => MembersView)
+export class MembersViewResolver {
+  @Query(() => MembersView)
+  membersView(@Ctx() ctx: AppContext): MembersView {
+    return Object.assign(new MembersView(), {
+      orgName: ctx.headers.orgName,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+  }
+
+  @FieldResolver(() => TeamSection)
+  async team(
+    @Root() root: MembersRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<TeamSection> {
+    const { value, error } = await runSection("team", async () => {
+      const [memberUrl, invitationUrl] = await Promise.all([
+        root._urls.url("member"),
+        root._urls.url("invitation"),
+      ]);
+      const [members, invitations] = await Promise.all([
+        ctx.dataSources.member.getMembers(memberUrl),
+        ctx.dataSources.invitation.getInvitations(invitationUrl),
+      ]);
+      const rows: TeamMemberDto[] = members.members.map(member => ({
+        id: member.memberId,
+        name: member.name,
+        email: member.email,
+        role: member.role,
+        status: member.isDeactivated ? "Deactivated" : "Active",
+        memberSince: member.memberSince,
+      }));
+      for (const invitation of invitations.invitations) {
+        rows.push({
+          id: invitation.id,
+          name: invitation.name,
+          email: invitation.email,
+          role: invitation.role,
+          status: "Invited",
+          inviteExpiresAt: invitation.expireAt,
+        });
+      }
+      return rows;
+    });
+    return { rows: value, error };
+  }
+}

--- a/systems/console-bff/dashboard/resolvers/metricsRange.ts
+++ b/systems/console-bff/dashboard/resolvers/metricsRange.ts
@@ -1,0 +1,81 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * Polled range metrics in the consolidated schema (plan Phase 4). This is
+ * the query-only port of the subscriptions service's range fetch: same
+ * upstream endpoint (`/v1/range/metrics/{key}`), same response mapping, but
+ * NO WebSocket workers and NO GraphQL subscriptions — the console polls
+ * (BUILD-PLAN §5.1·4). The standalone subscriptions service stays parked.
+ */
+import { Arg, Ctx, Field, InputType, Int, Query, Resolver } from "type-graphql";
+
+import { STATS_TYPE } from "../../common/enums";
+import { mapWithConcurrency } from "../../common/utils/concurrency";
+import type { AppContext } from "../../server/context";
+import { getNodeMetricRange } from "../../subscriptions/datasource/subscriptions-api";
+import type {
+  GetMetricsStatInput,
+  MetricsRes,
+} from "../../subscriptions/resolvers/types";
+import { MetricsRes as MetricsResType } from "../../subscriptions/resolvers/types";
+import { ServiceUrlResolver } from "../baseUrls";
+
+const MAX_KEYS = 10;
+
+@InputType()
+export class MetricsRangeInput {
+  /** Metric keys, e.g. ["uptime", "cpu_temperature"]. Max 10 per request. */
+  @Field(() => [String])
+  keys: string[];
+
+  /** Epoch seconds (must be > 0). */
+  @Field(() => Int)
+  from: number;
+
+  @Field(() => Int, { nullable: true })
+  to?: number;
+
+  @Field({ nullable: true })
+  nodeId?: string;
+
+  /** Prometheus aggregation, default "avg". */
+  @Field({ nullable: true })
+  operation?: string;
+}
+
+@Resolver()
+export class MetricsRangeResolver {
+  @Query(() => MetricsResType)
+  async metricsRange(
+    @Arg("data") data: MetricsRangeInput,
+    @Ctx() ctx: AppContext
+  ): Promise<MetricsRes> {
+    if (data.from <= 0) {
+      throw new Error("Argument 'from' must be a positive epoch timestamp.");
+    }
+    const keys = data.keys.slice(0, MAX_KEYS);
+    const urls = new ServiceUrlResolver(ctx.headers.orgName);
+    const baseURL = await urls.url("metrics");
+    const args = {
+      from: data.from,
+      to: data.to ?? Math.floor(Date.now() / 1000),
+      nodeId: data.nodeId,
+      operation: data.operation ?? "avg",
+      orgName: ctx.headers.orgName,
+      userId: ctx.headers.userId,
+      type: STATS_TYPE.HOME,
+      withSubscription: false,
+    } as GetMetricsStatInput;
+
+    const results = await mapWithConcurrency(keys, key =>
+      getNodeMetricRange(baseURL, key, args)
+    );
+    return { metrics: results.flatMap(res => res.metrics) };
+  }
+}

--- a/systems/console-bff/dashboard/resolvers/networkOverview.ts
+++ b/systems/console-bff/dashboard/resolvers/networkOverview.ts
@@ -1,0 +1,142 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import {
+  Arg,
+  Ctx,
+  FieldResolver,
+  Int,
+  Query,
+  Resolver,
+  Root,
+} from "type-graphql";
+
+import type { AppContext } from "../../server/context";
+import { ServiceUrlResolver } from "../baseUrls";
+import { countNodes, subscriberActivity } from "../derive";
+import { notImplementedSection, runSection } from "../section";
+import {
+  AlertsSection,
+  GapSection,
+  NetworkOverview,
+  NetworkSection,
+  NodeStatsSection,
+  SitesSection,
+  SubscriberStatsSection,
+} from "./types";
+
+const MAX_ALERTS = 20;
+
+type OverviewRoot = NetworkOverview & { _urls: ServiceUrlResolver };
+
+/**
+ * Network-lens home composite (plan §3.1). Core = networkId only; every
+ * section is lazy and pays only when selected. Serves: Network home,
+ * Business home (network section), Biz network screen.
+ */
+@Resolver(() => NetworkOverview)
+export class NetworkOverviewResolver {
+  @Query(() => NetworkOverview)
+  networkOverview(
+    @Arg("networkId") networkId: string,
+    @Ctx() ctx: AppContext
+  ): NetworkOverview {
+    const root: OverviewRoot = Object.assign(new NetworkOverview(), {
+      networkId,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+    return root;
+  }
+
+  @FieldResolver(() => NetworkSection)
+  async network(
+    @Root() root: OverviewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<NetworkSection> {
+    const { value, error } = await runSection("network", async () => {
+      const url = await root._urls.url("network");
+      return ctx.dataSources.network.getNetwork(url, root.networkId);
+    });
+    return { network: value, error };
+  }
+
+  @FieldResolver(() => NodeStatsSection)
+  async nodeStats(
+    @Root() root: OverviewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<NodeStatsSection> {
+    const { value, error } = await runSection("nodeStats", async () => {
+      const url = await root._urls.url("node");
+      const res = await ctx.dataSources.node.getNodesByNetwork(
+        url,
+        root.networkId
+      );
+      return countNodes(res.nodes);
+    });
+    return { ...value, error };
+  }
+
+  @FieldResolver(() => SitesSection)
+  async siteStats(
+    @Root() root: OverviewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SitesSection> {
+    const { value, error } = await runSection("siteStats", async () => {
+      const url = await root._urls.url("site");
+      const res = await ctx.dataSources.site.getSites(url, {
+        networkId: root.networkId,
+      });
+      return res.sites;
+    });
+    return { sites: value, error };
+  }
+
+  @FieldResolver(() => SubscriberStatsSection)
+  async subscriberStats(
+    @Root() root: OverviewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SubscriberStatsSection> {
+    const { value, error } = await runSection("subscriberStats", async () => {
+      const url = await root._urls.url("subscriber");
+      const [sims, subs] = await Promise.all([
+        ctx.dataSources.subscriber.getSimsByNetwork(url, root.networkId),
+        ctx.dataSources.subscriber.getSubscribersByNetwork(url, root.networkId),
+      ]);
+      const withSims = subs.subscribers.map(sub => ({
+        sim: sims.sims.filter(sim => sim.subscriberId === sub.uuid),
+      }));
+      return subscriberActivity(withSims);
+    });
+    return { ...value, error };
+  }
+
+  @FieldResolver(() => AlertsSection)
+  async latestAlerts(
+    @Root() root: OverviewRoot,
+    @Ctx() ctx: AppContext,
+    @Arg("limit", () => Int, { defaultValue: 5 }) limit: number
+  ): Promise<AlertsSection> {
+    const capped = Math.min(Math.max(limit, 1), MAX_ALERTS);
+    const { value, error } = await runSection("latestAlerts", async () => {
+      const url = await root._urls.url("notification");
+      const res = await ctx.dataSources.notification.getNotifications(
+        url,
+        ctx.headers.orgId,
+        ctx.headers.userId
+      );
+      return res.notifications.slice(0, capped);
+    });
+    return { notifications: value, error };
+  }
+
+  @FieldResolver(() => GapSection)
+  kpis(): GapSection {
+    // TODO(backend-gap): metric — network-level KPI summary endpoint —
+    // unblocks: networkOverview.kpis (metrics phase, plan Phase 4)
+    return { error: notImplementedSection("kpis").error };
+  }
+}

--- a/systems/console-bff/dashboard/resolvers/networkOverview.ts
+++ b/systems/console-bff/dashboard/resolvers/networkOverview.ts
@@ -18,10 +18,11 @@ import {
 import type { AppContext } from "../../server/context";
 import { ServiceUrlResolver } from "../baseUrls";
 import { countNodes, subscriberActivity } from "../derive";
-import { notImplementedSection, runSection } from "../section";
+import { NETWORK_KPI_KEYS, fetchLatestKpis } from "../kpis";
+import { runSection } from "../section";
 import {
   AlertsSection,
-  GapSection,
+  KpisSection,
   NetworkOverview,
   NetworkSection,
   NodeStatsSection,
@@ -133,10 +134,19 @@ export class NetworkOverviewResolver {
     return { notifications: value, error };
   }
 
-  @FieldResolver(() => GapSection)
-  kpis(): GapSection {
-    // TODO(backend-gap): metric — network-level KPI summary endpoint —
-    // unblocks: networkOverview.kpis (metrics phase, plan Phase 4)
-    return { error: notImplementedSection("kpis").error };
+  @FieldResolver(() => KpisSection)
+  async kpis(
+    @Root() root: OverviewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<KpisSection> {
+    // Phase 4: latest network KPIs polled from the metric service (closes
+    // backend gap #5). Console polls this selection — no subscriptions in v1.
+    const { value, error } = await runSection("kpis", async () => {
+      // NB: the metric system's service-discovery name is "metrics"
+      // (getSystemNameByService), not SUB_GRAPHS' "metric".
+      const url = await root._urls.url("metrics");
+      return fetchLatestKpis(ctx.dataSources.metric, url, NETWORK_KPI_KEYS);
+    });
+    return { metrics: value, error };
   }
 }

--- a/systems/console-bff/dashboard/resolvers/nodeViews.ts
+++ b/systems/console-bff/dashboard/resolvers/nodeViews.ts
@@ -1,0 +1,151 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import { Arg, Ctx, FieldResolver, Query, Resolver, Root } from "type-graphql";
+
+import { TIMEFRAME_FILTER } from "../../common/enums";
+import { GetHealthReportInputDto } from "../../health/resolvers/types";
+import type { AppContext } from "../../server/context";
+import { GetSoftwaresInput } from "../../software/resolvers/types";
+import { ServiceUrlResolver } from "../baseUrls";
+import { notImplementedSection, runSection } from "../section";
+import {
+  GapSection,
+  HealthSection,
+  NodeSection,
+  NodeStateSection,
+  NodeView,
+  NodesSection,
+  NodesView,
+  SoftwareSection,
+} from "./types";
+
+type NodesViewRoot = NodesView & { _urls: ServiceUrlResolver };
+type NodeViewRoot = NodeView & { _urls: ServiceUrlResolver };
+
+/**
+ * Nodes list composite (plan §3.1). Serves: Nodes list, Node pool (skips
+ * `health`), map views.
+ */
+@Resolver(() => NodesView)
+export class NodesViewResolver {
+  @Query(() => NodesView)
+  nodesView(
+    @Ctx() ctx: AppContext,
+    @Arg("networkId", { nullable: true }) networkId?: string
+  ): NodesView {
+    return Object.assign(new NodesView(), {
+      networkId,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+  }
+
+  @FieldResolver(() => NodesSection)
+  async nodes(
+    @Root() root: NodesViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<NodesSection> {
+    const { value, error } = await runSection("nodes", async () => {
+      const url = await root._urls.url("node");
+      const res = root.networkId
+        ? await ctx.dataSources.node.getNodesByNetwork(url, root.networkId)
+        : await ctx.dataSources.node.getNodes(url, {});
+      return res.nodes;
+    });
+    return { nodes: value, error };
+  }
+
+  @FieldResolver(() => GapSection)
+  health(): GapSection {
+    // TODO(backend-gap): health — bulk health endpoint (today: one call per
+    // node) — unblocks: nodesView.health (docs/backend-gaps.md #4)
+    return { error: notImplementedSection("health").error };
+  }
+}
+
+/**
+ * Node detail composite (plan §3.1). Serves: Node detail (all sections),
+ * node drawer/peek (core + `health` only).
+ */
+@Resolver(() => NodeView)
+export class NodeViewResolver {
+  @Query(() => NodeView)
+  nodeView(@Arg("nodeId") nodeId: string, @Ctx() ctx: AppContext): NodeView {
+    return Object.assign(new NodeView(), {
+      nodeId,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+  }
+
+  @FieldResolver(() => NodeSection)
+  async node(
+    @Root() root: NodeViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<NodeSection> {
+    const { value, error } = await runSection("node", async () => {
+      const url = await root._urls.url("node");
+      return ctx.dataSources.node.getNode(url, { id: root.nodeId });
+    });
+    return { node: value, error };
+  }
+
+  @FieldResolver(() => HealthSection)
+  async health(
+    @Root() root: NodeViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<HealthSection> {
+    const { value, error } = await runSection("health", async () => {
+      const url = await root._urls.url("health");
+      return ctx.dataSources.health.list(url, {
+        nodeId: root.nodeId,
+        timeframe: TIMEFRAME_FILTER.LATEST,
+      } as GetHealthReportInputDto);
+    });
+    return { health: value, error };
+  }
+
+  @FieldResolver(() => SoftwareSection)
+  async software(
+    @Root() root: NodeViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SoftwareSection> {
+    const { value, error } = await runSection("software", async () => {
+      const url = await root._urls.url("software");
+      return ctx.dataSources.software.getSoftwares(url, {
+        nodeId: root.nodeId,
+      } as GetSoftwaresInput);
+    });
+    return { softwares: value, error };
+  }
+
+  @FieldResolver(() => NodeStateSection)
+  async stateHistory(
+    @Root() root: NodeViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<NodeStateSection> {
+    const { value, error } = await runSection("stateHistory", async () => {
+      const url = await root._urls.url("state");
+      return ctx.dataSources.node.getNodeState(url, root.nodeId);
+    });
+    return { stateHistory: value, error };
+  }
+
+  @FieldResolver(() => GapSection)
+  kpis(): GapSection {
+    // TODO(backend-gap): metric — per-node latest KPI snapshot for detail
+    // header — unblocks: nodeView.kpis (metrics phase, plan Phase 4)
+    return { error: notImplementedSection("kpis").error };
+  }
+
+  @FieldResolver(() => GapSection)
+  radioStatus(): GapSection {
+    // TODO(backend-gap): controller — read endpoint for RF/service/internet
+    // switch state (controller exposes only mutations today) — unblocks:
+    // nodeView.radioStatus
+    return { error: notImplementedSection("radioStatus").error };
+  }
+}

--- a/systems/console-bff/dashboard/resolvers/nodeViews.ts
+++ b/systems/console-bff/dashboard/resolvers/nodeViews.ts
@@ -7,15 +7,18 @@
  */
 import { Arg, Ctx, FieldResolver, Query, Resolver, Root } from "type-graphql";
 
-import { TIMEFRAME_FILTER } from "../../common/enums";
+import { GRAPHS_TYPE, TIMEFRAME_FILTER } from "../../common/enums";
+import { getGraphsKeyByType, getNodeTypeFromId } from "../../common/utils";
 import { GetHealthReportInputDto } from "../../health/resolvers/types";
 import type { AppContext } from "../../server/context";
 import { GetSoftwaresInput } from "../../software/resolvers/types";
 import { ServiceUrlResolver } from "../baseUrls";
+import { fetchLatestKpis } from "../kpis";
 import { notImplementedSection, runSection } from "../section";
 import {
   GapSection,
   HealthSection,
+  KpisSection,
   NodeSection,
   NodeStateSection,
   NodeView,
@@ -134,11 +137,24 @@ export class NodeViewResolver {
     return { stateHistory: value, error };
   }
 
-  @FieldResolver(() => GapSection)
-  kpis(): GapSection {
-    // TODO(backend-gap): metric — per-node latest KPI snapshot for detail
-    // header — unblocks: nodeView.kpis (metrics phase, plan Phase 4)
-    return { error: notImplementedSection("kpis").error };
+  @FieldResolver(() => KpisSection)
+  async kpis(
+    @Root() root: NodeViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<KpisSection> {
+    // Phase 4: node-health KPIs (uptime/temps/memory by node type) polled
+    // from the metric service (closes backend gap #6). The latest-metric
+    // endpoint is org-scoped — node-level filtering lands with the metric
+    // service's node filter (same behavior as the legacy getNodeLatestMetric).
+    const { value, error } = await runSection("kpis", async () => {
+      const url = await root._urls.url("metrics");
+      const keys = getGraphsKeyByType(
+        GRAPHS_TYPE.NODE_HEALTH,
+        getNodeTypeFromId(root.nodeId)
+      );
+      return fetchLatestKpis(ctx.dataSources.metric, url, keys);
+    });
+    return { metrics: value, error };
   }
 
   @FieldResolver(() => GapSection)

--- a/systems/console-bff/dashboard/resolvers/simPoolView.ts
+++ b/systems/console-bff/dashboard/resolvers/simPoolView.ts
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import {
+  Arg,
+  Ctx,
+  FieldResolver,
+  Int,
+  Query,
+  Resolver,
+  Root,
+} from "type-graphql";
+
+import { SIM_STATUS, SIM_TYPES } from "../../common/enums";
+import type { AppContext } from "../../server/context";
+import { ServiceUrlResolver } from "../baseUrls";
+import { deriveSimPool } from "../derive";
+import { runSection } from "../section";
+import { PoolSimsSection, SimPoolStatsSection, SimPoolView } from "./types";
+
+const MAX_POOL_SIMS = 100;
+
+type SimPoolViewRoot = SimPoolView & { _urls: ServiceUrlResolver };
+
+/**
+ * SIM pool composite (plan §3.2). Serves both SIM pool screens (network
+ * manage + business manage) with one query.
+ */
+@Resolver(() => SimPoolView)
+export class SimPoolViewResolver {
+  @Query(() => SimPoolView)
+  simPoolView(
+    @Arg("simType") simType: string,
+    @Ctx() ctx: AppContext
+  ): SimPoolView {
+    return Object.assign(new SimPoolView(), {
+      simType,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+  }
+
+  @FieldResolver(() => SimPoolStatsSection)
+  async stats(
+    @Root() root: SimPoolViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SimPoolStatsSection> {
+    const { value, error } = await runSection("stats", async () => {
+      const url = await root._urls.url("sim");
+      const stats = await ctx.dataSources.sim.getSimPoolStats(
+        url,
+        root.simType
+      );
+      return { ...stats, ...deriveSimPool(stats) };
+    });
+    return { ...value, error };
+  }
+
+  @FieldResolver(() => PoolSimsSection)
+  async sims(
+    @Root() root: SimPoolViewRoot,
+    @Ctx() ctx: AppContext,
+    @Arg("limit", () => Int, { defaultValue: 20 }) limit: number
+  ): Promise<PoolSimsSection> {
+    const capped = Math.min(Math.max(limit, 1), MAX_POOL_SIMS);
+    const { value, error } = await runSection("sims", async () => {
+      const url = await root._urls.url("sim");
+      const res = await ctx.dataSources.sim.getSimsFromPool(url, {
+        type: root.simType as SIM_TYPES,
+        status: SIM_STATUS.ALL,
+      });
+      return res.sims.slice(0, capped);
+    });
+    return { sims: value, error };
+  }
+}

--- a/systems/console-bff/dashboard/resolvers/siteViews.ts
+++ b/systems/console-bff/dashboard/resolvers/siteViews.ts
@@ -1,0 +1,197 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import { Arg, Ctx, FieldResolver, Query, Resolver, Root } from "type-graphql";
+
+import { ComponentDto } from "../../component/resolvers/types";
+import type { AppContext } from "../../server/context";
+import { SiteDto } from "../../site/resolvers/types";
+import { ServiceUrlResolver } from "../baseUrls";
+import { groupNodeCountsBySite } from "../derive";
+import { notImplementedSection, runSection } from "../section";
+import {
+  GapSection,
+  NodesSection,
+  SiteComponentDto,
+  SiteComponentsSection,
+  SiteNodeCountsSection,
+  SiteSection,
+  SiteView,
+  SitesSection,
+  SitesView,
+} from "./types";
+
+type SitesViewRoot = SitesView & { _urls: ServiceUrlResolver };
+type SiteViewRoot = SiteView & {
+  _urls: ServiceUrlResolver;
+  /** site core memo so `components` doesn't re-fetch the site. */
+  _site?: Promise<SiteDto>;
+};
+
+const toSiteComponent = (
+  elementType: string,
+  component?: ComponentDto
+): SiteComponentDto => ({
+  elementType,
+  componentId: component?.partNumber ?? undefined,
+  componentName: component?.partNumber ? component.description : undefined,
+});
+
+/**
+ * Sites list composite (plan §3.1). Serves: Network sites list (skips
+ * `financials`), Business sites list (adds `financials`, skips `kpis`).
+ */
+@Resolver(() => SitesView)
+export class SitesViewResolver {
+  @Query(() => SitesView)
+  sitesView(
+    @Arg("networkId") networkId: string,
+    @Ctx() ctx: AppContext
+  ): SitesView {
+    return Object.assign(new SitesView(), {
+      networkId,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+  }
+
+  @FieldResolver(() => SitesSection)
+  async sites(
+    @Root() root: SitesViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SitesSection> {
+    const { value, error } = await runSection("sites", async () => {
+      const url = await root._urls.url("site");
+      const res = await ctx.dataSources.site.getSites(url, {
+        networkId: root.networkId,
+      });
+      return res.sites;
+    });
+    return { sites: value, error };
+  }
+
+  @FieldResolver(() => SiteNodeCountsSection)
+  async nodeCounts(
+    @Root() root: SitesViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SiteNodeCountsSection> {
+    const { value, error } = await runSection("nodeCounts", async () => {
+      const url = await root._urls.url("node");
+      const res = await ctx.dataSources.node.getNodesByNetwork(
+        url,
+        root.networkId
+      );
+      return groupNodeCountsBySite(res.nodes);
+    });
+    return { counts: value, error };
+  }
+
+  @FieldResolver(() => GapSection)
+  kpis(): GapSection {
+    // TODO(backend-gap): metric — per-site latest KPI summary for list rows —
+    // unblocks: sitesView.kpis (metrics phase, plan Phase 4)
+    return { error: notImplementedSection("kpis").error };
+  }
+
+  @FieldResolver(() => GapSection)
+  financials(): GapSection {
+    // TODO(backend-gap): billing — per-site revenue/cost rollup — unblocks:
+    // sitesView.financials (plan Phase 3, business lens)
+    return { error: notImplementedSection("financials").error };
+  }
+}
+
+/**
+ * Site detail composite (plan §3.1). Serves: Network site detail (skips
+ * `financials`), Business site detail (adds `financials`).
+ */
+@Resolver(() => SiteView)
+export class SiteViewResolver {
+  @Query(() => SiteView)
+  siteView(@Arg("siteId") siteId: string, @Ctx() ctx: AppContext): SiteView {
+    return Object.assign(new SiteView(), {
+      siteId,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+  }
+
+  private fetchSite(root: SiteViewRoot, ctx: AppContext): Promise<SiteDto> {
+    if (!root._site) {
+      root._site = root._urls
+        .url("site")
+        .then(url => ctx.dataSources.site.getSite(url, root.siteId));
+    }
+    return root._site;
+  }
+
+  @FieldResolver(() => SiteSection)
+  async site(
+    @Root() root: SiteViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SiteSection> {
+    const { value, error } = await runSection("site", () =>
+      this.fetchSite(root, ctx)
+    );
+    return { site: value, error };
+  }
+
+  @FieldResolver(() => NodesSection)
+  async nodes(
+    @Root() root: SiteViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<NodesSection> {
+    const { value, error } = await runSection("nodes", async () => {
+      const url = await root._urls.url("node");
+      const res = await ctx.dataSources.node.getNodesForSite(url, root.siteId);
+      return res.nodes;
+    });
+    return { nodes: value, error };
+  }
+
+  @FieldResolver(() => SiteComponentsSection)
+  async components(
+    @Root() root: SiteViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SiteComponentsSection> {
+    const { value, error } = await runSection("components", async () => {
+      const [site, compRes] = await Promise.all([
+        this.fetchSite(root, ctx),
+        ctx.dataSources.component.getComponentsByUserId(ctx.headers, "ALL"),
+      ]);
+      const byId = new Map<string, ComponentDto>(
+        compRes.components.map(comp => [comp.id, comp])
+      );
+      return [
+        toSiteComponent("ACCESS", byId.get(site.accessId)),
+        toSiteComponent("POWER", byId.get(site.powerId)),
+        toSiteComponent("BACKHAUL", byId.get(site.backhaulId)),
+        toSiteComponent("SWITCH", byId.get(site.switchId)),
+      ];
+    });
+    return { components: value, error };
+  }
+
+  @FieldResolver(() => GapSection)
+  power(): GapSection {
+    // TODO(backend-gap): metric — battery/solar/backhaul live status for a
+    // site — unblocks: siteView.power (metrics phase, plan Phase 4)
+    return { error: notImplementedSection("power").error };
+  }
+
+  @FieldResolver(() => GapSection)
+  kpis(): GapSection {
+    // TODO(backend-gap): metric — site uptime/KPI summary — unblocks:
+    // siteView.kpis (metrics phase, plan Phase 4)
+    return { error: notImplementedSection("kpis").error };
+  }
+
+  @FieldResolver(() => GapSection)
+  financials(): GapSection {
+    // TODO(backend-gap): billing — per-site revenue/cost rollup — unblocks:
+    // siteView.financials (plan Phase 3, business lens)
+    return { error: notImplementedSection("financials").error };
+  }
+}

--- a/systems/console-bff/dashboard/resolvers/siteViews.ts
+++ b/systems/console-bff/dashboard/resolvers/siteViews.ts
@@ -12,9 +12,11 @@ import type { AppContext } from "../../server/context";
 import { SiteDto } from "../../site/resolvers/types";
 import { ServiceUrlResolver } from "../baseUrls";
 import { groupNodeCountsBySite } from "../derive";
+import { SITE_KPI_KEYS, SITE_POWER_KEYS, fetchLatestKpis } from "../kpis";
 import { notImplementedSection, runSection } from "../section";
 import {
   GapSection,
+  KpisSection,
   NodesSection,
   SiteComponentDto,
   SiteComponentsSection,
@@ -174,18 +176,34 @@ export class SiteViewResolver {
     return { components: value, error };
   }
 
-  @FieldResolver(() => GapSection)
-  power(): GapSection {
-    // TODO(backend-gap): metric — battery/solar/backhaul live status for a
-    // site — unblocks: siteView.power (metrics phase, plan Phase 4)
-    return { error: notImplementedSection("power").error };
+  @FieldResolver(() => KpisSection)
+  async power(
+    @Root() root: SiteViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<KpisSection> {
+    // Phase 4: battery/solar power KPIs polled from the metric service
+    // (closes backend gap #8). Org-scoped latest values; per-site filtering
+    // lands with the metric service's site filter.
+    const { value, error } = await runSection("power", async () => {
+      const url = await root._urls.url("metrics");
+      return fetchLatestKpis(ctx.dataSources.metric, url, SITE_POWER_KEYS);
+    });
+    return { metrics: value, error };
   }
 
-  @FieldResolver(() => GapSection)
-  kpis(): GapSection {
-    // TODO(backend-gap): metric — site uptime/KPI summary — unblocks:
-    // siteView.kpis (metrics phase, plan Phase 4)
-    return { error: notImplementedSection("kpis").error };
+  @FieldResolver(() => KpisSection)
+  async kpis(
+    @Root() root: SiteViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<KpisSection> {
+    // Phase 4: backhaul/controller KPIs polled from the metric service
+    // (closes backend gap #7 for the detail screen; per-site list rows in
+    // sitesView remain a gap until a site filter exists).
+    const { value, error } = await runSection("kpis", async () => {
+      const url = await root._urls.url("metrics");
+      return fetchLatestKpis(ctx.dataSources.metric, url, SITE_KPI_KEYS);
+    });
+    return { metrics: value, error };
   }
 
   @FieldResolver(() => GapSection)

--- a/systems/console-bff/dashboard/resolvers/subscriberView.ts
+++ b/systems/console-bff/dashboard/resolvers/subscriberView.ts
@@ -1,0 +1,137 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import { Arg, Ctx, FieldResolver, Query, Resolver, Root } from "type-graphql";
+
+import type { AppContext } from "../../server/context";
+import { SubscriberDto } from "../../subscriber/resolver/types";
+import { ServiceUrlResolver } from "../baseUrls";
+import { isPaidPayment } from "../derive";
+import { notImplementedSection, runSection } from "../section";
+import {
+  GapSection,
+  PlanNameDto,
+  SubscriberBillingSection,
+  SubscriberPlansSection,
+  SubscriberSection,
+  SubscriberView,
+} from "./types";
+
+const MAX_PAYMENTS = 20;
+
+type SubscriberRoot = SubscriberView & {
+  _urls: ServiceUrlResolver;
+  /** subscriber core memo — `plans` and `billing` reuse it. */
+  _subscriber?: Promise<SubscriberDto>;
+};
+
+/**
+ * Customer-lens subscriber composite (plan §3.1). Serves: Customer home,
+ * subscriber detail drawer (any lens).
+ */
+@Resolver(() => SubscriberView)
+export class SubscriberViewResolver {
+  @Query(() => SubscriberView)
+  subscriberView(
+    @Arg("subscriberId") subscriberId: string,
+    @Ctx() ctx: AppContext
+  ): SubscriberView {
+    return Object.assign(new SubscriberView(), {
+      subscriberId,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+  }
+
+  private fetchSubscriber(
+    root: SubscriberRoot,
+    ctx: AppContext
+  ): Promise<SubscriberDto> {
+    if (!root._subscriber) {
+      root._subscriber = root._urls
+        .url("subscriber")
+        .then(url =>
+          ctx.dataSources.subscriber.getSubscriber(url, root.subscriberId)
+        );
+    }
+    return root._subscriber;
+  }
+
+  @FieldResolver(() => SubscriberSection)
+  async subscriber(
+    @Root() root: SubscriberRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SubscriberSection> {
+    const { value, error } = await runSection("subscriber", () =>
+      this.fetchSubscriber(root, ctx)
+    );
+    return { subscriber: value, error };
+  }
+
+  @FieldResolver(() => SubscriberPlansSection)
+  async plans(
+    @Root() root: SubscriberRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SubscriberPlansSection> {
+    const { value, error } = await runSection("plans", async () => {
+      const [subscriber, packagesUrl] = await Promise.all([
+        this.fetchSubscriber(root, ctx),
+        root._urls.url("package"),
+      ]);
+      const packages = await ctx.dataSources.package.getPackages(packagesUrl);
+      const namesById = new Map(
+        packages.packages.map(pkg => [pkg.uuid, pkg.name])
+      );
+      const activeIds = new Set(
+        (subscriber.sim ?? [])
+          .map(sim => sim.package)
+          .filter(pkg => pkg?.is_active)
+          .map(pkg => pkg?.package_id as string)
+      );
+      return Array.from(
+        activeIds,
+        (packageId): PlanNameDto => ({
+          packageId,
+          name: namesById.get(packageId) ?? packageId,
+        })
+      );
+    });
+    return { plans: value, error };
+  }
+
+  @FieldResolver(() => SubscriberBillingSection)
+  async billing(
+    @Root() root: SubscriberRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SubscriberBillingSection> {
+    const { value, error } = await runSection("billing", async () => {
+      const [subscriber, paymentsUrl] = await Promise.all([
+        this.fetchSubscriber(root, ctx),
+        root._urls.url("payments"),
+      ]);
+      const res = await ctx.dataSources.payment.getPayments(paymentsUrl, {});
+      // TODO(backend-gap): payments — payer/subscriber filter on
+      // /v1/payments (today: filter by payerEmail in the BFF) — unblocks:
+      // subscriberView.billing at scale
+      return res.payments
+        .filter(
+          payment =>
+            payment.payerEmail &&
+            payment.payerEmail.toLowerCase() === subscriber.email.toLowerCase()
+        )
+        .sort((a, b) => Number(isPaidPayment(b)) - Number(isPaidPayment(a)))
+        .slice(0, MAX_PAYMENTS);
+    });
+    return { payments: value, error };
+  }
+
+  @FieldResolver(() => GapSection)
+  usage(): GapSection {
+    // TODO(backend-gap): subscriber — batch usage endpoint + per-subscriber
+    // aggregation — unblocks: subscriberView.usage (docs/backend-gaps.md #2)
+    return { error: notImplementedSection("usage").error };
+  }
+}

--- a/systems/console-bff/dashboard/resolvers/subscribersView.ts
+++ b/systems/console-bff/dashboard/resolvers/subscribersView.ts
@@ -1,0 +1,83 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import { Arg, Ctx, FieldResolver, Query, Resolver, Root } from "type-graphql";
+
+import type { AppContext } from "../../server/context";
+import { ServiceUrlResolver } from "../baseUrls";
+import { groupBy } from "../derive";
+import { notImplementedSection, runSection } from "../section";
+import {
+  GapSection,
+  PlanNameDto,
+  PlansSection,
+  SubscribersSection,
+  SubscribersView,
+} from "./types";
+
+type SubscribersViewRoot = SubscribersView & { _urls: ServiceUrlResolver };
+
+/**
+ * Subscriber list composite (plan §3.1). Serves: Network customers,
+ * Business customers, Customer-lens list — each selects different columns.
+ */
+@Resolver(() => SubscribersView)
+export class SubscribersViewResolver {
+  @Query(() => SubscribersView)
+  subscribersView(
+    @Arg("networkId") networkId: string,
+    @Ctx() ctx: AppContext
+  ): SubscribersView {
+    return Object.assign(new SubscribersView(), {
+      networkId,
+      _urls: new ServiceUrlResolver(ctx.headers.orgName),
+    });
+  }
+
+  @FieldResolver(() => SubscribersSection)
+  async subscribers(
+    @Root() root: SubscribersViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<SubscribersSection> {
+    const { value, error } = await runSection("subscribers", async () => {
+      const url = await root._urls.url("subscriber");
+      const [sims, subs] = await Promise.all([
+        ctx.dataSources.subscriber.getSimsByNetwork(url, root.networkId),
+        ctx.dataSources.subscriber.getSubscribersByNetwork(url, root.networkId),
+      ]);
+      const simsBySubscriber = groupBy(sims.sims, sim => sim.subscriberId);
+      for (const sub of subs.subscribers) {
+        sub.sim = simsBySubscriber.get(sub.uuid) ?? [];
+      }
+      return subs.subscribers;
+    });
+    return { subscribers: value, error };
+  }
+
+  @FieldResolver(() => PlansSection)
+  async plans(
+    @Root() root: SubscribersViewRoot,
+    @Ctx() ctx: AppContext
+  ): Promise<PlansSection> {
+    const { value, error } = await runSection("plans", async () => {
+      const url = await root._urls.url("package");
+      const res = await ctx.dataSources.package.getPackages(url);
+      return res.packages.map(
+        (pkg): PlanNameDto => ({ packageId: pkg.uuid, name: pkg.name })
+      );
+    });
+    return { plans: value, error };
+  }
+
+  @FieldResolver(() => GapSection)
+  usage(): GapSection {
+    // TODO(backend-gap): subscriber — batch usage endpoint
+    // `/v1/usages?sim_ids=` + per-subscriber aggregation (today: one call per
+    // sim) — unblocks: subscribersView.usage (docs/backend-gaps.md #2)
+    return { error: notImplementedSection("usage").error };
+  }
+}

--- a/systems/console-bff/dashboard/resolvers/types.ts
+++ b/systems/console-bff/dashboard/resolvers/types.ts
@@ -98,6 +98,31 @@ export class GapSection {
   error?: SectionError | null;
 }
 
+/** One latest-value KPI from the metric service (polled — Phase 4). */
+@ObjectType()
+export class KpiEntryDto {
+  @Field()
+  key: string;
+
+  @Field(() => Number)
+  value: number;
+
+  @Field(() => Number)
+  timestamp: number;
+
+  @Field(() => Boolean)
+  success: boolean;
+}
+
+@ObjectType()
+export class KpisSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [KpiEntryDto], { nullable: true })
+  metrics?: KpiEntryDto[] | null;
+}
+
 /* ----------------------------- networkOverview ---------------------------- */
 
 @ObjectType()
@@ -120,7 +145,7 @@ export class NetworkOverview {
   siteStats?: SitesSection;
   subscriberStats?: SubscriberStatsSection;
   latestAlerts?: AlertsSection;
-  kpis?: GapSection;
+  kpis?: KpisSection;
 }
 
 /* -------------------------------- nodesView ------------------------------- */
@@ -181,7 +206,7 @@ export class NodeView {
   health?: HealthSection;
   software?: SoftwareSection;
   stateHistory?: NodeStateSection;
-  kpis?: GapSection;
+  kpis?: KpisSection;
   radioStatus?: GapSection;
 }
 
@@ -262,8 +287,8 @@ export class SiteView {
   site?: SiteSection;
   nodes?: NodesSection;
   components?: SiteComponentsSection;
-  power?: GapSection;
-  kpis?: GapSection;
+  power?: KpisSection;
+  kpis?: KpisSection;
   financials?: GapSection;
 }
 

--- a/systems/console-bff/dashboard/resolvers/types.ts
+++ b/systems/console-bff/dashboard/resolvers/types.ts
@@ -20,10 +20,12 @@
  */
 import { Field, Int, ObjectType } from "type-graphql";
 
+import { ReportDto } from "../../billing/resolvers/types";
 import { HealthInfo } from "../../health/resolvers/types";
 import { NetworkDto } from "../../network/resolvers/types";
 import { Node, NodeStateRes } from "../../node/resolvers/types";
 import { NotificationsDto } from "../../notification/resolvers/types";
+import { PaymentDto } from "../../payment/resolver/types";
 import { SimPoolResDto } from "../../sim/resolver/types";
 import { SiteDto } from "../../site/resolvers/types";
 import { Softwares } from "../../software/resolvers/types";
@@ -352,4 +354,218 @@ export class SimPoolView {
 
   stats?: SimPoolStatsSection;
   sims?: PoolSimsSection;
+}
+
+/* ------------------------- commerceView (Phase 3) ------------------------- */
+
+@ObjectType()
+export class RevenueSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => Number, { nullable: true })
+  totalPaid?: number | null;
+
+  @Field(() => Number, { nullable: true })
+  totalPending?: number | null;
+
+  @Field(() => Number, { nullable: true })
+  monthPaid?: number | null;
+
+  @Field(() => Number, { nullable: true })
+  prevMonthPaid?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  momPct?: number | null;
+}
+
+@ObjectType()
+export class PlanStatsDto {
+  @Field()
+  packageId: string;
+
+  @Field()
+  name: string;
+
+  @Field(() => Number)
+  amount: number;
+
+  @Field()
+  currency: string;
+
+  @Field(() => Boolean)
+  active: boolean;
+
+  @Field(() => Int, { nullable: true })
+  attachCount?: number | null;
+
+  @Field(() => Number)
+  revenue: number;
+
+  @Field(() => Int)
+  revenueSharePct: number;
+}
+
+@ObjectType()
+export class PlanStatsSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => Number, { nullable: true })
+  mrr?: number | null;
+
+  @Field(() => Number, { nullable: true })
+  arpu?: number | null;
+
+  @Field(() => [PlanStatsDto], { nullable: true })
+  plans?: PlanStatsDto[] | null;
+}
+
+@ObjectType()
+export class InvoicesSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [ReportDto], { nullable: true })
+  reports?: ReportDto[] | null;
+}
+
+@ObjectType()
+export class BalanceSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => Int, { nullable: true })
+  outstandingCount?: number | null;
+
+  @Field(() => String, { nullable: true })
+  latestUnpaidPeriod?: string | null;
+}
+
+@ObjectType()
+export class CommerceView {
+  @Field({ nullable: true })
+  networkId?: string;
+
+  revenue?: RevenueSection;
+  plans?: PlanStatsSection;
+  invoices?: InvoicesSection;
+  balance?: BalanceSection;
+}
+
+/* -------------------------- membersView (Phase 3) ------------------------- */
+
+@ObjectType()
+export class TeamMemberDto {
+  @Field()
+  id: string;
+
+  @Field({ nullable: true })
+  name?: string;
+
+  @Field({ nullable: true })
+  email?: string;
+
+  @Field()
+  role: string;
+
+  /** Active | Deactivated | Invited */
+  @Field()
+  status: string;
+
+  @Field({ nullable: true })
+  memberSince?: string;
+
+  @Field({ nullable: true })
+  inviteExpiresAt?: string;
+}
+
+@ObjectType()
+export class TeamSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [TeamMemberDto], { nullable: true })
+  rows?: TeamMemberDto[] | null;
+}
+
+@ObjectType()
+export class MembersView {
+  @Field()
+  orgName: string;
+
+  team?: TeamSection;
+}
+
+/* ------------------------- inventoryView (Phase 3) ------------------------ */
+
+@ObjectType()
+export class CategoryCountDto {
+  @Field()
+  category: string;
+
+  @Field(() => Int)
+  count: number;
+}
+
+@ObjectType()
+export class ComponentStatsSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => Int, { nullable: true })
+  total?: number | null;
+
+  @Field(() => [CategoryCountDto], { nullable: true })
+  byCategory?: CategoryCountDto[] | null;
+}
+
+@ObjectType()
+export class InventoryView {
+  @Field()
+  orgName: string;
+
+  components?: ComponentStatsSection;
+  unassignedNodes?: NodesSection;
+  simStock?: SimPoolStatsSection;
+}
+
+/* ------------------------- subscriberView (Phase 3) ----------------------- */
+
+@ObjectType()
+export class SubscriberSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => SubscriberDto, { nullable: true })
+  subscriber?: SubscriberDto | null;
+}
+
+@ObjectType()
+export class SubscriberPlansSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [PlanNameDto], { nullable: true })
+  plans?: PlanNameDto[] | null;
+}
+
+@ObjectType()
+export class SubscriberBillingSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [PaymentDto], { nullable: true })
+  payments?: PaymentDto[] | null;
+}
+
+@ObjectType()
+export class SubscriberView {
+  @Field()
+  subscriberId: string;
+
+  subscriber?: SubscriberSection;
+  plans?: SubscriberPlansSection;
+  billing?: SubscriberBillingSection;
+  usage?: GapSection;
 }

--- a/systems/console-bff/dashboard/resolvers/types.ts
+++ b/systems/console-bff/dashboard/resolvers/types.ts
@@ -1,0 +1,355 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+
+/**
+ * View-domain composite types (plan §3). Each composite has a cheap core
+ * (root resolver) and lazy sections (@FieldResolver) that hit upstreams only
+ * when selected. Every section embeds its own nullable `error`
+ * (SectionError) — see §4.5: data null + error set = failed/not-implemented;
+ * data null + no error = genuinely empty.
+ *
+ * Schema is design-complete against frontend needs (§3.5): sections whose
+ * backend doesn't exist yet are declared here and return NOT_IMPLEMENTED
+ * until the gap closes (see docs/backend-gaps.md) — closing a gap never
+ * changes this schema.
+ */
+import { Field, Int, ObjectType } from "type-graphql";
+
+import { HealthInfo } from "../../health/resolvers/types";
+import { NetworkDto } from "../../network/resolvers/types";
+import { Node, NodeStateRes } from "../../node/resolvers/types";
+import { NotificationsDto } from "../../notification/resolvers/types";
+import { SimPoolResDto } from "../../sim/resolver/types";
+import { SiteDto } from "../../site/resolvers/types";
+import { Softwares } from "../../software/resolvers/types";
+import { SubscriberDto } from "../../subscriber/resolver/types";
+import { SectionError } from "../types";
+
+/* ----------------------------- shared sections ---------------------------- */
+
+@ObjectType()
+export class NodeStatsSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => Int, { nullable: true })
+  total?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  online?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  offline?: number | null;
+}
+
+@ObjectType()
+export class NodesSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [Node], { nullable: true })
+  nodes?: Node[] | null;
+}
+
+@ObjectType()
+export class SitesSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [SiteDto], { nullable: true })
+  sites?: SiteDto[] | null;
+}
+
+@ObjectType()
+export class SubscriberStatsSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => Int, { nullable: true })
+  total?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  active?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  inactive?: number | null;
+}
+
+@ObjectType()
+export class AlertsSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [NotificationsDto], { nullable: true })
+  notifications?: NotificationsDto[] | null;
+}
+
+/** Placeholder-only section: schema-complete, backend gap (§3.5). */
+@ObjectType()
+export class GapSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+}
+
+/* ----------------------------- networkOverview ---------------------------- */
+
+@ObjectType()
+export class NetworkSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => NetworkDto, { nullable: true })
+  network?: NetworkDto | null;
+}
+
+@ObjectType()
+export class NetworkOverview {
+  @Field()
+  networkId: string;
+
+  // Sections resolved lazily — see NetworkOverviewResolver.
+  network?: NetworkSection;
+  nodeStats?: NodeStatsSection;
+  siteStats?: SitesSection;
+  subscriberStats?: SubscriberStatsSection;
+  latestAlerts?: AlertsSection;
+  kpis?: GapSection;
+}
+
+/* -------------------------------- nodesView ------------------------------- */
+
+@ObjectType()
+export class NodesView {
+  @Field({ nullable: true })
+  networkId?: string;
+
+  nodes?: NodesSection;
+  health?: GapSection;
+}
+
+/* -------------------------------- nodeView -------------------------------- */
+
+@ObjectType()
+export class NodeSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => Node, { nullable: true })
+  node?: Node | null;
+}
+
+@ObjectType()
+export class HealthSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => HealthInfo, { nullable: true })
+  health?: HealthInfo | null;
+}
+
+@ObjectType()
+export class SoftwareSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => Softwares, { nullable: true })
+  softwares?: Softwares | null;
+}
+
+@ObjectType()
+export class NodeStateSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => NodeStateRes, { nullable: true })
+  stateHistory?: NodeStateRes | null;
+}
+
+@ObjectType()
+export class NodeView {
+  @Field()
+  nodeId: string;
+
+  node?: NodeSection;
+  health?: HealthSection;
+  software?: SoftwareSection;
+  stateHistory?: NodeStateSection;
+  kpis?: GapSection;
+  radioStatus?: GapSection;
+}
+
+/* -------------------------------- sitesView ------------------------------- */
+
+@ObjectType()
+export class SiteNodeCountDto {
+  @Field()
+  siteId: string;
+
+  @Field(() => Int)
+  total: number;
+
+  @Field(() => Int)
+  online: number;
+
+  @Field(() => Int)
+  offline: number;
+}
+
+@ObjectType()
+export class SiteNodeCountsSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [SiteNodeCountDto], { nullable: true })
+  counts?: SiteNodeCountDto[] | null;
+}
+
+@ObjectType()
+export class SitesView {
+  @Field()
+  networkId: string;
+
+  sites?: SitesSection;
+  nodeCounts?: SiteNodeCountsSection;
+  kpis?: GapSection;
+  financials?: GapSection;
+}
+
+/* -------------------------------- siteView -------------------------------- */
+
+@ObjectType()
+export class SiteComponentDto {
+  @Field()
+  elementType: string;
+
+  @Field({ nullable: true })
+  componentId?: string;
+
+  @Field({ nullable: true })
+  componentName?: string;
+}
+
+@ObjectType()
+export class SiteComponentsSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [SiteComponentDto], { nullable: true })
+  components?: SiteComponentDto[] | null;
+}
+
+@ObjectType()
+export class SiteSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => SiteDto, { nullable: true })
+  site?: SiteDto | null;
+}
+
+@ObjectType()
+export class SiteView {
+  @Field()
+  siteId: string;
+
+  site?: SiteSection;
+  nodes?: NodesSection;
+  components?: SiteComponentsSection;
+  power?: GapSection;
+  kpis?: GapSection;
+  financials?: GapSection;
+}
+
+/* ----------------------------- subscribersView ---------------------------- */
+
+@ObjectType()
+export class SubscribersSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [SubscriberDto], { nullable: true })
+  subscribers?: SubscriberDto[] | null;
+}
+
+@ObjectType()
+export class PlanNameDto {
+  @Field()
+  packageId: string;
+
+  @Field()
+  name: string;
+}
+
+@ObjectType()
+export class PlansSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [PlanNameDto], { nullable: true })
+  plans?: PlanNameDto[] | null;
+}
+
+@ObjectType()
+export class SubscribersView {
+  @Field()
+  networkId: string;
+
+  subscribers?: SubscribersSection;
+  plans?: PlansSection;
+  usage?: GapSection;
+}
+
+/* ------------------------------- simPoolView ------------------------------ */
+
+@ObjectType()
+export class SimPoolStatsSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => Int, { nullable: true })
+  total?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  available?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  consumed?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  failed?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  esim?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  physical?: number | null;
+
+  @Field(() => Int, { nullable: true })
+  pctAssigned?: number | null;
+
+  @Field(() => Boolean, { nullable: true })
+  lowStock?: boolean | null;
+}
+
+@ObjectType()
+export class PoolSimsSection {
+  @Field(() => SectionError, { nullable: true })
+  error?: SectionError | null;
+
+  @Field(() => [SimPoolResDto], { nullable: true })
+  sims?: SimPoolResDto[] | null;
+}
+
+@ObjectType()
+export class SimPoolView {
+  @Field()
+  simType: string;
+
+  stats?: SimPoolStatsSection;
+  sims?: PoolSimsSection;
+}

--- a/systems/console-bff/dashboard/section.ts
+++ b/systems/console-bff/dashboard/section.ts
@@ -32,6 +32,45 @@ export class SectionErrorCollector {
 }
 
 /**
+ * Result of one composite section: the value (null on failure) plus the
+ * typed error (null on success). Sections embed `error` in their own GraphQL
+ * type rather than a composite-level errors list because GraphQL executes
+ * sibling field resolvers concurrently — a top-level `errors` field would
+ * resolve before the sections it reports on.
+ */
+export interface SectionResult<T> {
+  value: T | null;
+  error: SectionError | null;
+}
+
+/**
+ * Like `withSection`, but returns the error alongside the value so section
+ * field resolvers can embed it in their section type (the composite-query
+ * pattern). Same timeout + logging behavior.
+ */
+export async function runSection<T>(
+  section: string,
+  fn: () => Promise<T>,
+  timeoutMs: number = SECTION_TIMEOUT_MS
+): Promise<SectionResult<T>> {
+  const collector = new SectionErrorCollector();
+  const value = await withSection(collector, section, fn, timeoutMs);
+  return { value, error: collector.list()[0] ?? null };
+}
+
+/** `SectionResult` for a backend gap (§3.5): null value + NOT_IMPLEMENTED. */
+export const notImplementedSection = <T>(
+  section: string
+): SectionResult<T> => ({
+  value: null,
+  error: {
+    section,
+    code: SectionErrorCode.NOT_IMPLEMENTED,
+    message: `${section} is not available yet`,
+  },
+});
+
+/**
  * Marks a section whose backend endpoint/property doesn't exist yet
  * (docs/bff-screen-api-plan.md §3.5). Call from the section resolver next to
  * its `TODO(backend-gap)` comment and return null. Never fabricate data for

--- a/systems/console-bff/dashboard/section.ts
+++ b/systems/console-bff/dashboard/section.ts
@@ -1,0 +1,116 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import { logger } from "../common/logger";
+import { SectionError, SectionErrorCode } from "./types";
+
+/** Per-section upstream timeout — tighter than the global HTTP_TIMEOUT_MS
+ *  so one slow upstream degrades a section, not the whole screen. */
+export const SECTION_TIMEOUT_MS = parseInt(
+  process.env.SECTION_TIMEOUT_MS ?? "5000"
+);
+
+/**
+ * Request-scoped collector for composite section failures. One instance is
+ * created per composite root resolver and threaded to its section resolvers;
+ * the composite's `errors` field resolves `list()` last.
+ */
+export class SectionErrorCollector {
+  private readonly errors: SectionError[] = [];
+
+  add(section: string, code: SectionErrorCode, message: string): void {
+    this.errors.push({ section, code, message });
+  }
+
+  list(): SectionError[] {
+    return this.errors;
+  }
+}
+
+/**
+ * Marks a section whose backend endpoint/property doesn't exist yet
+ * (docs/bff-screen-api-plan.md §3.5). Call from the section resolver next to
+ * its `TODO(backend-gap)` comment and return null. Never fabricate data for
+ * a gap — the console renders a placeholder off this code.
+ */
+export const sectionNotImplemented = (
+  collector: SectionErrorCollector,
+  section: string
+): null => {
+  collector.add(
+    section,
+    SectionErrorCode.NOT_IMPLEMENTED,
+    `${section} is not available yet`
+  );
+  return null;
+};
+
+const toSectionErrorCode = (error: unknown): SectionErrorCode => {
+  const err = error as {
+    message?: string;
+    code?: number | string;
+    extensions?: { response?: { status?: number } };
+  };
+  const status =
+    err?.extensions?.response?.status ??
+    (typeof err?.code === "number" ? err.code : undefined);
+  if (err?.message === "SECTION_TIMEOUT") {
+    return SectionErrorCode.UPSTREAM_TIMEOUT;
+  }
+  if (status === 404) return SectionErrorCode.NOT_FOUND;
+  if (status === 401 || status === 403) return SectionErrorCode.FORBIDDEN;
+  if (typeof status === "number") return SectionErrorCode.UPSTREAM_ERROR;
+  return SectionErrorCode.INTERNAL;
+};
+
+/**
+ * Errors-as-data wrapper for composite section resolvers
+ * (docs/bff-screen-api-plan.md §4.5). Every section resolver MUST run its
+ * upstream work through this wrapper — never hand-roll try/catch.
+ *
+ * On success: returns the value and logs section latency (requestId is
+ * stamped by the logger's AsyncLocalStorage context).
+ * On failure/timeout: logs, records a typed SectionError on the collector,
+ * and returns null so the rest of the composite still resolves.
+ */
+export async function withSection<T>(
+  collector: SectionErrorCollector,
+  section: string,
+  fn: () => Promise<T>,
+  timeoutMs: number = SECTION_TIMEOUT_MS
+): Promise<T | null> {
+  const startedAt = Date.now();
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    const result = await Promise.race([
+      fn(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("SECTION_TIMEOUT")),
+          timeoutMs
+        );
+      }),
+    ]);
+    logger.info("composite section resolved", {
+      section,
+      durationMs: Date.now() - startedAt,
+    });
+    return result;
+  } catch (error) {
+    const code = toSectionErrorCode(error);
+    logger.error("composite section failed", {
+      section,
+      code,
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    collector.add(section, code, `Failed to load ${section}`);
+    return null;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/systems/console-bff/dashboard/types.ts
+++ b/systems/console-bff/dashboard/types.ts
@@ -1,0 +1,66 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2026-present, Ukama Inc.
+ */
+import { Field, ObjectType, registerEnumType } from "type-graphql";
+
+/**
+ * Errors-as-data contract for composite (view-domain) queries — see
+ * docs/bff-screen-api-plan.md §4.5. Frontend branches on `code`,
+ * never on `message` text.
+ */
+export enum SectionErrorCode {
+  UPSTREAM_TIMEOUT = "UPSTREAM_TIMEOUT",
+  UPSTREAM_ERROR = "UPSTREAM_ERROR",
+  NOT_FOUND = "NOT_FOUND",
+  FORBIDDEN = "FORBIDDEN",
+  INTERNAL = "INTERNAL",
+  /** Schema is design-complete but the backend endpoint/property does not
+   *  exist yet (TODO(backend-gap) in the resolver). The section resolves to
+   *  null until the upstream ships; the console renders a placeholder and
+   *  needs no change when data arrives. */
+  NOT_IMPLEMENTED = "NOT_IMPLEMENTED",
+}
+
+registerEnumType(SectionErrorCode, {
+  name: "SectionErrorCode",
+  description:
+    "Machine-readable failure code for a composite query section. " +
+    "UI branches on this code; `message` is for display/logs only.",
+});
+
+@ObjectType({
+  description:
+    "Typed failure of one section of a composite query. The section's data " +
+    "field resolves to null and a SectionError describes why, so the UI can " +
+    "distinguish 'failed' from 'genuinely empty'.",
+})
+export class SectionError {
+  @Field(() => String)
+  section: string;
+
+  @Field(() => SectionErrorCode)
+  code: SectionErrorCode;
+
+  @Field(() => String)
+  message: string;
+}
+
+@ObjectType({
+  description:
+    "Expected/business failure of a mutation (validation, state conflict). " +
+    "Rendered inline on forms; unexpected failures still throw.",
+})
+export class UserError {
+  @Field(() => String, { nullable: true })
+  field?: string;
+
+  @Field(() => String)
+  code: string;
+
+  @Field(() => String)
+  message: string;
+}

--- a/systems/console-bff/metric/datasource/metric_api.ts
+++ b/systems/console-bff/metric/datasource/metric_api.ts
@@ -43,6 +43,28 @@ class MetricAPI extends BaseRESTDataSource {
       parseSiteLatestMetricRes(res, args)
     );
   };
+
+  /**
+   * Generic latest-value read for one metric key (org-scoped, no entity
+   * stamping). Used by the dashboard KPI sections (plan Phase 4 — polled,
+   * no subscriptions in v1).
+   */
+  getLatestMetric = async (
+    baseURL: string,
+    type: string
+  ): Promise<{ type: string; value: [number, number]; success: boolean }> => {
+    this.logger.info(
+      `GetLatestMetric [GET]: ${baseURL}/${VERSION}/${METRICS}/${type}`
+    );
+    this.baseURL = baseURL;
+    return this.get(`/${VERSION}/${METRICS}/${type}`).then(res => {
+      const data = res?.data?.result?.[0];
+      if (data?.value?.length > 0) {
+        return { type, value: data.value as [number, number], success: true };
+      }
+      return { type, value: [0, 0] as [number, number], success: false };
+    });
+  };
 }
 
 export default MetricAPI;

--- a/systems/console-bff/org/resolver/getOrgTree.ts
+++ b/systems/console-bff/org/resolver/getOrgTree.ts
@@ -11,15 +11,8 @@ import { SUB_GRAPHS } from "../../common/configs";
 import { SIM_STATUS, SIM_TYPES } from "../../common/enums";
 import { openStore } from "../../common/storage";
 import { getBaseURL } from "../../common/utils";
-import ComponentApi from "../../component/datasource/component_api";
-import MemberApi from "../../member/datasource/member_api";
-import NetworkApi from "../../network/datasource/network_api";
-import PackageApi from "../../package/datasource/package_api";
-import SimApi from "../../sim/datasource/sim_api";
-import SiteApi from "../../site/datasource/site_api";
-import SubscriberApi from "../../subscriber/datasource/subscriber_api";
-import UserApi from "../../user/datasource/user_api";
-import { Context } from "../context";
+import { ComponentDto } from "../../component/resolvers/types";
+import type { AppContext } from "../../server/context";
 import {
   Component,
   DataPlan,
@@ -99,41 +92,46 @@ const DEFAULT_ORG_TREE = {
   },
 };
 
+const toComponent = (
+  elementType: string,
+  component?: ComponentDto
+): Component => ({
+  componentId: component?.partNumber ? component.partNumber : undefined,
+  componentName: component?.partNumber ? component.description : undefined,
+  elementType,
+});
+
 @Resolver()
 export class GetOrgTreeResolver {
   @Query(() => OrgTreeRes)
-  async getOrgTree(@Ctx() ctx: Context): Promise<OrgTreeRes> {
+  async getOrgTree(@Ctx() ctx: AppContext): Promise<OrgTreeRes> {
+    // Uses ctx.dataSources (per-request instances) so RESTDataSource GET
+    // deduplication applies — do not instantiate datasources inline.
     const { dataSources, headers } = ctx;
     const store = openStore();
-    const registryUrl = await getBaseURL(
-      SUB_GRAPHS.network.name,
-      headers.orgName,
-      store
-    );
-    const dataPlanUrl = await getBaseURL(
-      SUB_GRAPHS.package.name,
-      headers.orgName,
-      store
-    );
-    const subscriberUrl = await getBaseURL(
-      SUB_GRAPHS.sim.name,
-      headers.orgName,
-      store
-    );
-    const userAPI = new UserApi();
-    const siteAPI = new SiteApi();
-    const memberAPI = new MemberApi();
-    const simsAPI = new SimApi();
-    const networkAPI = new NetworkApi();
-    const packageAPI = new PackageApi();
-    const subscriberAPI = new SubscriberApi();
-    const componentAPI = new ComponentApi();
+    const [registryUrl, dataPlanUrl, subscriberUrl] = await Promise.all([
+      getBaseURL(SUB_GRAPHS.network.name, headers.orgName, store),
+      getBaseURL(SUB_GRAPHS.package.name, headers.orgName, store),
+      getBaseURL(SUB_GRAPHS.sim.name, headers.orgName, store),
+    ]);
 
     const res: Org = DEFAULT_ORG_TREE;
     const nr: Network = DEFAULT_ORG_TREE.networks[0];
 
-    const orgRes = await dataSources.org.getOrg(headers.orgName);
-    const userRes = await userAPI.getUser(orgRes.owner);
+    // Independent root fetches — run in parallel.
+    const [orgRes, networksRes, plansRes, simsRes, membersRes] =
+      await Promise.all([
+        dataSources.org.getOrg(headers.orgName),
+        dataSources.network.getNetworks(registryUrl.message),
+        dataSources.package.getPackages(dataPlanUrl.message),
+        dataSources.sim.getSimsFromPool(subscriberUrl.message, {
+          type: SIM_TYPES.ukama_data,
+          status: SIM_STATUS.ALL,
+        }),
+        dataSources.member.getMembers(registryUrl.message),
+      ]);
+
+    const userRes = await dataSources.user.getUser(orgRes.owner);
     res.orgName = headers.orgName;
     res.orgId = headers.orgId;
     res.ownerId = orgRes.owner;
@@ -143,108 +141,46 @@ export class GetOrgTreeResolver {
     res.currency = orgRes.currency;
     res.elementType = "ORG";
 
-    const networksRes = await networkAPI.getNetworks(registryUrl.message);
     if (networksRes.networks.length > 0) {
-      nr.networkId = networksRes.networks[0].id;
+      const networkId = networksRes.networks[0].id;
+      nr.networkId = networkId;
       nr.networkName = networksRes.networks[0].name;
       nr.elementType = "NETWORK";
-      res.networks = [nr];
 
-      const siteRes = await siteAPI.getSites(registryUrl.message, {
-        networkId: networksRes.networks[0].id,
-      });
-      const sr: Site[] = [];
+      // Sites + subscribers for the network are independent of each other.
+      const [siteRes, subscriberRes] = await Promise.all([
+        dataSources.site.getSites(registryUrl.message, { networkId }),
+        dataSources.subscriber.getSubscribersByNetwork(
+          subscriberUrl.message,
+          networkId
+        ),
+      ]);
+
       if (siteRes.sites.length > 0) {
-        const compRes = await componentAPI.getComponentsByUserId(
+        const compRes = await dataSources.component.getComponentsByUserId(
           headers,
           "ALL"
         );
-        for (const site of siteRes.sites) {
-          const cr: Component[] = [];
-          const accessRes = compRes.components.find(
-            comp => comp.id === site.accessId
-          );
-          if (accessRes?.partNumber) {
-            cr.push({
-              componentId: accessRes.partNumber,
-              componentName: accessRes.description,
-              elementType: "ACCESS",
-            });
-          } else {
-            cr.push({
-              componentId: undefined,
-              componentName: undefined,
-              elementType: "ACCESS",
-            });
-          }
-
-          const powerRes = compRes.components.find(
-            comp => comp.id === site.powerId
-          );
-          if (powerRes?.partNumber) {
-            cr.push({
-              componentId: powerRes.partNumber,
-              componentName: powerRes.description,
-              elementType: "POWER",
-            });
-          } else {
-            cr.push({
-              componentId: undefined,
-              componentName: undefined,
-              elementType: "POWER",
-            });
-          }
-
-          const backhaulRes = compRes.components.find(
-            comp => comp.id === site.backhaulId
-          );
-          if (backhaulRes?.partNumber) {
-            cr.push({
-              componentId: backhaulRes.partNumber,
-              componentName: backhaulRes.description,
-              elementType: "BACKHAUL",
-            });
-          } else {
-            cr.push({
-              componentId: undefined,
-              componentName: undefined,
-              elementType: "BACKHAUL",
-            });
-          }
-
-          const switchRes = compRes.components.find(
-            comp => comp.id === site.switchId
-          );
-          if (switchRes?.partNumber) {
-            cr.push({
-              componentId: switchRes.partNumber,
-              componentName: switchRes.description,
-              elementType: "SWITCH",
-            });
-          } else {
-            cr.push({
-              componentId: undefined,
-              componentName: undefined,
-              elementType: "SWITCH",
-            });
-          }
-
-          sr.push({
+        // Index components once (O(n)) instead of find() 4x per site.
+        const componentsById = new Map<string, ComponentDto>(
+          compRes.components.map(comp => [comp.id, comp])
+        );
+        nr.sites = siteRes.sites.map(
+          (site): Site => ({
             siteId: site.id,
             siteName: site.name,
             elementType: "SITE",
-            components: cr,
-          });
-        }
-        nr.sites = sr;
+            components: [
+              toComponent("ACCESS", componentsById.get(site.accessId)),
+              toComponent("POWER", componentsById.get(site.powerId)),
+              toComponent("BACKHAUL", componentsById.get(site.backhaulId)),
+              toComponent("SWITCH", componentsById.get(site.switchId)),
+            ],
+          })
+        );
       } else {
         nr.sites = [];
       }
-
-      const subscriberRes = await subscriberAPI.getSubscribersByNetwork(
-        subscriberUrl.message,
-        networksRes.networks[0].id
-      );
 
       if (subscriberRes.subscribers.length > 0) {
         const ssr: Subscribers = DEFAULT_ORG_TREE.networks[0].subscribers;
@@ -269,25 +205,18 @@ export class GetOrgTreeResolver {
       res.networks = [];
     }
 
-    const plansRes = await packageAPI.getPackages(dataPlanUrl.message);
     if (plansRes.packages.length > 0) {
-      const dr: DataPlan[] = [];
-      plansRes.packages.forEach(plan => {
-        dr.push({
+      res.dataplans = plansRes.packages.map(
+        (plan): DataPlan => ({
           planId: plan.uuid,
           planName: plan.name,
           elementType: "DATAPLAN",
-        });
-      });
-      res.dataplans = dr;
+        })
+      );
     } else {
       res.dataplans = [];
     }
 
-    const simsRes = await simsAPI.getSimsFromPool(subscriberUrl.message, {
-      type: SIM_TYPES.ukama_data,
-      status: SIM_STATUS.ALL,
-    });
     if (simsRes.sims.length > 0) {
       const simr = DEFAULT_ORG_TREE.sims;
       simr.totalSims = simsRes.sims.length.toString();
@@ -299,7 +228,6 @@ export class GetOrgTreeResolver {
       res.sims = undefined;
     }
 
-    const membersRes = await memberAPI.getMembers(registryUrl.message);
     if (membersRes.members.length > 0) {
       const mr = DEFAULT_ORG_TREE.members;
       mr.totalMembers = membersRes.members.length.toString();

--- a/systems/console-bff/server/index.ts
+++ b/systems/console-bff/server/index.ts
@@ -34,6 +34,7 @@ import { validateEnv } from "../common/configs/validateEnv";
 import { HTTP401Error, HTTP500Error, Messages } from "../common/errors";
 import { logger } from "../common/logger";
 import { configureExpress } from "../common/middleware/expressApp";
+import { persistedOperations } from "../common/middleware/persistedOperations";
 import { closeStore, openStore } from "../common/storage";
 import { THeaders } from "../common/types";
 import InitAPI from "../init/datasource/init_api";
@@ -122,6 +123,9 @@ const startServer = async () => {
       credentials: true,
     }),
     express.json({ limit: JSON_BODY_LIMIT }),
+    // Production allowlist: only operations shipped by the console are
+    // accepted when PERSISTED_OPS_ENFORCED=true (no-op otherwise).
+    persistedOperations({ allowIntrospection: INTROSPECTION_ENABLED }),
     expressMiddleware(server, {
       context: async ({ req }): Promise<AppContext> => {
         const requestId = (req.headers["x-request-id"] as string) ?? "";

--- a/systems/console-bff/server/schema.ts
+++ b/systems/console-bff/server/schema.ts
@@ -19,6 +19,7 @@ import * as tq from "type-graphql";
 import billingResolvers from "../billing/resolvers";
 import componentResolvers from "../component/resolvers";
 import controllerResolvers from "../controller/resolvers";
+import dashboardResolvers from "../dashboard/resolvers";
 import healthResolvers from "../health/resolvers";
 import initResolvers from "../init/resolver";
 import invitationResolvers from "../invitation/resolver";
@@ -42,6 +43,7 @@ import userResolvers from "../user/resolver";
 // inferring a combined literal type (a 21-array spread otherwise produces a
 // "union type too complex to represent" error under ts-node).
 const ALL_RESOLVERS: CallableFunction[] = [
+  ...dashboardResolvers,
   ...orgResolvers,
   ...userResolvers,
   ...networkResolvers,

--- a/systems/console-bff/sim/resolver/addPackagestoSim.ts
+++ b/systems/console-bff/sim/resolver/addPackagestoSim.ts
@@ -8,6 +8,7 @@
 import { Arg, Ctx, Mutation, Resolver } from "type-graphql";
 
 import { logger } from "../../common/logger";
+import { mapWithConcurrencySettled } from "../../common/utils/concurrency";
 import { Context } from "../context";
 import {
   AddPackagSimResDto,
@@ -23,27 +24,37 @@ export class AddPackagesToSimResolver {
     @Ctx() ctx: Context
   ): Promise<AddPackagesSimResDto> {
     const { dataSources, baseURL } = ctx;
-    const pacakgesId: AddPackagSimResDto[] = [];
-    for (const packageInfo of data.packages) {
-      try {
-        await dataSources.sim.addPackageToSim(
+
+    // Parallel with bounded concurrency; report per-package outcome instead
+    // of failing the whole mutation on the first error.
+    const results = await mapWithConcurrencySettled(
+      data.packages,
+      packageInfo =>
+        dataSources.sim.addPackageToSim(
           baseURL,
           data.sim_id,
           packageInfo.package_id,
           packageInfo.start_date
-        );
-        pacakgesId.push({
-          packageId: packageInfo.package_id,
-        });
-      } catch (error) {
+        )
+    );
+
+    const packages: AddPackagSimResDto[] = results.map((result, i) => {
+      const packageId = data.packages[i].package_id;
+      if (result.status === "rejected") {
         logger.error(
-          `Error adding package to sim: ${packageInfo.package_id}: ${error}`
+          `Error adding package to sim: ${packageId}: ${result.reason}`
         );
-        throw new Error("Failed to add package to sim");
+        return {
+          packageId,
+          success: false,
+          error: "Failed to add package to sim",
+        };
       }
-    }
+      return { packageId, success: true };
+    });
+
     return {
-      packages: pacakgesId,
+      packages,
     };
   }
 }

--- a/systems/console-bff/sim/resolver/getDataUsages.ts
+++ b/systems/console-bff/sim/resolver/getDataUsages.ts
@@ -8,6 +8,7 @@
 import { Arg, Ctx, Query, Resolver } from "type-graphql";
 
 import { logger } from "../../common/logger";
+import { mapWithConcurrency } from "../../common/utils/concurrency";
 import { Context } from "../context";
 import { SimDataUsages, SimDto, SimUsagesInputDto } from "./types";
 
@@ -42,14 +43,13 @@ export class GetDataUsagesResolver {
 
     logger.info(`SimUsages: ${JSON.stringify(simUsages)}`);
 
-    const usages = await Promise.all(
-      simUsages.map((item: any) =>
-        dataSources.sim.getDataUsage(baseURL, {
-          type: data.type,
-          iccid: item.iccid,
-          simId: item.simId,
-        })
-      )
+    // Bounded fan-out: one upstream call per sim, max 10 in flight.
+    const usages = await mapWithConcurrency(simUsages, (item: any) =>
+      dataSources.sim.getDataUsage(baseURL, {
+        type: data.type,
+        iccid: item.iccid,
+        simId: item.simId,
+      })
     );
 
     return {

--- a/systems/console-bff/sim/resolver/types.ts
+++ b/systems/console-bff/sim/resolver/types.ts
@@ -140,6 +140,12 @@ export class RemovePackageFromSimResDto {
 export class AddPackagSimResDto {
   @Field(() => String, { nullable: true })
   packageId: string;
+
+  @Field(() => Boolean, { nullable: true })
+  success?: boolean;
+
+  @Field(() => String, { nullable: true })
+  error?: string;
 }
 
 @ObjectType()

--- a/systems/console-bff/subscriber/resolver/getSubscribersByNetwork.ts
+++ b/systems/console-bff/subscriber/resolver/getSubscribersByNetwork.ts
@@ -10,6 +10,7 @@ import { Arg, Ctx, Query, Resolver } from "type-graphql";
 import { Context } from "../context";
 import {
   SubscriberDto,
+  SubscriberSimDto,
   SubscriberSimsResDto,
   SubscribersResDto,
 } from "./types";
@@ -23,14 +24,28 @@ export class GetSubscribersByNetworkResolver {
   ): Promise<SubscribersResDto> {
     const { dataSources, baseURL } = ctx;
     const networkSub: SubscriberDto[] = [];
-    const sims: SubscriberSimsResDto =
-      await dataSources.subscriber.getSimsByNetwork(baseURL, networkId);
 
-    const subs: SubscribersResDto =
-      await dataSources.subscriber.getSubscribersByNetwork(baseURL, networkId);
+    // Independent upstream calls — fetch in parallel.
+    const [sims, subs]: [SubscriberSimsResDto, SubscribersResDto] =
+      await Promise.all([
+        dataSources.subscriber.getSimsByNetwork(baseURL, networkId),
+        dataSources.subscriber.getSubscribersByNetwork(baseURL, networkId),
+      ]);
+
+    // Group sims by subscriber once (O(n + m)) instead of filtering the
+    // whole sims array per subscriber (O(n * m)).
+    const simsBySubscriber = new Map<string, SubscriberSimDto[]>();
+    for (const sim of sims.sims) {
+      const group = simsBySubscriber.get(sim.subscriberId);
+      if (group) {
+        group.push(sim);
+      } else {
+        simsBySubscriber.set(sim.subscriberId, [sim]);
+      }
+    }
 
     for (const sub of subs.subscribers) {
-      sub.sim = sims.sims.filter(sim => sim.subscriberId === sub.uuid);
+      sub.sim = simsBySubscriber.get(sub.uuid) ?? [];
       networkSub.push({
         dob: sub.dob,
         uuid: sub.uuid,

--- a/systems/console-bff/subscriptions/resolvers/resolver.ts
+++ b/systems/console-bff/subscriptions/resolvers/resolver.ts
@@ -28,6 +28,7 @@ import {
   transformMetricsArray,
   wsUrlResolver,
 } from "../../common/utils";
+import { mapWithConcurrency } from "../../common/utils/concurrency";
 import {
   getNodeMetricRange,
   getNotifications,
@@ -493,17 +494,25 @@ class SubscriptionsResolvers {
         const sites = siteIds && siteIds.length > 0 ? siteIds : [""];
         const nodes = nodeIds && nodeIds.length > 0 ? nodeIds : [""];
 
+        // Fetch site/node combinations in parallel (bounded) instead of
+        // awaiting each combination sequentially.
+        const combos: { siteId: string; nodeId: string }[] = [];
         for (const siteId of sites) {
           for (const nodeId of nodes) {
-            const processedMetrics = await fetchMetricsForSiteNodeCombination(
-              baseURL,
-              metricsKey,
-              siteId,
-              nodeId,
-              data
-            );
-            metrics.metrics.push(...processedMetrics);
+            combos.push({ siteId, nodeId });
           }
+        }
+        const results = await mapWithConcurrency(combos, combo =>
+          fetchMetricsForSiteNodeCombination(
+            baseURL,
+            metricsKey,
+            combo.siteId,
+            combo.nodeId,
+            data
+          )
+        );
+        for (const processedMetrics of results) {
+          metrics.metrics.push(...processedMetrics);
         }
       }
 


### PR DESCRIPTION
**console-bff**

11 view-domain composites in a new dashboard/ module (networkOverview, nodeView, siteView, subscribersView, commerceView, membersView, inventoryView, …) — lazy @FieldResolver sections, errors-as-data (SectionError, NOT_IMPLEMENTED for backend gaps), server-side derivations (status rollups, MRR/ARPU, revenue MoM).
Perf/hardening: N+1 and fan-out fixes, billing filters bug fix, gzip compression, persisted-operations allowlist (off by default), per-section latency logging, unit tests.
Polled metrics for v1 (no WebSockets/subscriptions): latest-KPI sections + metricsRange query; subscriptions service stays parked.

**ukama-console**

All lenses wired off src/data mocks via per-screen GraphQL documents + codegen (offline SCHEMA_PATH mode); SectionFallback renders loading / failed-with-retry / "—" for gaps / empty.
Polling plumbing in place but globally disabled (enable per screen via visiblePoll(ms, true)).
Fix: moved proxy.ts → src/proxy.ts (auth gate was silently ignored with a src/ dir — no redirect without session cookies).