### PR TITLE
Console BFF > Hook site controller integration

### DIFF
--- a/systems/console-bff/controller/datasource/controller_api.ts
+++ b/systems/console-bff/controller/datasource/controller_api.ts
@@ -12,8 +12,8 @@ import {
   RestartNodeInputDto,
   RestartNodesInputDto,
   RestartSiteInputDto,
-  ToggleInternetSwitchInputDto,
   SetSiteInputDto,
+  ToggleInternetSwitchInputDto,
   ToggleSiteStatusInputDto,
 } from "../resolvers/types";
 
@@ -90,15 +90,12 @@ class ControllerApi extends BaseRESTDataSource {
     );
 
     this.baseURL = baseURL;
-    return this.post(
-      `/${VERSION}/sites/${req.siteId}/internet-port`,
-      {
-        body: {
-          port: req.port,
-          status: req.status,
-        },
-      }
-    )
+    return this.post(`/${VERSION}/sites/${req.siteId}/internet-port`, {
+      body: {
+        port: req.port,
+        status: req.status,
+      },
+    })
       .then(() => {
         return { success: true };
       })

--- a/systems/console-bff/controller/datasource/controller_api.ts
+++ b/systems/console-bff/controller/datasource/controller_api.ts
@@ -13,7 +13,6 @@ import {
   RestartNodesInputDto,
   RestartSiteInputDto,
   ToggleInternetSwitchInputDto,
-  ToggleRFStatusInputDto,
   ToggleSiteStatusInputDto,
 } from "../resolvers/types";
 

--- a/systems/console-bff/controller/datasource/controller_api.ts
+++ b/systems/console-bff/controller/datasource/controller_api.ts
@@ -13,6 +13,7 @@ import {
   RestartNodesInputDto,
   RestartSiteInputDto,
   ToggleInternetSwitchInputDto,
+  SetSiteInputDto,
   ToggleSiteStatusInputDto,
 } from "../resolvers/types";
 
@@ -136,6 +137,25 @@ class ControllerApi extends BaseRESTDataSource {
 
     this.baseURL = baseURL;
     return this.post(`/${VERSION}/sites/${req.siteId}/service/${state}`)
+      .then(() => {
+        return { success: true };
+      })
+      .catch(error => {
+        this.logger.error(`Request failed: ${error}`);
+        return { success: false };
+      });
+  };
+  setSite = async (
+    baseURL: string,
+    req: SetSiteInputDto
+  ): Promise<TBooleanResponse> => {
+    const state = req.status ? "on" : "off";
+    this.logger.info(
+      `SetSite [POST]: ${baseURL}/${VERSION}/sites/${req.siteId}/${state}`
+    );
+
+    this.baseURL = baseURL;
+    return this.post(`/${VERSION}/sites/${req.siteId}/${state}`)
       .then(() => {
         return { success: true };
       })

--- a/systems/console-bff/controller/datasource/controller_api.ts
+++ b/systems/console-bff/controller/datasource/controller_api.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2023-present, Ukama Inc.
+ * Copyright (c) 2026-present, Ukama Inc.
  */
 import { VERSION } from "../../common/configs";
 import { BaseRESTDataSource } from "../../common/datasource";

--- a/systems/console-bff/controller/datasource/controller_api.ts
+++ b/systems/console-bff/controller/datasource/controller_api.ts
@@ -14,6 +14,7 @@ import {
   RestartSiteInputDto,
   ToggleInternetSwitchInputDto,
   ToggleRFStatusInputDto,
+  ToggleSiteStatusInputDto,
 } from "../resolvers/types";
 
 const CONTROLLER = "controller";
@@ -105,27 +106,15 @@ class ControllerApi extends BaseRESTDataSource {
   };
   toggleRFStatus = async (
     baseURL: string,
-    req: ToggleRFStatusInputDto
+    req: ToggleSiteStatusInputDto
   ): Promise<TBooleanResponse> => {
+    const state = req.status ? "on" : "off";
     this.logger.info(
-      `ToggleRFStatus [POST]: ${baseURL}/${VERSION}/${CONTROLLER}/nodes/${req.nodeId.replace(
-        "tnode",
-        "anode"
-      )}/toggle-radio`
+      `ToggleRFStatus [POST]: ${baseURL}/${VERSION}/sites/${req.siteId}/radio/${state}`
     );
 
     this.baseURL = baseURL;
-    return this.post(
-      `/${VERSION}/${CONTROLLER}/nodes/${req.nodeId.replace(
-        "tnode",
-        "anode"
-      )}/toggle-radio`,
-      {
-        body: {
-          state: req.status ? "on" : "off",
-        },
-      }
-    )
+    return this.post(`/${VERSION}/sites/${req.siteId}/radio/${state}`)
       .then(() => {
         return { success: true };
       })
@@ -136,21 +125,15 @@ class ControllerApi extends BaseRESTDataSource {
   };
   toggleService = async (
     baseURL: string,
-    req: ToggleRFStatusInputDto
+    req: ToggleSiteStatusInputDto
   ): Promise<TBooleanResponse> => {
+    const state = req.status ? "on" : "off";
     this.logger.info(
-      `ToggleServiceStatus [POST]: ${baseURL}/${VERSION}/${CONTROLLER}/nodes/${req.nodeId}/toggle-service`
+      `ToggleServiceStatus [POST]: ${baseURL}/${VERSION}/sites/${req.siteId}/service/${state}`
     );
 
     this.baseURL = baseURL;
-    return this.post(
-      `/${VERSION}/${CONTROLLER}/nodes/${req.nodeId}/toggle-service`,
-      {
-        body: {
-          state: req.status ? "on" : "off",
-        },
-      }
-    )
+    return this.post(`/${VERSION}/sites/${req.siteId}/service/${state}`)
       .then(() => {
         return { success: true };
       })

--- a/systems/console-bff/controller/datasource/controller_api.ts
+++ b/systems/console-bff/controller/datasource/controller_api.ts
@@ -82,12 +82,12 @@ class ControllerApi extends BaseRESTDataSource {
     req: ToggleInternetSwitchInputDto
   ): Promise<TBooleanResponse> => {
     this.logger.info(
-      `ToggleInternetSwitch [POST]: ${baseURL}/${VERSION}/${CONTROLLER}/sites/${req.siteId}/toggle-internet-switch`
+      `ToggleInternetSwitch [POST]: ${baseURL}/${VERSION}/sites/${req.siteId}/internet-port`
     );
 
     this.baseURL = baseURL;
     return this.post(
-      `/${VERSION}/${CONTROLLER}/sites/${req.siteId}/toggle-internet-port`,
+      `/${VERSION}/sites/${req.siteId}/internet-port`,
       {
         body: {
           port: req.port,

--- a/systems/console-bff/controller/datasource/controller_api.ts
+++ b/systems/console-bff/controller/datasource/controller_api.ts
@@ -42,12 +42,15 @@ class ControllerApi extends BaseRESTDataSource {
     req: RestartNodesInputDto
   ): Promise<TBooleanResponse> => {
     this.logger.info(
-      `RestartNodes [POST]: ${baseURL}/${VERSION}/network/${req.networkId}/restart-nodes`
+      `RestartNodes [POST]: ${baseURL}/${VERSION}/${CONTROLLER}/networks/${req.networkId}/restart-nodes`
     );
     this.baseURL = baseURL;
-    return this.post(`/${VERSION}/network/${req.networkId}/restart-nodes`, {
-      body: req.nodeIds,
-    })
+    return this.post(
+      `/${VERSION}/${CONTROLLER}/networks/${req.networkId}/restart-nodes`,
+      {
+        body: req.nodeIds,
+      }
+    )
       .then(() => {
         return { success: true };
       })

--- a/systems/console-bff/controller/datasource/controller_api.ts
+++ b/systems/console-bff/controller/datasource/controller_api.ts
@@ -62,11 +62,11 @@ class ControllerApi extends BaseRESTDataSource {
     req: RestartSiteInputDto
   ): Promise<TBooleanResponse> => {
     this.logger.info(
-      `RestartSite [POST]: ${baseURL}/${VERSION}/networks/${req.networkId}/sites/${req.siteId}/restart`
+      `RestartSite [POST]: ${baseURL}/${VERSION}/${CONTROLLER}/networks/${req.networkId}/sites/${req.siteId}/restart`
     );
     this.baseURL = baseURL;
     return this.post(
-      `/${VERSION}/networks/${req.networkId}/sites/${req.siteId}/restart`
+      `/${VERSION}/${CONTROLLER}/networks/${req.networkId}/sites/${req.siteId}/restart`
     )
       .then(() => {
         return { success: true };

--- a/systems/console-bff/controller/resolvers/index.ts
+++ b/systems/console-bff/controller/resolvers/index.ts
@@ -11,6 +11,7 @@ import { ExampleResolver } from "./exampleResolver";
 import { RestartNodeResolver } from "./restartNode";
 import { RestartNodesResolver } from "./restartNodes";
 import { RestartSiteResolver } from "./restartSite";
+import { SetSiteResolver } from "./setSite";
 import { ToggleInternetSwitchResolver } from "./toggleInternetSwitch";
 import { ToggleRFStatusResolver } from "./toggleRFStatus";
 import { ToggleServiceResolver } from "./toggleService";
@@ -23,6 +24,7 @@ const resolvers: NonEmptyArray<any> = [
   ToggleServiceResolver,
   ToggleRFStatusResolver,
   ToggleInternetSwitchResolver,
+  SetSiteResolver,
 ];
 
 export default resolvers;

--- a/systems/console-bff/controller/resolvers/index.ts
+++ b/systems/console-bff/controller/resolvers/index.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2023-present, Ukama Inc.
+ * Copyright (c) 2026-present, Ukama Inc.
  */
 import { NonEmptyArray } from "type-graphql";
 

--- a/systems/console-bff/controller/resolvers/setSite.ts
+++ b/systems/console-bff/controller/resolvers/setSite.ts
@@ -1,0 +1,25 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2023-present, Ukama Inc.
+ */
+import { Arg, Ctx, Mutation, Resolver } from "type-graphql";
+
+import { CBooleanResponse } from "../../common/types";
+import type { AppContext } from "../../server/context";
+import { SetSiteInputDto } from "./types";
+
+@Resolver()
+export class SetSiteResolver {
+  @Mutation(() => CBooleanResponse)
+  async setSite(
+    @Arg("data") data: SetSiteInputDto,
+    @Ctx() ctx: AppContext
+  ): Promise<CBooleanResponse> {
+    const { dataSources } = ctx;
+    const baseURL = await ctx.urls.url("controller");
+    return dataSources.controller.setSite(baseURL, data);
+  }
+}

--- a/systems/console-bff/controller/resolvers/setSite.ts
+++ b/systems/console-bff/controller/resolvers/setSite.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2023-present, Ukama Inc.
+ * Copyright (c) 2026-present, Ukama Inc.
  */
 import { Arg, Ctx, Mutation, Resolver } from "type-graphql";
 

--- a/systems/console-bff/controller/resolvers/toggleRFStatus.ts
+++ b/systems/console-bff/controller/resolvers/toggleRFStatus.ts
@@ -9,13 +9,13 @@ import { Arg, Ctx, Mutation, Resolver } from "type-graphql";
 
 import { CBooleanResponse } from "../../common/types";
 import type { AppContext } from "../../server/context";
-import { ToggleRFStatusInputDto } from "./types";
+import { ToggleSiteStatusInputDto } from "./types";
 
 @Resolver()
 export class ToggleRFStatusResolver {
   @Mutation(() => CBooleanResponse)
   async toggleRFStatus(
-    @Arg("data") data: ToggleRFStatusInputDto,
+    @Arg("data") data: ToggleSiteStatusInputDto,
     @Ctx() ctx: AppContext
   ): Promise<CBooleanResponse> {
     const { dataSources } = ctx;

--- a/systems/console-bff/controller/resolvers/toggleRFStatus.ts
+++ b/systems/console-bff/controller/resolvers/toggleRFStatus.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2023-present, Ukama Inc.
+ * Copyright (c) 2026-present, Ukama Inc.
  */
 import { Arg, Ctx, Mutation, Resolver } from "type-graphql";
 

--- a/systems/console-bff/controller/resolvers/toggleService.ts
+++ b/systems/console-bff/controller/resolvers/toggleService.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2023-present, Ukama Inc.
+ * Copyright (c) 2026-present, Ukama Inc.
  */
 import { Arg, Ctx, Mutation, Resolver } from "type-graphql";
 

--- a/systems/console-bff/controller/resolvers/toggleService.ts
+++ b/systems/console-bff/controller/resolvers/toggleService.ts
@@ -9,13 +9,13 @@ import { Arg, Ctx, Mutation, Resolver } from "type-graphql";
 
 import { CBooleanResponse } from "../../common/types";
 import type { AppContext } from "../../server/context";
-import { ToggleRFStatusInputDto } from "./types";
+import { ToggleSiteStatusInputDto } from "./types";
 
 @Resolver()
 export class ToggleServiceResolver {
   @Mutation(() => CBooleanResponse)
   async toggleService(
-    @Arg("data") data: ToggleRFStatusInputDto,
+    @Arg("data") data: ToggleSiteStatusInputDto,
     @Ctx() ctx: AppContext
   ): Promise<CBooleanResponse> {
     const { dataSources } = ctx;

--- a/systems/console-bff/controller/resolvers/types.ts
+++ b/systems/console-bff/controller/resolvers/types.ts
@@ -51,3 +51,12 @@ export class ToggleRFStatusInputDto {
   @Field()
   status: boolean;
 }
+
+@InputType()
+export class ToggleSiteStatusInputDto {
+  @Field()
+  siteId: string;
+
+  @Field()
+  status: boolean;
+}

--- a/systems/console-bff/controller/resolvers/types.ts
+++ b/systems/console-bff/controller/resolvers/types.ts
@@ -60,3 +60,12 @@ export class ToggleSiteStatusInputDto {
   @Field()
   status: boolean;
 }
+
+@InputType()
+export class SetSiteInputDto {
+  @Field()
+  siteId: string;
+
+  @Field()
+  status: boolean;
+}

--- a/systems/console-bff/controller/resolvers/types.ts
+++ b/systems/console-bff/controller/resolvers/types.ts
@@ -44,15 +44,6 @@ export class ToggleInternetSwitchInputDto {
 }
 
 @InputType()
-export class ToggleRFStatusInputDto {
-  @Field()
-  nodeId: string;
-
-  @Field()
-  status: boolean;
-}
-
-@InputType()
 export class ToggleSiteStatusInputDto {
   @Field()
   siteId: string;

--- a/systems/console-bff/controller/resolvers/types.ts
+++ b/systems/console-bff/controller/resolvers/types.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2023-present, Ukama Inc.
+ * Copyright (c) 2026-present, Ukama Inc.
  */
 import { Field, InputType } from "type-graphql";
 

--- a/systems/node/site-controller/pkg/reconciler/reconciler.go
+++ b/systems/node/site-controller/pkg/reconciler/reconciler.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	contpb "github.com/ukama/ukama/systems/node/controller/pb/gen"
 	"github.com/ukama/ukama/systems/node/site-controller/pkg/adapters"
 	"github.com/ukama/ukama/systems/node/site-controller/pkg/db"
 	"github.com/ukama/ukama/systems/node/site-controller/pkg/policy"
@@ -267,20 +268,49 @@ func (r *Reconciler) ensureCriticalPoe(ctx context.Context, siteID string) error
 	}
 	return nil
 }
+// resolveSiteNode returns the node id assigned to a role in the site port map
+// (tower for service, amplifier for radio).
+func (r *Reconciler) resolveSiteNode(siteID, role string) (string, error) {
+	ports, err := r.ports.GetBySite(siteID)
+	if err != nil {
+		return "", err
+	}
+	p, err := policy.FindRole(ports, role)
+	if err != nil {
+		return "", err
+	}
+	if p.NodeID == "" {
+		return "", fmt.Errorf("no node assigned to role %s for site %s", role, siteID)
+	}
+	return p.NodeID, nil
+}
+
 func (r *Reconciler) applyService(ctx context.Context, siteID, state string) error {
-	_, err := r.controllerProvider.GetClient()
+	nodeID, err := r.resolveSiteNode(siteID, policy.RoleTower)
+	if err != nil {
+		return fmt.Errorf("resolve service node: %w", err)
+	}
+	client, err := r.controllerProvider.GetClient()
 	if err != nil {
 		return fmt.Errorf("get controller client: %w", err)
 	}
-	// TODO: Implement controller service call
-	return fmt.Errorf("apply service: %w", err)
+	if _, err := client.ToggleNodeService(ctx, &contpb.ToggleNodeServiceRequest{NodeId: nodeID, State: state}); err != nil {
+		return fmt.Errorf("apply service: %w", err)
+	}
+	return nil
 }
 
 func (r *Reconciler) applyRadio(ctx context.Context, siteID, state string) error {
-	_, err := r.controllerProvider.GetClient()
+	nodeID, err := r.resolveSiteNode(siteID, policy.RoleAmplifier)
+	if err != nil {
+		return fmt.Errorf("resolve radio node: %w", err)
+	}
+	client, err := r.controllerProvider.GetClient()
 	if err != nil {
 		return fmt.Errorf("get controller client: %w", err)
 	}
-	// TODO: Implement controller radio call
-	return fmt.Errorf("apply radio: %w", err)
+	if _, err := client.ToggleRfSwitch(ctx, &contpb.ToggleRfSwitchRequest{NodeId: nodeID, State: state}); err != nil {
+		return fmt.Errorf("apply radio: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Hooks the console-bff `controller` module to the new site-controller integration, so site actions go through the site-controller (which resolves the node and applies the site-level operation lock) instead of hitting thenode-controller directly.