### PR TITLE
aisg implementation and testing for ukama's sector antenna (#1417)

### DIFF
--- a/nodes/apps/aisg/RUN.md
+++ b/nodes/apps/aisg/RUN.md
@@ -215,20 +215,22 @@ rm -f /tmp/aisg-ctrl.sock
   2>&1 | tee /tmp/aisg-real/aisg-ctrl.log
 ```
 
-Send requests with `socat`:
+Send requests with `socat`.  `STDIO,ignoreeof` keeps the receive half open after
+`printf` reaches EOF, which is required for operations such as `scan` that take
+longer than an immediate status request:
 
 ```bash
 printf '{"id":"status-1","type":"get_status","payload":{}}\n' \
-  | socat - UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
+  | socat -T 15 STDIO,ignoreeof UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
 
 printf '{"id":"scan-1","type":"scan","payload":{}}\n' \
-  | socat - UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
+  | socat -T 15 STDIO,ignoreeof UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
 
 printf '{"id":"info-1","type":"get_info","payload":{}}\n' \
-  | socat - UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
+  | socat -T 15 STDIO,ignoreeof UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
 
 printf '{"id":"err-1","type":"get_alarm_status","payload":{}}\n' \
-  | socat - UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
+  | socat -T 15 STDIO,ignoreeof UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
 ```
 
 ## 8. Clean shutdown

--- a/nodes/apps/aisg/RUN.md
+++ b/nodes/apps/aisg/RUN.md
@@ -1,0 +1,243 @@
+# AISG Runbook
+
+Ukama AISG supports one AISG v2 / TS 25.xxx single-antenna RET device.
+AISG v2.0 is the umbrella standard; TS 25.461 / TS 25.462 / TS 25.463 win
+whenever there is conflict.
+
+Use this order:
+
+```text
+1. Protocol golden tests
+2. Strict RET emulator ladder
+3. Read-only hardware ladder
+4. Optional movement hardware ladder
+```
+
+## 1. Build
+
+Expected repo layout:
+
+```text
+nodes/
+  ukamaOS/
+  apps/
+    aisg/
+      aisgd/
+      ctrl/
+      emu/
+```
+
+From `nodes/apps/aisg`:
+
+```bash
+test -f ../../../ukamaOS/config.mk && echo "OK: ukamaOS config found"
+make -C ctrl
+make -C emu
+make -C aisgd
+```
+
+## 2. Protocol-only golden tests
+
+These tests use local stubs and do not need the full Ukama platform build.
+
+```bash
+make protocol-test
+```
+
+They validate HDLC, XID, RETAP framing, return codes, tilt endian, and config
+segment size.
+
+## 3. Strict RET emulator ladder
+
+This validates `aisg-ctrl` against a standards-shaped single-antenna RET device.
+It is the main software gate before touching hardware.
+
+```bash
+tests/scripts/run-ret-emu-ladder.sh
+```
+
+To keep logs:
+
+```bash
+AISG_KEEP_LOGS=1 tests/scripts/run-ret-emu-ladder.sh
+```
+
+The script starts:
+
+```text
+aisg-emu --mode ret --pty <tmp>/aisg-ret0
+aisg-ctrl --backend raw-rs485 --device <tmp>/aisg-ret0
+```
+
+Then runs:
+
+```text
+get_status
+scan/connect
+get_info
+get_alarm_status
+get_tilt before calibration, expecting NotCalibrated
+send_configuration_data
+calibrate
+get_tilt
+set_tilt 0.5
+get_tilt verify
+```
+
+Negative strict-emulator checks:
+
+```bash
+tests/scripts/run-ret-emu-negative.sh
+```
+
+This verifies the emulator does not respond to the old invalid scan and does
+not accept RETAP before address assignment/SNRM.
+
+## 4. Real hardware setup
+
+Real setup:
+
+```text
+Linux machine
+  -> USB-RS485 adapter exposed as /dev/ttyUSB0, /dev/ttyACM0, or /dev/serial/by-id/...
+  -> AISG M16 harness
+  -> real single-antenna RET device
+```
+
+Hardware checklist:
+
+```text
+Power: PSU +10–30 V to AISG Pin6 and PSU return to Pin7
+RS485: A+ adapter terminal to AISG Pin3 (B/Vb); B- to Pin5 (A/Va)
+GND/reference: adapter GND to AISG Pin4; do not bridge Pin4 to Pin7
+Baud: start with 9600 8N1
+Adapter: automatic TX/RX direction control preferred
+Idle polarity: V(Pin3)-V(Pin5) must be positive, preferably above 200 mV
+```
+
+Stop ModemManager during testing:
+
+```bash
+sudo systemctl stop ModemManager 2>/dev/null || true
+```
+
+Give the user serial permissions:
+
+```bash
+sudo usermod -a -G dialout "$USER"
+newgrp dialout
+```
+
+For one-time testing:
+
+```bash
+sudo chmod a+rw /dev/ttyUSB0
+```
+
+## 5. Read-only hardware ladder
+
+Run only read-only operations first:
+
+```bash
+AISG_TTY=/dev/ttyUSB0 tests/scripts/run-real-hw-ladder.sh
+```
+
+The script runs:
+
+```text
+get_status
+scan/connect
+get_info
+get_alarm_status
+```
+
+If this fails but the strict emulator passes, investigate:
+
+```text
+power/current
+RS485 A/B polarity
+RS485 reference/GND
+USB-RS485 direction control
+TX echo vs real RX
+vendor config/pinout quirks
+```
+
+Logs are kept by default under `/tmp/aisg-real.*`.
+
+## 6. Optional movement hardware ladder
+
+Only run movement after read-only hardware tests pass.
+
+```bash
+AISG_TTY=/dev/ttyUSB0 \
+AISG_MOVE=1 \
+AISG_CONFIG_BLOB=/path/to/vendor-antenna.cfg \
+tests/scripts/run-real-hw-ladder.sh
+```
+
+Movement sequence:
+
+```text
+send_configuration_data, if AISG_CONFIG_BLOB is set
+calibrate
+get_tilt
+set_tilt 0.5
+get_tilt verify
+```
+
+Do not repeatedly move the motor until the antenna tilt range and vendor config
+file are confirmed.
+
+## 7. Manual controller socket examples
+
+Create a temporary `aisg-ctrl` config:
+
+```bash
+mkdir -p /tmp/aisg-real
+cat >/tmp/aisg-real/aisg-ctrl.toml <<'EOF_CTRL'
+[service]
+socket = "/tmp/aisg-ctrl.sock"
+
+[backend]
+type = "raw-rs485"
+
+[raw_rs485]
+device = "/dev/ttyUSB0"
+baud = 9600
+EOF_CTRL
+```
+
+Start controller:
+
+```bash
+rm -f /tmp/aisg-ctrl.sock
+./ctrl/aisg-ctrl -c /tmp/aisg-real/aisg-ctrl.toml -l TRACE \
+  2>&1 | tee /tmp/aisg-real/aisg-ctrl.log
+```
+
+Send requests with `socat`:
+
+```bash
+printf '{"id":"status-1","type":"get_status","payload":{}}\n' \
+  | socat - UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
+
+printf '{"id":"scan-1","type":"scan","payload":{}}\n' \
+  | socat - UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
+
+printf '{"id":"info-1","type":"get_info","payload":{}}\n' \
+  | socat - UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
+
+printf '{"id":"err-1","type":"get_alarm_status","payload":{}}\n' \
+  | socat - UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq
+```
+
+## 8. Clean shutdown
+
+Stop `aisgd`, `aisg-ctrl`, and `aisg-emu` with `Ctrl-C`, then remove temporary
+sockets:
+
+```bash
+rm -f /tmp/aisg-ctrl.sock /tmp/aisg-ret0
+```
+
+Power down the external supply only after software is stopped.

--- a/nodes/apps/aisg/ctrl/inc/aisg_v2.h
+++ b/nodes/apps/aisg/ctrl/inc/aisg_v2.h
@@ -47,11 +47,17 @@
 #define AISG_3GPP_RELEASE_ID               0x06
 #define AISG_PROTOCOL_VERSION              0x02
 #define AISG_LINK_TIMEOUT_MS               180000
+#define AISG_LINK_KEEPALIVE_MS             150000
 #define AISG_MIN_TURNAROUND_US             3000
-#define AISG_HDLC_DEFAULT_INFO_MAX         78
+#define AISG_HDLC_DEFAULT_FRAME_MAX        78
+/* N=78 includes address, control and the two FCS octets. */
+#define AISG_HDLC_DEFAULT_INFO_MAX         (AISG_HDLC_DEFAULT_FRAME_MAX - 4)
 
 
 #define AISG_DEFAULT_TIMEOUT_MS            3000
+#define AISG_SCAN_WINDOW_MS                2000
+#define AISG_SCAN_RESPONSE_TIMEOUT_MS      100
+#define AISG_SCAN_RETRY_DELAY_US           25000
 #define AISG_SCAN_EXTRA_TIMEOUT_MS         250
 #define AISG_MAX_RX_ATTEMPTS               4
 
@@ -97,6 +103,7 @@ typedef struct {
     bool hasAisgVersion;
     uint8_t negotiatedAisgVersion;
     size_t maxInfoLen;
+    int64_t lastActivityMs;
     AisgError lastError;
 } AisgBus;
 
@@ -117,6 +124,7 @@ void aisg_v2_bus_reset_link(AisgBus *bus);
 const char *aisg_v2_l2_state_str(AisgL2State state);
 const char *aisg_v2_error_str(AisgError error);
 bool aisg_v2_scan(AisgBus *bus, AisgDevice *device);
+bool aisg_v2_keepalive(AisgBus *bus);
 bool aisg_v2_disconnect(AisgBus *bus);
 bool aisg_v2_send_retap(AisgBus *bus,
                         RetapRequest *request,

--- a/nodes/apps/aisg/ctrl/inc/backend.h
+++ b/nodes/apps/aisg/ctrl/inc/backend.h
@@ -18,6 +18,7 @@ typedef struct Backend Backend;
 typedef struct {
     bool (*open)(Backend *backend);
     void (*close)(Backend *backend);
+    void (*tick)(Backend *backend);
     bool (*execute)(Backend *backend,
                     CtrlRequest *request,
                     CtrlResponse *response);
@@ -32,6 +33,7 @@ struct Backend {
 bool backend_init(Backend *backend, Config *config);
 bool backend_open(Backend *backend);
 void backend_close(Backend *backend);
+void backend_tick(Backend *backend);
 bool backend_execute(Backend *backend,
                      CtrlRequest *request,
                      CtrlResponse *response);

--- a/nodes/apps/aisg/ctrl/inc/serial.h
+++ b/nodes/apps/aisg/ctrl/inc/serial.h
@@ -17,11 +17,14 @@ typedef struct {
     int fd;
     char device[256];
     int baud;
+    /* A closing HDLC flag may also be the opening flag of the next frame. */
+    bool openingFlagPending;
 } SerialPort;
 
 bool serial_open(SerialPort *port, const char *device, int baud);
 void serial_close(SerialPort *port);
 bool serial_write_all(SerialPort *port, const uint8_t *data, size_t len);
+bool serial_discard_input(SerialPort *port);
 bool serial_read_frame(SerialPort *port,
                        uint8_t *buf,
                        size_t size,

--- a/nodes/apps/aisg/ctrl/src/aisg_v2.c
+++ b/nodes/apps/aisg/ctrl/src/aisg_v2.c
@@ -14,37 +14,10 @@
 #include "aisg_v2.h"
 #include "hdlc.h"
 #include "usys_log.h"
+#include "xid.h"
 
 #define AISG_TRACE_BYTES_PER_LINE          16
 #define AISG_POLL_DELAY_US                 50000
-
-#define XID_INFO_MIN_LEN                   3
-#define XID_SCAN_ID_LEN                    AISG_XID_UNIQUE_ID_MAX
-
-typedef struct {
-    bool hasUniqueId;
-    uint8_t uniqueId[AISG_XID_UNIQUE_ID_MAX];
-    size_t uniqueIdLen;
-
-    bool hasAddress;
-    uint8_t address;
-
-    bool hasMask;
-    uint8_t mask[AISG_XID_UNIQUE_ID_MAX];
-    size_t maskLen;
-
-    bool hasDeviceType;
-    uint8_t deviceType;
-
-    bool has3gppRelease;
-    uint8_t release;
-
-    bool hasAisgVersion;
-    uint8_t aisgVersion;
-
-    bool hasVendorCode;
-    uint16_t vendorCode;
-} XidAddressingParams;
 
 static const char *l2_state_name(AisgL2State state)
 {
@@ -232,20 +205,34 @@ static bool read_decoded_frame(AisgBus *bus,
     uint8_t raw[HDLC_MAX_FRAME];
     size_t rawLen;
     int attempt;
+    int waitMs;
+    int64_t startMs;
 
     if (bus == NULL || rxFrame == NULL) {
         return false;
     }
 
+    startMs = monotonic_ms();
+
     for (attempt = 0; attempt < AISG_MAX_RX_ATTEMPTS; attempt++) {
         memset(raw, 0, sizeof(raw));
         rawLen = 0;
+
+        waitMs = remaining_ms(startMs, timeoutMs);
+        if (waitMs <= 0) {
+            usys_log_debug("aisg: RX deadline expired attempt=%d",
+                           attempt + 1);
+            return false;
+        }
 
         if (!serial_read_frame(bus->serial,
                                raw,
                                sizeof(raw),
                                &rawLen,
-                               timeoutMs)) {
+                               waitMs)) {
+            if (rawLen > 0) {
+                log_hex_bytes("RX partial hdlc", raw, rawLen);
+            }
             usys_log_debug("aisg: RX timeout attempt=%d", attempt + 1);
             return false;
         }
@@ -319,291 +306,6 @@ static bool send_frame(AisgBus *bus,
     return read_decoded_frame(bus, txFrame, rxFrame, timeoutMs);
 }
 
-static bool append_xid_param(uint8_t *buf,
-                             size_t size,
-                             size_t *off,
-                             uint8_t pi,
-                             const uint8_t *pv,
-                             size_t pvLen)
-{
-    if (buf == NULL || off == NULL || pv == NULL) {
-        return false;
-    }
-
-    if (pvLen == 0 || pvLen > 255) {
-        return false;
-    }
-
-    if (*off + 2 + pvLen > size) {
-        return false;
-    }
-
-    buf[(*off)++] = pi;
-    buf[(*off)++] = (uint8_t)pvLen;
-    memcpy(&buf[*off], pv, pvLen);
-    *off += pvLen;
-
-    return true;
-}
-
-static bool begin_xid_addressing_info(uint8_t *info,
-                                      size_t size,
-                                      size_t *off)
-{
-    if (info == NULL || off == NULL || size < XID_INFO_MIN_LEN) {
-        return false;
-    }
-
-    *off = 0;
-    info[(*off)++] = AISG_XID_FI;
-    info[(*off)++] = AISG_XID_GI_ADDRESSING;
-    info[(*off)++] = 0x00; /* GL, filled by finish_xid_info(). */
-
-    return true;
-}
-
-static bool finish_xid_info(uint8_t *info, size_t off)
-{
-    size_t gl;
-
-    if (info == NULL || off < XID_INFO_MIN_LEN) {
-        return false;
-    }
-
-    gl = off - XID_INFO_MIN_LEN;
-    if (gl > 255) {
-        return false;
-    }
-
-    info[2] = (uint8_t)gl;
-
-    return true;
-}
-
-static bool build_xid_scan_info(uint8_t *info, size_t size, size_t *len)
-{
-    uint8_t uid[XID_SCAN_ID_LEN];
-    uint8_t mask[XID_SCAN_ID_LEN];
-    size_t off;
-
-    if (info == NULL || len == NULL) {
-        return false;
-    }
-
-    memset(uid, 0, sizeof(uid));
-    memset(mask, 0, sizeof(mask));
-
-    if (!begin_xid_addressing_info(info, size, &off)) {
-        return false;
-    }
-
-    if (!append_xid_param(info,
-                          size,
-                          &off,
-                          AISG_XID_PI_UNIQUE_ID,
-                          uid,
-                          sizeof(uid))) {
-        return false;
-    }
-
-    if (!append_xid_param(info,
-                          size,
-                          &off,
-                          AISG_XID_PI_BIT_MASK,
-                          mask,
-                          sizeof(mask))) {
-        return false;
-    }
-
-    if (!finish_xid_info(info, off)) {
-        return false;
-    }
-
-    *len = off;
-
-    return true;
-}
-
-static bool build_xid_assign_info(const AisgDevice *device,
-                                  uint8_t assignedAddress,
-                                  uint8_t *info,
-                                  size_t size,
-                                  size_t *len)
-{
-    uint8_t address[1];
-    uint8_t deviceType[1];
-    size_t off;
-
-    if (device == NULL || info == NULL || len == NULL) {
-        return false;
-    }
-
-    if (device->uniqueIdLen == 0 ||
-        device->uniqueIdLen > AISG_XID_UNIQUE_ID_MAX) {
-        return false;
-    }
-
-    address[0] = assignedAddress;
-    deviceType[0] = AISG_SUPPORTED_DEVICE_TYPE;
-
-    if (!begin_xid_addressing_info(info, size, &off)) {
-        return false;
-    }
-
-    if (!append_xid_param(info,
-                          size,
-                          &off,
-                          AISG_XID_PI_UNIQUE_ID,
-                          device->uniqueId,
-                          device->uniqueIdLen)) {
-        return false;
-    }
-
-    if (!append_xid_param(info,
-                          size,
-                          &off,
-                          AISG_XID_PI_HDLC_ADDRESS,
-                          address,
-                          sizeof(address))) {
-        return false;
-    }
-
-    if (!append_xid_param(info,
-                          size,
-                          &off,
-                          AISG_XID_PI_DEVICE_TYPE,
-                          deviceType,
-                          sizeof(deviceType))) {
-        return false;
-    }
-
-    if (!finish_xid_info(info, off)) {
-        return false;
-    }
-
-    *len = off;
-
-    return true;
-}
-
-static bool parse_xid_addressing_info(const uint8_t *info,
-                                      size_t infoLen,
-                                      XidAddressingParams *params)
-{
-    size_t pos;
-    size_t end;
-    uint8_t gl;
-    uint8_t pi;
-    uint8_t pl;
-    const uint8_t *pv;
-
-    if (info == NULL || params == NULL) {
-        return false;
-    }
-
-    memset(params, 0, sizeof(*params));
-
-    if (infoLen < XID_INFO_MIN_LEN) {
-        return false;
-    }
-
-    if (info[0] != AISG_XID_FI || info[1] != AISG_XID_GI_ADDRESSING) {
-        return false;
-    }
-
-    gl = info[2];
-    if ((size_t)gl > infoLen - XID_INFO_MIN_LEN) {
-        return false;
-    }
-
-    pos = XID_INFO_MIN_LEN;
-    end = XID_INFO_MIN_LEN + (size_t)gl;
-
-    while (pos < end) {
-        if (pos + 2 > end) {
-            return false;
-        }
-
-        pi = info[pos++];
-        pl = info[pos++];
-
-        if (pl == 0 || pos + (size_t)pl > end) {
-            return false;
-        }
-
-        pv = &info[pos];
-        pos += (size_t)pl;
-
-        switch (pi) {
-        case AISG_XID_PI_UNIQUE_ID:
-            if (pl > AISG_XID_UNIQUE_ID_MAX) {
-                return false;
-            }
-            params->hasUniqueId = true;
-            params->uniqueIdLen = pl;
-            memcpy(params->uniqueId, pv, pl);
-            break;
-
-        case AISG_XID_PI_HDLC_ADDRESS:
-            if (pl != 1) {
-                return false;
-            }
-            params->hasAddress = true;
-            params->address = pv[0];
-            break;
-
-        case AISG_XID_PI_BIT_MASK:
-            if (pl > AISG_XID_UNIQUE_ID_MAX) {
-                return false;
-            }
-            params->hasMask = true;
-            params->maskLen = pl;
-            memcpy(params->mask, pv, pl);
-            break;
-
-        case AISG_XID_PI_DEVICE_TYPE:
-            if (pl != 1) {
-                return false;
-            }
-            params->hasDeviceType = true;
-            params->deviceType = pv[0];
-            break;
-
-        case AISG_XID_PI_3GPP_RELEASE:
-            if (pl != 1) {
-                return false;
-            }
-            params->has3gppRelease = true;
-            params->release = pv[0];
-            break;
-
-        case AISG_XID_PI_AISG_VERSION:
-            if (pl != 1) {
-                return false;
-            }
-            params->hasAisgVersion = true;
-            params->aisgVersion = pv[0];
-            break;
-
-        case AISG_XID_PI_VENDOR_CODE:
-            if (pl != 2) {
-                return false;
-            }
-            params->hasVendorCode = true;
-            params->vendorCode = (uint16_t)(((uint16_t)pv[0] << 8) | pv[1]);
-            break;
-
-        default:
-            usys_log_debug("aisg: XID ignoring unsupported PI=0x%02X len=%u",
-                           pi,
-                           pl);
-            break;
-        }
-    }
-
-    return pos == end;
-}
-
 static void apply_xid_params_to_device(const XidAddressingParams *params,
                                        AisgDevice *device)
 {
@@ -648,7 +350,9 @@ static bool read_extra_scan_response(AisgBus *bus)
     return true;
 }
 
-static bool xid_scan_single(AisgBus *bus, AisgDevice *device)
+static bool xid_scan_once(AisgBus *bus,
+                          AisgDevice *device,
+                          int responseTimeoutMs)
 {
     HdlcFrame tx;
     HdlcFrame rx;
@@ -665,19 +369,18 @@ static bool xid_scan_single(AisgBus *bus, AisgDevice *device)
     tx.address = AISG_ADDR_BROADCAST;
     tx.control = hdlc_xid_ctrl(true);
 
-    if (!build_xid_scan_info(tx.info, sizeof(tx.info), &infoLen)) {
+    if (!xid_build_scan_info(tx.info, sizeof(tx.info), &infoLen)) {
         usys_log_debug("aisg: XID scan build failed");
         return false;
     }
     tx.infoLen = infoLen;
 
     usys_log_debug("aisg: XID scan start uid_len=%d mask=all-zero scope=%s",
-                   XID_SCAN_ID_LEN,
+                   AISG_XID_SCAN_ID_LEN,
                    AISG_SCOPE_NAME);
 
-    if (!send_frame(bus, &tx, &rx, AISG_DEFAULT_TIMEOUT_MS)) {
-        usys_log_debug("aisg: XID scan failed: no valid response");
-        set_error(bus, AISG_ERROR_TRANSPORT);
+    if (!send_frame(bus, &tx, &rx, responseTimeoutMs)) {
+        usys_log_debug("aisg: XID scan attempt: no valid response");
         return false;
     }
 
@@ -687,7 +390,7 @@ static bool xid_scan_single(AisgBus *bus, AisgDevice *device)
         return false;
     }
 
-    if (!parse_xid_addressing_info(rx.info, rx.infoLen, &params)) {
+    if (!xid_parse_addressing_info(rx.info, rx.infoLen, &params)) {
         usys_log_debug("aisg: XID scan failed: malformed XID response");
         return false;
     }
@@ -731,6 +434,59 @@ static bool xid_scan_single(AisgBus *bus, AisgDevice *device)
     return true;
 }
 
+static bool xid_scan_single(AisgBus *bus, AisgDevice *device)
+{
+    int64_t startMs;
+    int waitMs;
+    unsigned int attempt;
+
+    if (bus == NULL || device == NULL) {
+        return false;
+    }
+
+    startMs = monotonic_ms();
+    attempt = 0;
+
+    usys_log_debug("aisg: continuous XID scan window=%dms response_timeout=%dms",
+                   AISG_SCAN_WINDOW_MS,
+                   AISG_SCAN_RESPONSE_TIMEOUT_MS);
+
+    for (;;) {
+        waitMs = remaining_ms(startMs, AISG_SCAN_WINDOW_MS);
+        if (waitMs <= 0) break;
+        if (waitMs > AISG_SCAN_RESPONSE_TIMEOUT_MS) {
+            waitMs = AISG_SCAN_RESPONSE_TIMEOUT_MS;
+        }
+
+        attempt++;
+        usys_log_debug("aisg: XID scan attempt=%u elapsed_ms=%lld",
+                       attempt,
+                       (long long)(monotonic_ms() - startMs));
+
+        if (xid_scan_once(bus, device, waitMs)) {
+            usys_log_debug("aisg: XID scan acquired device attempt=%u",
+                           attempt);
+            return true;
+        }
+
+        if (device->unsupported ||
+            bus->lastError == AISG_ERROR_MULTIPLE_DEVICES ||
+            bus->lastError == AISG_ERROR_UNSUPPORTED_DEVICE_TYPE) {
+            return false;
+        }
+
+        if (remaining_ms(startMs, AISG_SCAN_WINDOW_MS) <= 0) break;
+        usleep(AISG_SCAN_RETRY_DELAY_US);
+    }
+
+    set_error(bus, AISG_ERROR_TIMEOUT);
+    usys_log_debug("aisg: continuous XID scan timed out attempts=%u window=%dms",
+                   attempt,
+                   AISG_SCAN_WINDOW_MS);
+
+    return false;
+}
+
 static bool xid_assign_address(AisgBus *bus, AisgDevice *device)
 {
     HdlcFrame tx;
@@ -748,8 +504,12 @@ static bool xid_assign_address(AisgBus *bus, AisgDevice *device)
     tx.address = AISG_ADDR_BROADCAST;
     tx.control = hdlc_xid_ctrl(true);
 
-    if (!build_xid_assign_info(device,
+    if (!xid_build_assign_info(device->uniqueId,
+                               device->uniqueIdLen,
                                AISG_ADDR_ASSIGNED,
+                               AISG_SUPPORTED_DEVICE_TYPE,
+                               false,
+                               0,
                                tx.info,
                                sizeof(tx.info),
                                &infoLen)) {
@@ -782,7 +542,7 @@ static bool xid_assign_address(AisgBus *bus, AisgDevice *device)
         return false;
     }
 
-    if (!parse_xid_addressing_info(rx.info, rx.infoLen, &params)) {
+    if (!xid_parse_addressing_info(rx.info, rx.infoLen, &params)) {
         usys_log_debug("aisg: XID address assignment failed: malformed response");
         return false;
     }
@@ -825,38 +585,6 @@ static bool xid_assign_address(AisgBus *bus, AisgDevice *device)
     return true;
 }
 
-static bool build_xid_one_octet_info(uint8_t pi,
-                                     uint8_t value,
-                                     uint8_t *info,
-                                     size_t size,
-                                     size_t *len)
-{
-    uint8_t pv[1];
-    size_t off;
-
-    if (info == NULL || len == NULL) {
-        return false;
-    }
-
-    pv[0] = value;
-
-    if (!begin_xid_addressing_info(info, size, &off)) {
-        return false;
-    }
-
-    if (!append_xid_param(info, size, &off, pi, pv, sizeof(pv))) {
-        return false;
-    }
-
-    if (!finish_xid_info(info, off)) {
-        return false;
-    }
-
-    *len = off;
-
-    return true;
-}
-
 static bool xid_negotiate_one_octet(AisgBus *bus,
                                     const char *name,
                                     uint8_t pi,
@@ -887,7 +615,7 @@ static bool xid_negotiate_one_octet(AisgBus *bus,
     tx.address = bus->deviceAddress;
     tx.control = hdlc_xid_ctrl(true);
 
-    if (!build_xid_one_octet_info(pi,
+    if (!xid_build_one_octet_info(pi,
                                   offered,
                                   tx.info,
                                   sizeof(tx.info),
@@ -923,7 +651,7 @@ static bool xid_negotiate_one_octet(AisgBus *bus,
         return false;
     }
 
-    if (!parse_xid_addressing_info(rx.info, rx.infoLen, &params)) {
+    if (!xid_parse_addressing_info(rx.info, rx.infoLen, &params)) {
         usys_log_debug("aisg: %s negotiation failed: malformed XID response",
                        name);
         return false;
@@ -947,7 +675,17 @@ static bool xid_negotiate_one_octet(AisgBus *bus,
         return false;
     }
 
-    if (value != offered) {
+    if (pi == AISG_XID_PI_3GPP_RELEASE) {
+        /* TS 25.462 permits the secondary to select a lower release. */
+        if (value == 0 || value > offered) {
+            usys_log_debug("aisg: %s negotiation failed: accepted=0x%02X offered=0x%02X",
+                           name,
+                           value,
+                           offered);
+            set_error(bus, AISG_ERROR_UNSUPPORTED_PROTOCOL_VERSION);
+            return false;
+        }
+    } else if (value != offered) {
         usys_log_debug("aisg: %s negotiation failed: accepted=0x%02X expected=0x%02X",
                        name,
                        value,
@@ -1063,6 +801,7 @@ static bool l2_establish_link(AisgBus *bus)
     bus->state = AISG_L2_CONNECTED;
     bus->ns = 0;
     bus->nr = 0;
+    bus->lastActivityMs = monotonic_ms();
 
     usys_log_debug("aisg: link establishment OK state=%s addr=0x%02X",
                    l2_state_name(bus->state),
@@ -1085,6 +824,7 @@ void aisg_v2_bus_init(AisgBus *bus, SerialPort *serial)
     bus->nr            = 0;
     bus->state         = AISG_L2_NO_ADDRESS;
     bus->maxInfoLen    = AISG_HDLC_DEFAULT_INFO_MAX;
+    bus->lastActivityMs = 0;
     bus->lastError     = AISG_ERROR_NONE;
 
     usys_log_debug("aisg: init scope=%s supported_device_type=0x%02X state=%s",
@@ -1107,6 +847,7 @@ void aisg_v2_bus_reset_link(AisgBus *bus)
     bus->deviceAddress = AISG_ADDR_DEFAULT;
     bus->state = AISG_L2_NO_ADDRESS;
     bus->maxInfoLen = AISG_HDLC_DEFAULT_INFO_MAX;
+    bus->lastActivityMs = 0;
     bus->lastError = AISG_ERROR_NONE;
 }
 
@@ -1127,7 +868,14 @@ bool aisg_v2_scan(AisgBus *bus, AisgDevice *device)
     bus->hasAisgVersion = false;
     bus->negotiatedAisgVersion = 0;
     bus->maxInfoLen = AISG_HDLC_DEFAULT_INFO_MAX;
+    bus->lastActivityMs = 0;
     bus->lastError = AISG_ERROR_NONE;
+
+    if (!serial_discard_input(bus->serial)) {
+        usys_log_debug("aisg: failed to discard stale serial input before scan");
+        set_error(bus, AISG_ERROR_TRANSPORT);
+        return false;
+    }
 
     if (!xid_scan_single(bus, device)) {
         usys_log_debug("aisg: scan failed");
@@ -1316,6 +1064,104 @@ static bool l2_poll_for_i_response(AisgBus *bus,
     }
 }
 
+static void l2_mark_link_lost(AisgBus *bus, AisgError error)
+{
+    if (bus == NULL) return;
+
+    bus->deviceAddress = AISG_ADDR_DEFAULT;
+    bus->ns = 0;
+    bus->nr = 0;
+    bus->state = AISG_L2_NO_ADDRESS;
+    bus->has3gppRelease = false;
+    bus->negotiated3gppRelease = 0;
+    bus->hasAisgVersion = false;
+    bus->negotiatedAisgVersion = 0;
+    bus->lastActivityMs = 0;
+    set_error(bus, error);
+}
+
+bool aisg_v2_keepalive(AisgBus *bus)
+{
+    HdlcFrame tx;
+    HdlcFrame rx;
+    int64_t nowMs;
+
+    if (bus == NULL || bus->state != AISG_L2_CONNECTED) {
+        if (bus != NULL) set_error(bus, AISG_ERROR_LINK_NOT_CONNECTED);
+        return false;
+    }
+
+    nowMs = monotonic_ms();
+    if (bus->lastActivityMs <= 0) {
+        bus->lastActivityMs = nowMs;
+        return true;
+    }
+
+    if (nowMs - bus->lastActivityMs < AISG_LINK_KEEPALIVE_MS) {
+        return true;
+    }
+
+    memset(&tx, 0, sizeof(tx));
+    memset(&rx, 0, sizeof(rx));
+
+    tx.address = bus->deviceAddress;
+    tx.control = hdlc_rr_ctrl(bus->nr, true);
+
+    usys_log_debug("aisg: link keepalive RR addr=0x%02X nr=%u idle_ms=%lld",
+                   bus->deviceAddress,
+                   bus->nr,
+                   (long long)(nowMs - bus->lastActivityMs));
+
+    if (!send_frame(bus, &tx, &rx, AISG_DEFAULT_TIMEOUT_MS)) {
+        usys_log_debug("aisg: link keepalive timed out; link lost");
+        l2_mark_link_lost(bus, AISG_ERROR_TIMEOUT);
+        return false;
+    }
+
+    if (rx.address != tx.address ||
+        (!hdlc_is_rr(rx.control) && !hdlc_is_rnr(rx.control)) ||
+        !hdlc_poll_final(rx.control) ||
+        hdlc_nr(rx.control) != bus->ns ||
+        rx.infoLen != 0) {
+        usys_log_debug("aisg: invalid keepalive response addr=0x%02X ctrl=0x%02X nr=%u info_len=%zu",
+                       rx.address,
+                       rx.control,
+                       hdlc_nr(rx.control),
+                       rx.infoLen);
+        l2_mark_link_lost(bus, AISG_ERROR_PROTOCOL);
+        return false;
+    }
+
+    bus->lastActivityMs = monotonic_ms();
+    set_error(bus,
+              hdlc_is_rnr(rx.control) ? AISG_ERROR_RECEIVER_NOT_READY
+                                      : AISG_ERROR_NONE);
+
+    return true;
+}
+
+static bool l2_acknowledge_i_response(AisgBus *bus)
+{
+    HdlcFrame ack;
+
+    if (bus == NULL || bus->state != AISG_L2_CONNECTED) return false;
+
+    memset(&ack, 0, sizeof(ack));
+    ack.address = bus->deviceAddress;
+    ack.control = hdlc_rr_ctrl(bus->nr, false);
+
+    usys_log_debug("aisg: acknowledging secondary I-frame RR nr=%u",
+                   bus->nr);
+
+    if (!send_frame(bus, &ack, NULL, AISG_DEFAULT_TIMEOUT_MS)) {
+        set_error(bus, AISG_ERROR_TRANSPORT);
+        return false;
+    }
+
+    bus->lastActivityMs = monotonic_ms();
+    return true;
+}
+
 bool aisg_v2_disconnect(AisgBus *bus)
 {
     HdlcFrame tx;
@@ -1373,6 +1219,10 @@ bool aisg_v2_send_retap(AisgBus *bus,
         usys_log_debug("aisg: RETAP rejected: link state=%s expected=CONNECTED",
                        l2_state_name(bus->state));
         set_error(bus, AISG_ERROR_LINK_NOT_CONNECTED);
+        return false;
+    }
+
+    if (!aisg_v2_keepalive(bus)) {
         return false;
     }
 
@@ -1441,6 +1291,15 @@ bool aisg_v2_send_retap(AisgBus *bus,
         set_error(bus, AISG_ERROR_PROTOCOL);
         return false;
     }
+
+    if (request->procedure == RETAP_PROC_RESET_SOFTWARE &&
+        !l2_acknowledge_i_response(bus)) {
+        usys_log_debug("aisg: failed to acknowledge ResetSoftware response");
+        return false;
+    }
+
+    bus->lastActivityMs = monotonic_ms();
+    bus->lastError = AISG_ERROR_NONE;
 
     usys_log_debug("aisg: RETAP RX procedure=0x%02X return=0x%02X failure=0x%02X data_len=%zu",
                    response->procedure,

--- a/nodes/apps/aisg/ctrl/src/aisg_v2.c
+++ b/nodes/apps/aisg/ctrl/src/aisg_v2.c
@@ -200,7 +200,8 @@ static bool same_frame(const HdlcFrame *a, const HdlcFrame *b)
 static bool read_decoded_frame(AisgBus *bus,
                                const HdlcFrame *txFrame,
                                HdlcFrame *rxFrame,
-                               int timeoutMs)
+                               int timeoutMs,
+                               bool allowIdenticalResponse)
 {
     uint8_t raw[HDLC_MAX_FRAME];
     size_t rawLen;
@@ -249,9 +250,13 @@ static bool read_decoded_frame(AisgBus *bus,
         log_frame("RX frame", rxFrame);
 
         if (txFrame != NULL && same_frame(txFrame, rxFrame)) {
-            usys_log_debug("aisg: RX rejected local echo attempt=%d",
-                           attempt + 1);
-            continue;
+            if (!allowIdenticalResponse) {
+                usys_log_debug("aisg: RX rejected local echo attempt=%d",
+                               attempt + 1);
+                continue;
+            }
+
+            usys_log_debug("aisg: RX accepted identical XID negotiation response");
         }
 
         return true;
@@ -263,10 +268,11 @@ static bool read_decoded_frame(AisgBus *bus,
     return false;
 }
 
-static bool send_frame(AisgBus *bus,
-                       const HdlcFrame *txFrame,
-                       HdlcFrame *rxFrame,
-                       int timeoutMs)
+static bool send_frame_with_policy(AisgBus *bus,
+                                   const HdlcFrame *txFrame,
+                                   HdlcFrame *rxFrame,
+                                   int timeoutMs,
+                                   bool allowIdenticalResponse)
 {
     uint8_t raw[HDLC_MAX_FRAME];
     size_t rawLen;
@@ -303,7 +309,23 @@ static bool send_frame(AisgBus *bus,
         return true;
     }
 
-    return read_decoded_frame(bus, txFrame, rxFrame, timeoutMs);
+    return read_decoded_frame(bus,
+                              txFrame,
+                              rxFrame,
+                              timeoutMs,
+                              allowIdenticalResponse);
+}
+
+static bool send_frame(AisgBus *bus,
+                       const HdlcFrame *txFrame,
+                       HdlcFrame *rxFrame,
+                       int timeoutMs)
+{
+    return send_frame_with_policy(bus,
+                                  txFrame,
+                                  rxFrame,
+                                  timeoutMs,
+                                  false);
 }
 
 static void apply_xid_params_to_device(const XidAddressingParams *params,
@@ -338,7 +360,11 @@ static bool read_extra_scan_response(AisgBus *bus)
 
     memset(&extra, 0, sizeof(extra));
 
-    if (!read_decoded_frame(bus, NULL, &extra, AISG_SCAN_EXTRA_TIMEOUT_MS)) {
+    if (!read_decoded_frame(bus,
+                            NULL,
+                            &extra,
+                            AISG_SCAN_EXTRA_TIMEOUT_MS,
+                            false)) {
         return false;
     }
 
@@ -650,7 +676,17 @@ static bool xid_negotiate_one_octet(AisgBus *bus,
                    offered,
                    bus->deviceAddress);
 
-    if (!send_frame(bus, &tx, &rx, AISG_DEFAULT_TIMEOUT_MS)) {
+    /*
+     * TS 25.462 Annex B explicitly permits the secondary to accept a
+     * proposed XID value by returning the same value.  For this exchange the
+     * complete response can therefore be byte-for-byte identical to the
+     * command; it must not be discarded as generic adapter loopback.
+     */
+    if (!send_frame_with_policy(bus,
+                                &tx,
+                                &rx,
+                                AISG_DEFAULT_TIMEOUT_MS,
+                                true)) {
         usys_log_debug("aisg: %s negotiation failed: no response", name);
         return false;
     }

--- a/nodes/apps/aisg/ctrl/src/aisg_v2.c
+++ b/nodes/apps/aisg/ctrl/src/aisg_v2.c
@@ -256,7 +256,7 @@ static bool read_decoded_frame(AisgBus *bus,
                 continue;
             }
 
-            usys_log_debug("aisg: RX accepted identical XID negotiation response");
+            usys_log_debug("aisg: RX accepted protocol-valid identical response");
         }
 
         return true;
@@ -857,12 +857,114 @@ static bool l2_establish_link(AisgBus *bus)
     bus->ns = 0;
     bus->nr = 0;
     bus->lastActivityMs = monotonic_ms();
+    bus->lastError = AISG_ERROR_NONE;
 
     usys_log_debug("aisg: link establishment OK state=%s addr=0x%02X",
                    l2_state_name(bus->state),
                    bus->deviceAddress);
 
     return true;
+}
+
+static bool recover_assigned_device(AisgBus *bus, AisgDevice *device)
+{
+    AisgError recoveryError;
+    HdlcFrame tx;
+    HdlcFrame rx;
+
+    if (bus == NULL || device == NULL) {
+        return false;
+    }
+
+    /*
+     * This controller supports one RET and always assigns address 0x01.  A
+     * controller restart can therefore leave the secondary addressed (or
+     * connected) while local state has returned to NO_ADDRESS.  Such a
+     * secondary correctly ignores a no-address device scan until its three
+     * minute timer expires.  DISC first normalizes either CONNECTED or
+     * ADDRESS_ASSIGNED to ADDRESS_ASSIGNED, after which version negotiation
+     * and SNRM can be repeated without power-cycling the antenna.
+     */
+    usys_log_debug("aisg: attempting assigned-address recovery addr=0x%02X",
+                   AISG_ADDR_ASSIGNED);
+
+    bus->deviceAddress = AISG_ADDR_ASSIGNED;
+    bus->state = AISG_L2_ADDRESS_ASSIGNED;
+    bus->ns = 0;
+    bus->nr = 0;
+    bus->has3gppRelease = false;
+    bus->negotiated3gppRelease = 0;
+    bus->hasAisgVersion = false;
+    bus->negotiatedAisgVersion = 0;
+    bus->lastActivityMs = 0;
+    bus->lastError = AISG_ERROR_NONE;
+
+    memset(&tx, 0, sizeof(tx));
+    memset(&rx, 0, sizeof(rx));
+    tx.address = AISG_ADDR_ASSIGNED;
+    tx.control = hdlc_disc_ctrl(true);
+
+    usys_log_debug("aisg: assigned-address recovery DISC addr=0x%02X",
+                   tx.address);
+    if (!send_frame(bus, &tx, &rx, AISG_DEFAULT_TIMEOUT_MS)) {
+        set_error(bus, AISG_ERROR_TIMEOUT);
+        goto recovery_failed;
+    }
+
+    if (rx.address != tx.address ||
+        (!hdlc_is_ua(rx.control) && !hdlc_is_dm(rx.control)) ||
+        !hdlc_poll_final(rx.control) ||
+        rx.infoLen != 0) {
+        usys_log_debug("aisg: assigned-address recovery DISC response invalid addr=0x%02X ctrl=0x%02X info_len=%zu",
+                       rx.address,
+                       rx.control,
+                       rx.infoLen);
+        set_error(bus, AISG_ERROR_PROTOCOL);
+        goto recovery_failed;
+    }
+
+    bus->state = AISG_L2_ADDRESS_ASSIGNED;
+    bus->ns = 0;
+    bus->nr = 0;
+
+    if (!xid_negotiate_3gpp_release(bus) ||
+        !xid_negotiate_aisg_version(bus) ||
+        !l2_establish_link(bus)) {
+        goto recovery_failed;
+    }
+
+    memset(device, 0, sizeof(*device));
+    device->present = true;
+    device->address = AISG_ADDR_ASSIGNED;
+    device->deviceType = AISG_SUPPORTED_DEVICE_TYPE;
+    snprintf(device->model, sizeof(device->model), "%s", "single-ret");
+
+    bus->lastError = AISG_ERROR_NONE;
+    usys_log_debug("aisg: assigned-address recovery OK state=%s addr=0x%02X",
+                   l2_state_name(bus->state),
+                   bus->deviceAddress);
+    return true;
+
+recovery_failed:
+    recoveryError = bus->lastError;
+    if (recoveryError == AISG_ERROR_NONE) {
+        recoveryError = AISG_ERROR_TIMEOUT;
+    }
+
+    bus->deviceAddress = AISG_ADDR_DEFAULT;
+    bus->state = AISG_L2_NO_ADDRESS;
+    bus->ns = 0;
+    bus->nr = 0;
+    bus->has3gppRelease = false;
+    bus->negotiated3gppRelease = 0;
+    bus->hasAisgVersion = false;
+    bus->negotiatedAisgVersion = 0;
+    bus->lastActivityMs = 0;
+    bus->lastError = recoveryError;
+
+    usys_log_debug("aisg: assigned-address recovery failed error=%s",
+                   aisg_v2_error_str(recoveryError));
+    return false;
 }
 
 void aisg_v2_bus_init(AisgBus *bus, SerialPort *serial)
@@ -912,6 +1014,13 @@ bool aisg_v2_scan(AisgBus *bus, AisgDevice *device)
         return false;
     }
 
+    if (bus->state == AISG_L2_CONNECTED && device->present) {
+        bus->lastError = AISG_ERROR_NONE;
+        usys_log_debug("aisg: scan reused existing connected device addr=0x%02X",
+                       bus->deviceAddress);
+        return true;
+    }
+
     memset(device, 0, sizeof(AisgDevice));
 
     bus->deviceAddress = AISG_ADDR_DEFAULT;
@@ -933,6 +1042,10 @@ bool aisg_v2_scan(AisgBus *bus, AisgDevice *device)
     }
 
     if (!xid_scan_single(bus, device)) {
+        if (bus->lastError == AISG_ERROR_TIMEOUT &&
+            recover_assigned_device(bus, device)) {
+            return true;
+        }
         usys_log_debug("aisg: scan failed");
         return false;
     }
@@ -1112,7 +1225,8 @@ static bool l2_poll_for_i_response(AisgBus *bus,
                        bus->nr,
                        waitMs);
 
-        if (!send_frame(bus, &poll, rx, waitMs)) {
+        /* An RR response may legitimately be identical to the RR poll. */
+        if (!send_frame_with_policy(bus, &poll, rx, waitMs, true)) {
             set_error(bus, AISG_ERROR_TIMEOUT);
             return false;
         }
@@ -1134,6 +1248,8 @@ static void l2_mark_link_lost(AisgBus *bus, AisgError error)
     bus->lastActivityMs = 0;
     set_error(bus, error);
 }
+
+static bool l2_acknowledge_i_response(AisgBus *bus);
 
 bool aisg_v2_keepalive(AisgBus *bus)
 {
@@ -1167,17 +1283,18 @@ bool aisg_v2_keepalive(AisgBus *bus)
                    bus->nr,
                    (long long)(nowMs - bus->lastActivityMs));
 
-    if (!send_frame(bus, &tx, &rx, AISG_DEFAULT_TIMEOUT_MS)) {
+    /* An RR response may legitimately be byte-for-byte identical to the poll. */
+    if (!send_frame_with_policy(bus,
+                                &tx,
+                                &rx,
+                                AISG_DEFAULT_TIMEOUT_MS,
+                                true)) {
         usys_log_debug("aisg: link keepalive timed out; link lost");
         l2_mark_link_lost(bus, AISG_ERROR_TIMEOUT);
         return false;
     }
 
-    if (rx.address != tx.address ||
-        (!hdlc_is_rr(rx.control) && !hdlc_is_rnr(rx.control)) ||
-        !hdlc_poll_final(rx.control) ||
-        hdlc_nr(rx.control) != bus->ns ||
-        rx.infoLen != 0) {
+    if (rx.address != tx.address || !hdlc_poll_final(rx.control)) {
         usys_log_debug("aisg: invalid keepalive response addr=0x%02X ctrl=0x%02X nr=%u info_len=%zu",
                        rx.address,
                        rx.control,
@@ -1187,10 +1304,42 @@ bool aisg_v2_keepalive(AisgBus *bus)
         return false;
     }
 
+    if (hdlc_is_i_frame(rx.control)) {
+        if (hdlc_nr(rx.control) != bus->ns ||
+            hdlc_ns(rx.control) != bus->nr) {
+            usys_log_debug("aisg: keepalive I-frame sequence invalid ns=%u expected=%u nr=%u expected=%u",
+                           hdlc_ns(rx.control),
+                           bus->nr,
+                           hdlc_nr(rx.control),
+                           bus->ns);
+            l2_mark_link_lost(bus, AISG_ERROR_PROTOCOL);
+            return false;
+        }
+
+        bus->nr = (uint8_t)((hdlc_ns(rx.control) + 1) & 0x07);
+        usys_log_debug("aisg: keepalive received unsolicited I-frame info_len=%zu next_nr=%u",
+                       rx.infoLen,
+                       bus->nr);
+        if (!l2_acknowledge_i_response(bus)) {
+            l2_mark_link_lost(bus, AISG_ERROR_TRANSPORT);
+            return false;
+        }
+    } else if ((!hdlc_is_rr(rx.control) && !hdlc_is_rnr(rx.control)) ||
+               hdlc_nr(rx.control) != bus->ns ||
+               rx.infoLen != 0) {
+        usys_log_debug("aisg: invalid keepalive supervisory response ctrl=0x%02X nr=%u expected=%u info_len=%zu",
+                       rx.control,
+                       hdlc_nr(rx.control),
+                       bus->ns,
+                       rx.infoLen);
+        l2_mark_link_lost(bus, AISG_ERROR_PROTOCOL);
+        return false;
+    }
+
     bus->lastActivityMs = monotonic_ms();
-    set_error(bus,
-              hdlc_is_rnr(rx.control) ? AISG_ERROR_RECEIVER_NOT_READY
-                                      : AISG_ERROR_NONE);
+    set_error(bus, hdlc_is_rnr(rx.control)
+                       ? AISG_ERROR_RECEIVER_NOT_READY
+                       : AISG_ERROR_NONE);
 
     return true;
 }

--- a/nodes/apps/aisg/ctrl/src/aisg_v2.c
+++ b/nodes/apps/aisg/ctrl/src/aisg_v2.c
@@ -395,13 +395,32 @@ static bool xid_scan_once(AisgBus *bus,
         return false;
     }
 
-    if (!params.hasUniqueId || !params.hasAddress || !params.hasDeviceType) {
+    if (!params.hasUniqueId || !params.hasDeviceType) {
         usys_log_debug("aisg: XID scan failed: missing required response "
-                       "fields uid=%u addr=%u type=%u",
+                       "fields uid=%u type=%u",
                        params.hasUniqueId ? 1 : 0,
-                       params.hasAddress ? 1 : 0,
                        params.hasDeviceType ? 1 : 0);
         return false;
+    }
+
+    /*
+     * TS 25.462 says a scan response contains PI=2 (HDLC Address), but
+     * deployed RETs exist which omit PI=2 and only put their address in the
+     * CRC-protected HDLC address field. Accept that response and continue to
+     * the normal address-assignment exchange.
+     */
+    if (!params.hasAddress) {
+        params.hasAddress = true;
+        params.address = rx.address;
+        usys_log_debug("aisg: XID scan response omitted PI=2; using HDLC "
+                       "source address=0x%02X",
+                       rx.address);
+    } else if (params.address != rx.address) {
+        usys_log_debug("aisg: XID scan address mismatch PI2=0x%02X "
+                       "HDLC=0x%02X; using HDLC source address",
+                       params.address,
+                       rx.address);
+        params.address = rx.address;
     }
 
     apply_xid_params_to_device(&params, device);

--- a/nodes/apps/aisg/ctrl/src/backend.c
+++ b/nodes/apps/aisg/ctrl/src/backend.c
@@ -38,6 +38,12 @@ void backend_close(Backend *backend) {
     }
 }
 
+void backend_tick(Backend *backend) {
+    if (backend != NULL && backend->ops.tick != NULL) {
+        backend->ops.tick(backend);
+    }
+}
+
 bool backend_execute(Backend *backend,
                      CtrlRequest *request,
                      CtrlResponse *response) {

--- a/nodes/apps/aisg/ctrl/src/backend_raw_rs485.c
+++ b/nodes/apps/aisg/ctrl/src/backend_raw_rs485.c
@@ -234,9 +234,10 @@ static bool execute_retap(RawRs485Context *ctx,
     CtrlCode code;
 
     if (!aisg_v2_send_retap(&ctx->bus, request, response)) {
-        return ctrl_response_set_aisg_error(ctrlResp,
-                                            ctx->bus.lastError,
-                                            "failed to execute RETAP");
+        ctrl_response_set_aisg_error(ctrlResp,
+                                     ctx->bus.lastError,
+                                     "failed to execute RETAP");
+        return false;
     }
 
     if (response->returnCode != RETAP_RETURN_FAIL) {
@@ -245,7 +246,8 @@ static bool execute_retap(RawRs485Context *ctx,
 
     code = retap_response_code(response);
 
-    return ctrl_response_set_error(ctrlResp, code, ctrl_code_str(code));
+    ctrl_response_set_error(ctrlResp, code, ctrl_code_str(code));
+    return false;
 }
 
 static bool raw_require_connected(RawRs485Context *ctx, CtrlResponse *response)
@@ -259,9 +261,10 @@ static bool raw_require_connected(RawRs485Context *ctx, CtrlResponse *response)
         ctx->bus.lastError = AISG_ERROR_LINK_NOT_CONNECTED;
     }
 
-    return ctrl_response_set_error(response,
-                                   CtrlCodeLinkNotConnected,
-                                   "device not connected; run scan first");
+    ctrl_response_set_error(response,
+                            CtrlCodeLinkNotConnected,
+                            "device not connected; run scan first");
+    return false;
 }
 
 static bool raw_require_configured(RawRs485Context *ctx, CtrlResponse *response)
@@ -274,9 +277,10 @@ static bool raw_require_configured(RawRs485Context *ctx, CtrlResponse *response)
         return true;
     }
 
-    return ctrl_response_set_error(response,
-                                   CtrlCodeNotConfigured,
-                                   "configuration must be loaded first");
+    ctrl_response_set_error(response,
+                            CtrlCodeNotConfigured,
+                            "configuration must be loaded first");
+    return false;
 }
 
 static bool raw_require_calibrated(RawRs485Context *ctx, CtrlResponse *response)
@@ -289,9 +293,10 @@ static bool raw_require_calibrated(RawRs485Context *ctx, CtrlResponse *response)
         return true;
     }
 
-    return ctrl_response_set_error(response,
-                                   CtrlCodeNotCalibrated,
-                                   "calibration must be completed first");
+    ctrl_response_set_error(response,
+                            CtrlCodeNotCalibrated,
+                            "calibration must be completed first");
+    return false;
 }
 
 static void raw_clear_device_runtime_state(RawRs485Context *ctx)
@@ -614,24 +619,27 @@ static bool read_config_blob(CtrlRequest *request,
     const char *path = NULL;
 
     if (request == NULL || data == NULL || len == NULL) {
-        return ctrl_response_set_error(response,
-                                       CtrlCodeInvalidRequest,
-                                       "invalid config request");
+        ctrl_response_set_error(response,
+                                CtrlCodeInvalidRequest,
+                                "invalid config request");
+        return false;
     }
 
     value = json_object_get(request->payload, "configPath");
     path = json_is_string(value) ? json_string_value(value) : NULL;
 
     if (path == NULL || path[0] == '\0') {
-        return ctrl_response_set_error(response,
-                                       CtrlCodeInvalidRequest,
-                                       "missing configPath");
+        ctrl_response_set_error(response,
+                                CtrlCodeInvalidRequest,
+                                "missing configPath");
+        return false;
     }
 
     if (!read_file_alloc(path, data, len)) {
-        return ctrl_response_set_error(response,
-                                       CtrlCodeInvalidRequest,
-                                       "failed to read config blob");
+        ctrl_response_set_error(response,
+                                CtrlCodeInvalidRequest,
+                                "failed to read config blob");
+        return false;
     }
 
     return true;

--- a/nodes/apps/aisg/ctrl/src/backend_raw_rs485.c
+++ b/nodes/apps/aisg/ctrl/src/backend_raw_rs485.c
@@ -447,17 +447,35 @@ static JsonObj *build_tilt_payload(int16_t tilt)
     return json;
 }
 
-static JsonObj *build_device_data_payload(int field)
+static JsonObj *build_device_data_payload(int field,
+                                          const uint8_t *data,
+                                          size_t len)
 {
     JsonObj *json = NULL;
+    char *hex = NULL;
+    size_t i;
+
+    if (data == NULL && len != 0) {
+        return NULL;
+    }
+
+    hex = calloc((len * 2) + 1, 1);
+    if (hex == NULL) return NULL;
+
+    for (i = 0; i < len; i++) {
+        snprintf(&hex[i * 2], 3, "%02X", data[i]);
+    }
 
     json = json_object();
     if (json == NULL) {
+        free(hex);
         return NULL;
     }
 
     json_object_set_new(json, "field", json_integer(field));
-    json_object_set_new(json, "dataHex", json_string(""));
+    json_object_set_new(json, "dataHex", json_string(hex));
+    json_object_set_new(json, "length", json_integer((json_int_t)len));
+    free(hex);
 
     return json;
 }
@@ -471,6 +489,16 @@ static bool raw_handle_ping(RawRs485Context *ctx, CtrlResponse *response)
 
 static bool raw_handle_status(RawRs485Context *ctx, CtrlResponse *response)
 {
+    AisgError keepaliveError;
+
+    if (ctx != NULL && ctx->device.present &&
+        ctx->bus.state == AISG_L2_CONNECTED &&
+        !aisg_v2_keepalive(&ctx->bus)) {
+        keepaliveError = ctx->bus.lastError;
+        raw_clear_device_runtime_state(ctx);
+        ctx->bus.lastError = keepaliveError;
+    }
+
     return ctrl_response_set_ok(response, build_status_payload(ctx));
 }
 
@@ -825,6 +853,11 @@ static bool raw_handle_get_device_data(RawRs485Context *ctx,
                                        "missing field");
     }
     field = (int)json_integer_value(value);
+    if (field < 0 || field > 255) {
+        return ctrl_response_set_error(response,
+                                       CtrlCodeInvalidRequest,
+                                       "field must be between 0 and 255");
+    }
 
     retap_build_get_device_data(&retapReq, (uint8_t)field);
 
@@ -832,7 +865,24 @@ static bool raw_handle_get_device_data(RawRs485Context *ctx,
         return false;
     }
 
-    return ctrl_response_set_ok(response, build_device_data_payload(field));
+    /* A supported field is returned as <field number><field data>. */
+    if (retapResp.dataLen == 0) {
+        return ctrl_response_set_ok(
+            response,
+            build_device_data_payload(field, NULL, 0));
+    }
+
+    if (retapResp.data[0] != (uint8_t)field) {
+        return ctrl_response_set_error(response,
+                                       CtrlCodeFormatError,
+                                       "GetDeviceData field mismatch");
+    }
+
+    return ctrl_response_set_ok(
+        response,
+        build_device_data_payload(field,
+                                  &retapResp.data[1],
+                                  retapResp.dataLen - 1));
 }
 
 

--- a/nodes/apps/aisg/ctrl/src/backend_raw_rs485.c
+++ b/nodes/apps/aisg/ctrl/src/backend_raw_rs485.c
@@ -320,6 +320,31 @@ static void raw_clear_device_runtime_state(RawRs485Context *ctx)
     aisg_v2_bus_reset_link(&ctx->bus);
 }
 
+static void raw_tick(Backend *backend)
+{
+    RawRs485Context *ctx;
+    AisgError keepaliveError;
+
+    if (backend == NULL || backend->priv == NULL) {
+        return;
+    }
+
+    ctx = backend->priv;
+    if (!ctx->device.present || ctx->bus.state != AISG_L2_CONNECTED) {
+        return;
+    }
+
+    if (aisg_v2_keepalive(&ctx->bus)) {
+        return;
+    }
+
+    keepaliveError = ctx->bus.lastError;
+    usys_log_warn("aisg: background keepalive failed: %s",
+                  aisg_v2_error_str(keepaliveError));
+    raw_clear_device_runtime_state(ctx);
+    ctx->bus.lastError = keepaliveError;
+}
+
 static void raw_update_identity(RawRs485Context *ctx, RetapInfo *info)
 {
     if (ctx == NULL || info == NULL) {
@@ -789,6 +814,14 @@ static bool raw_handle_get_tilt(RawRs485Context *ctx,
 
     ctx->tiltTenthsDeg = tilt;
     ctx->tiltKnown = true;
+    /*
+     * A successful GetTilt excludes the RETAP NotCalibrated and NotScaled
+     * states.  The RET may retain its configuration across controller
+     * restarts, so reflect the device's observed operational state instead of
+     * requiring a destructive reconfiguration merely to set local flags.
+     */
+    ctx->configured = true;
+    ctx->calibrated = true;
 
     return ctrl_response_set_ok(response, build_tilt_payload(tilt));
 }
@@ -999,6 +1032,7 @@ bool backend_raw_rs485_init(Backend *backend, Config *config)
     static BackendOps ops = {
         .open    = raw_open,
         .close   = raw_close,
+        .tick    = raw_tick,
         .execute = raw_execute,
     };
 

--- a/nodes/apps/aisg/ctrl/src/backend_raw_rs485.c
+++ b/nodes/apps/aisg/ctrl/src/backend_raw_rs485.c
@@ -867,6 +867,13 @@ static bool raw_handle_set_tilt(RawRs485Context *ctx,
         return false;
     }
 
+    /*
+     * TS 25.463 section 6.6.3 defines SetTilt as a synchronous class-1
+     * procedure: the secondary performs the movement and then returns OK or
+     * FAIL (within two minutes). execute_retap() has already received and
+     * validated that terminal response, so no operation remains pending.
+     */
+    json_object_set_new(payload, "state", json_string("completed"));
     json_object_set_new(payload, "targetTiltDeg", json_real(target));
     json_object_set_new(payload, "currentTiltDeg", json_real(tilt / 10.0));
     json_object_set_new(payload, "rawTiltTenthsDeg", json_integer(tilt));

--- a/nodes/apps/aisg/ctrl/src/main.c
+++ b/nodes/apps/aisg/ctrl/src/main.c
@@ -86,6 +86,8 @@ int main(int argc, char **argv) {
 
     signal(SIGINT, handle_signal);
     signal(SIGTERM, handle_signal);
+    /* A client disconnect must not terminate the controller while replying. */
+    signal(SIGPIPE, SIG_IGN);
 
     if (!backend_init(&backend, &config)) {
         usys_log_error("failed to initialize backend");
@@ -101,6 +103,7 @@ int main(int argc, char **argv) {
     }
 
     ok = ctrl_server_run(&config, &backend, &gRunning);
+    usys_log_info("aisg-ctrl server stopped ok=%u", ok ? 1 : 0);
     backend_close(&backend);
     config_free(&config);
 

--- a/nodes/apps/aisg/ctrl/src/serial.c
+++ b/nodes/apps/aisg/ctrl/src/serial.c
@@ -7,13 +7,25 @@
  */
 
 #include <fcntl.h>
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <termios.h>
+#include <time.h>
 #include <unistd.h>
 #include <sys/select.h>
 
 #include "serial.h"
+
+#define HDLC_FLAG                          0x7E
+
+static int64_t monotonic_ms(void) {
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) return 0;
+
+    return ((int64_t)ts.tv_sec * 1000) + ((int64_t)ts.tv_nsec / 1000000);
+}
 
 static speed_t baud_to_speed(int baud) {
     switch (baud) {
@@ -54,6 +66,12 @@ bool serial_open(SerialPort *port, const char *device, int baud) {
     tio.c_cflag &= ~CSTOPB;
     tio.c_cflag &= ~CSIZE;
     tio.c_cflag |= CS8;
+#ifdef CRTSCTS
+    tio.c_cflag &= ~CRTSCTS;
+#endif
+    tio.c_iflag &= ~(IXON | IXOFF | IXANY);
+    tio.c_cc[VMIN] = 0;
+    tio.c_cc[VTIME] = 0;
 
     if (tcsetattr(port->fd, TCSANOW, &tio) != 0) {
         serial_close(port);
@@ -79,8 +97,25 @@ bool serial_write_all(SerialPort *port, const uint8_t *data, size_t len) {
     off = 0;
     while (off < len) {
         n = write(port->fd, data + off, len - off);
+        if (n < 0 && errno == EINTR) continue;
         if (n <= 0) return false;
         off += (size_t)n;
+    }
+
+    /* Start the AISG reply timer only after the final flag left the tty. */
+    while (tcdrain(port->fd) != 0) {
+        if (errno != EINTR) return false;
+    }
+
+    return true;
+}
+
+bool serial_discard_input(SerialPort *port) {
+    if (port == NULL || port->fd < 0) return false;
+
+    port->openingFlagPending = false;
+    while (tcflush(port->fd, TCIFLUSH) != 0) {
+        if (errno != EINTR) return false;
     }
 
     return true;
@@ -96,32 +131,92 @@ bool serial_read_frame(SerialPort *port,
     uint8_t byte;
     bool seenFlag;
     size_t off;
+    int64_t deadlineMs;
+    int64_t nowMs;
+    int waitMs;
+    int ready;
+    ssize_t n;
 
-    if (port == NULL || port->fd < 0 || buf == NULL || len == NULL) {
+    if (port == NULL || port->fd < 0 || buf == NULL || len == NULL ||
+        size < 2) {
         return false;
     }
 
+    *len = 0;
     off = 0;
-    seenFlag = false;
+    seenFlag = port->openingFlagPending;
+    port->openingFlagPending = false;
 
-    while (off < size) {
-        FD_ZERO(&rfds);
-        FD_SET(port->fd, &rfds);
-        tv.tv_sec = timeoutMs / 1000;
-        tv.tv_usec = (timeoutMs % 1000) * 1000;
-
-        if (select(port->fd + 1, &rfds, NULL, NULL, &tv) <= 0) return false;
-        if (read(port->fd, &byte, 1) != 1) return false;
-
-        buf[off++] = byte;
-        if (byte == 0x7E) {
-            if (seenFlag && off > 1) {
-                *len = off;
-                return true;
-            }
-            seenFlag = true;
-        }
+    if (seenFlag) {
+        buf[off++] = HDLC_FLAG;
     }
 
-    return false;
+    if (timeoutMs <= 0) timeoutMs = 1;
+    deadlineMs = monotonic_ms() + timeoutMs;
+
+    for (;;) {
+        nowMs = monotonic_ms();
+        waitMs = (int)(deadlineMs - nowMs);
+        if (waitMs <= 0) {
+            *len = off;
+            port->openingFlagPending = seenFlag && off == 1;
+            return false;
+        }
+
+        FD_ZERO(&rfds);
+        FD_SET(port->fd, &rfds);
+        tv.tv_sec = waitMs / 1000;
+        tv.tv_usec = (waitMs % 1000) * 1000;
+
+        ready = select(port->fd + 1, &rfds, NULL, NULL, &tv);
+        if (ready < 0 && errno == EINTR) continue;
+        if (ready <= 0) {
+            *len = off;
+            port->openingFlagPending = seenFlag && off == 1;
+            return false;
+        }
+
+        n = read(port->fd, &byte, 1);
+        if (n < 0 && errno == EINTR) continue;
+        if (n != 1) {
+            *len = off;
+            port->openingFlagPending = seenFlag && off == 1;
+            return false;
+        }
+
+        if (byte == HDLC_FLAG) {
+            if (!seenFlag) {
+                seenFlag = true;
+                off = 0;
+                buf[off++] = byte;
+                continue;
+            }
+
+            /* Fill flags and a shared closing/opening flag are not frames. */
+            if (off == 1) continue;
+
+            if (off >= size) {
+                *len = off;
+                return false;
+            }
+
+            buf[off++] = byte;
+            if (off > 2) {
+                *len = off;
+                port->openingFlagPending = true;
+                return true;
+            }
+
+            continue;
+        }
+
+        if (!seenFlag) continue;
+
+        if (off >= size) {
+            *len = off;
+            return false;
+        }
+
+        buf[off++] = byte;
+    }
 }

--- a/nodes/apps/aisg/ctrl/src/server.c
+++ b/nodes/apps/aisg/ctrl/src/server.c
@@ -50,6 +50,9 @@ static bool write_all(int fd, const char *data, size_t len) {
     off = 0;
     while (off < len) {
         n = write(fd, data + off, len - off);
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
         if (n <= 0) {
             return false;
         }
@@ -129,7 +132,10 @@ static void handle_client(int fd, Backend *backend) {
         }
     }
 
-    send_response(fd, &response);
+    if (!send_response(fd, &response)) {
+        usys_log_warn("failed to send controller response: %s",
+                      strerror(errno));
+    }
     ctrl_request_free(&request);
     ctrl_response_free(&response);
     json_decref(json);

--- a/nodes/apps/aisg/ctrl/src/server.c
+++ b/nodes/apps/aisg/ctrl/src/server.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 
@@ -19,6 +20,7 @@
 #include "usys_log.h"
 
 #define CTRL_SERVER_READ_BUF 8192
+#define CTRL_SERVER_TICK_MS 1000
 
 static bool read_line(int fd, char *buf, size_t size) {
     size_t off;
@@ -144,6 +146,8 @@ static void handle_client(int fd, Backend *backend) {
 bool ctrl_server_run(Config *config, Backend *backend, volatile bool *running) {
     int serverFd;
     int clientFd;
+    int pollResult;
+    struct pollfd pollFd;
     struct sockaddr_un addr;
 
     if (config == NULL || backend == NULL || running == NULL) {
@@ -178,7 +182,31 @@ bool ctrl_server_run(Config *config, Backend *backend, volatile bool *running) {
     }
 
     usys_log_info("aisg-ctrl listening on %s", config->socketPath);
+    memset(&pollFd, 0, sizeof(pollFd));
+    pollFd.fd = serverFd;
+    pollFd.events = POLLIN;
+
     while (*running) {
+        pollResult = poll(&pollFd, 1, CTRL_SERVER_TICK_MS);
+        if (pollResult < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            usys_log_error("server poll failed: %s", strerror(errno));
+            break;
+        }
+
+        if (pollResult == 0) {
+            backend_tick(backend);
+            continue;
+        }
+
+        if ((pollFd.revents & POLLIN) == 0) {
+            usys_log_error("server socket poll revents=0x%X",
+                           pollFd.revents);
+            break;
+        }
+
         clientFd = accept(serverFd, NULL, NULL);
         if (clientFd < 0) {
             if (errno == EINTR) {

--- a/nodes/apps/aisg/tests/protocol/Makefile
+++ b/nodes/apps/aisg/tests/protocol/Makefile
@@ -5,12 +5,13 @@
 ROOT ?= ../..
 CC ?= gcc
 
-CFLAGS += -std=c99 -Wall -Wextra -Werror -g
+CFLAGS += -std=c99 -Wall -Wextra -Werror -g -D_DEFAULT_SOURCE
 CFLAGS += -I./stubs
 CFLAGS += -I$(ROOT)/ctrl/inc
 
 PROTOCOL_SRCS = \
 	$(ROOT)/ctrl/src/hdlc.c \
+	$(ROOT)/ctrl/src/serial.c \
 	$(ROOT)/ctrl/src/xid.c \
 	$(ROOT)/ctrl/src/retap.c \
 	$(ROOT)/ctrl/src/retap_ops.c

--- a/nodes/apps/aisg/tests/protocol/Makefile
+++ b/nodes/apps/aisg/tests/protocol/Makefile
@@ -10,6 +10,7 @@ CFLAGS += -I./stubs
 CFLAGS += -I$(ROOT)/ctrl/inc
 
 PROTOCOL_SRCS = \
+	$(ROOT)/ctrl/src/aisg_v2.c \
 	$(ROOT)/ctrl/src/hdlc.c \
 	$(ROOT)/ctrl/src/serial.c \
 	$(ROOT)/ctrl/src/xid.c \
@@ -17,6 +18,7 @@ PROTOCOL_SRCS = \
 	$(ROOT)/ctrl/src/retap_ops.c
 
 TARGET = test_protocol
+LDLIBS += -lutil
 
 .PHONY: all test clean
 
@@ -26,7 +28,7 @@ test: $(TARGET)
 	./$(TARGET)
 
 $(TARGET): test_protocol.c $(PROTOCOL_SRCS)
-	$(CC) $(CFLAGS) -o $@ test_protocol.c $(PROTOCOL_SRCS)
+	$(CC) $(CFLAGS) -o $@ test_protocol.c $(PROTOCOL_SRCS) $(LDLIBS)
 
 clean:
 	rm -f $(TARGET) *.o

--- a/nodes/apps/aisg/tests/protocol/stubs/jansson.h
+++ b/nodes/apps/aisg/tests/protocol/stubs/jansson.h
@@ -1,6 +1,34 @@
 #ifndef AISG_TEST_STUB_JANSSON_H_
 #define AISG_TEST_STUB_JANSSON_H_
 
+#include <stddef.h>
+
 typedef struct json_t json_t;
+typedef long long json_int_t;
+
+static inline json_t *json_object(void) { return (json_t *)0; }
+static inline json_t *json_array(void) { return (json_t *)0; }
+static inline json_t *json_string(const char *s) { (void)s; return (json_t *)0; }
+static inline json_t *json_integer(json_int_t v) { (void)v; return (json_t *)0; }
+static inline json_t *json_real(double v) { (void)v; return (json_t *)0; }
+static inline json_t *json_boolean(int v) { (void)v; return (json_t *)0; }
+static inline json_t *json_true(void) { return (json_t *)0; }
+static inline json_t *json_false(void) { return (json_t *)0; }
+static inline json_t *json_null(void) { return (json_t *)0; }
+static inline int json_object_set_new(json_t *o, const char *k, json_t *v)
+{ (void)o; (void)k; (void)v; return 0; }
+static inline int json_array_append_new(json_t *a, json_t *v)
+{ (void)a; (void)v; return 0; }
+static inline void json_decref(json_t *v) { (void)v; }
+static inline json_t *json_object_get(const json_t *o, const char *k)
+{ (void)o; (void)k; return (json_t *)0; }
+static inline int json_is_string(const json_t *v) { (void)v; return 0; }
+static inline int json_is_integer(const json_t *v) { (void)v; return 0; }
+static inline int json_is_number(const json_t *v) { (void)v; return 0; }
+static inline const char *json_string_value(const json_t *v)
+{ (void)v; return (const char *)0; }
+static inline json_int_t json_integer_value(const json_t *v)
+{ (void)v; return 0; }
+static inline double json_number_value(const json_t *v) { (void)v; return 0.0; }
 
 #endif /* AISG_TEST_STUB_JANSSON_H_ */

--- a/nodes/apps/aisg/tests/protocol/stubs/jansson.h
+++ b/nodes/apps/aisg/tests/protocol/stubs/jansson.h
@@ -5,6 +5,9 @@
 
 typedef struct json_t json_t;
 typedef long long json_int_t;
+typedef struct { int line; int column; char text[160]; } json_error_t;
+
+#define JSON_COMPACT 0x20
 
 static inline json_t *json_object(void) { return (json_t *)0; }
 static inline json_t *json_array(void) { return (json_t *)0; }
@@ -30,5 +33,9 @@ static inline const char *json_string_value(const json_t *v)
 static inline json_int_t json_integer_value(const json_t *v)
 { (void)v; return 0; }
 static inline double json_number_value(const json_t *v) { (void)v; return 0.0; }
+static inline json_t *json_loads(const char *s, size_t flags, json_error_t *e)
+{ (void)s; (void)flags; (void)e; return (json_t *)0; }
+static inline char *json_dumps(const json_t *v, size_t flags)
+{ (void)v; (void)flags; return (char *)0; }
 
 #endif /* AISG_TEST_STUB_JANSSON_H_ */

--- a/nodes/apps/aisg/tests/protocol/stubs/usys_log.h
+++ b/nodes/apps/aisg/tests/protocol/stubs/usys_log.h
@@ -11,4 +11,10 @@
 static inline void usys_log_set_level(int level) { (void)level; }
 static inline void usys_log_set_service(const char *svc) { (void)svc; }
 
+static inline void usys_log_trace(const char *fmt, ...) { (void)fmt; }
+static inline void usys_log_debug(const char *fmt, ...) { (void)fmt; }
+static inline void usys_log_info(const char *fmt, ...) { (void)fmt; }
+static inline void usys_log_warn(const char *fmt, ...) { (void)fmt; }
+static inline void usys_log_error(const char *fmt, ...) { (void)fmt; }
+
 #endif /* AISG_TEST_STUB_USYS_LOG_H_ */

--- a/nodes/apps/aisg/tests/protocol/stubs/usys_log.h
+++ b/nodes/apps/aisg/tests/protocol/stubs/usys_log.h
@@ -1,6 +1,10 @@
 #ifndef AISG_TEST_STUB_USYS_LOG_H_
 #define AISG_TEST_STUB_USYS_LOG_H_
 
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #define LOG_TRACE 0
 #define LOG_DEBUG 1
 #define LOG_INFO  2
@@ -11,8 +15,27 @@
 static inline void usys_log_set_level(int level) { (void)level; }
 static inline void usys_log_set_service(const char *svc) { (void)svc; }
 
-static inline void usys_log_trace(const char *fmt, ...) { (void)fmt; }
-static inline void usys_log_debug(const char *fmt, ...) { (void)fmt; }
+static inline void aisg_test_log(const char *fmt, va_list ap)
+{
+    if (getenv("AISG_TEST_TRACE") == NULL) return;
+    vfprintf(stderr, fmt, ap);
+    fputc('\n', stderr);
+}
+
+static inline void usys_log_trace(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    aisg_test_log(fmt, ap);
+    va_end(ap);
+}
+static inline void usys_log_debug(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    aisg_test_log(fmt, ap);
+    va_end(ap);
+}
 static inline void usys_log_info(const char *fmt, ...) { (void)fmt; }
 static inline void usys_log_warn(const char *fmt, ...) { (void)fmt; }
 static inline void usys_log_error(const char *fmt, ...) { (void)fmt; }

--- a/nodes/apps/aisg/tests/protocol/test_protocol.c
+++ b/nodes/apps/aisg/tests/protocol/test_protocol.c
@@ -9,10 +9,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <unistd.h>
 
+#include "aisg_v2.h"
 #include "hdlc.h"
 #include "retap.h"
 #include "retap_ops.h"
+#include "serial.h"
 #include "xid.h"
 
 #define CHECK(expr) do {                                                       \
@@ -80,15 +83,85 @@ static bool test_hdlc_roundtrip_and_escaping(void)
     return true;
 }
 
+static bool test_serial_fill_and_shared_flags(void)
+{
+    HdlcFrame tx1;
+    HdlcFrame tx2;
+    HdlcFrame rx;
+    SerialPort port;
+    uint8_t raw1[HDLC_MAX_FRAME];
+    uint8_t raw2[HDLC_MAX_FRAME];
+    uint8_t stream[HDLC_MAX_FRAME * 2];
+    uint8_t frame[HDLC_MAX_FRAME];
+    size_t raw1Len = 0;
+    size_t raw2Len = 0;
+    size_t streamLen = 0;
+    size_t frameLen = 0;
+    int fds[2];
+
+    memset(&tx1, 0, sizeof(tx1));
+    memset(&tx2, 0, sizeof(tx2));
+    memset(&rx, 0, sizeof(rx));
+    memset(&port, 0, sizeof(port));
+
+    tx1.address = 0x01;
+    tx1.control = hdlc_rr_ctrl(0, true);
+    tx2.address = 0x01;
+    tx2.control = hdlc_i_ctrl(0, 0, true);
+    tx2.info[0] = 0x34;
+    tx2.infoLen = 1;
+
+    CHECK(hdlc_encode_frame(&tx1, raw1, sizeof(raw1), &raw1Len));
+    CHECK(hdlc_encode_frame(&tx2, raw2, sizeof(raw2), &raw2Len));
+    CHECK(pipe(fds) == 0);
+    port.fd = fds[0];
+
+    /* Noise and any number of leading/fill flags must be ignored. */
+    stream[streamLen++] = 0x55;
+    stream[streamLen++] = HDLC_FLAG;
+    stream[streamLen++] = HDLC_FLAG;
+    memcpy(&stream[streamLen], raw1, raw1Len);
+    streamLen += raw1Len;
+    CHECK(write(fds[1], stream, streamLen) == (ssize_t)streamLen);
+    CHECK(serial_read_frame(&port,
+                            frame,
+                            sizeof(frame),
+                            &frameLen,
+                            100));
+    CHECK(hdlc_decode_frame(frame, frameLen, &rx));
+    CHECK(rx.address == tx1.address);
+    CHECK(rx.control == tx1.control);
+
+    /* The previous closing flag is allowed to open the next frame. */
+    CHECK(write(fds[1], &raw2[1], raw2Len - 1) == (ssize_t)(raw2Len - 1));
+    CHECK(serial_read_frame(&port,
+                            frame,
+                            sizeof(frame),
+                            &frameLen,
+                            100));
+    CHECK(hdlc_decode_frame(frame, frameLen, &rx));
+    CHECK(rx.address == tx2.address);
+    CHECK(rx.control == tx2.control);
+    CHECK(rx.infoLen == 1 && rx.info[0] == 0x34);
+
+    close(fds[0]);
+    close(fds[1]);
+    return true;
+}
+
 static bool test_xid_scan_and_assignment(void)
 {
+    HdlcFrame scan;
+    uint8_t raw[HDLC_MAX_FRAME];
     uint8_t info[256];
+    size_t rawLen = 0;
     size_t infoLen = 0;
     XidAddressingParams params;
     const uint8_t uid[] = { 'U', 'K', 'A', 'M', 'A', '0', '0', '1' };
     uint16_t vendor = ((uint16_t)'U' << 8) | (uint8_t)'K';
 
     CHECK(xid_build_scan_info(info, sizeof(info), &infoLen));
+    CHECK(infoLen == 45);
     CHECK(xid_parse_addressing_info(info, infoLen, &params));
     CHECK(params.hasUniqueId);
     CHECK(params.uniqueIdLen == AISG_XID_SCAN_ID_LEN);
@@ -101,6 +174,21 @@ static bool test_xid_scan_and_assignment(void)
                                    params.uniqueIdLen,
                                    params.mask,
                                    params.maskLen));
+
+    memset(&scan, 0, sizeof(scan));
+    scan.address = AISG_ADDR_BROADCAST;
+    scan.control = hdlc_xid_ctrl(true);
+    memcpy(scan.info, info, infoLen);
+    scan.infoLen = infoLen;
+    CHECK(hdlc_encode_frame(&scan, raw, sizeof(raw), &rawLen));
+    CHECK(rawLen == 51);
+    CHECK(raw[0] == 0x7E && raw[1] == 0xFF && raw[2] == 0xBF);
+    CHECK(raw[3] == 0x81 && raw[4] == 0xF0 && raw[5] == 0x2A);
+    CHECK(raw[6] == 0x01 && raw[7] == 0x13);
+    CHECK(raw[27] == 0x03 && raw[28] == 0x13);
+    CHECK(raw[48] == 0x7F && raw[49] == 0x0F && raw[50] == 0x7E);
+    CHECK(AISG_HDLC_DEFAULT_FRAME_MAX == 78);
+    CHECK(AISG_HDLC_DEFAULT_INFO_MAX == 74);
 
     CHECK(xid_build_assign_info(uid,
                                 sizeof(uid),
@@ -244,6 +332,7 @@ int main(void)
         bool (*fn)(void);
     } tests[] = {
         { "hdlc_roundtrip_and_escaping", test_hdlc_roundtrip_and_escaping },
+        { "serial_fill_and_shared_flags", test_serial_fill_and_shared_flags },
         { "xid_scan_and_assignment",     test_xid_scan_and_assignment },
         { "retap_golden_packets",        test_retap_golden_packets },
         { "retap_config_limits",         test_retap_config_limits },

--- a/nodes/apps/aisg/tests/protocol/test_protocol.c
+++ b/nodes/apps/aisg/tests/protocol/test_protocol.c
@@ -254,6 +254,49 @@ static bool test_real_ret_scan_response_without_pi2(void)
     return true;
 }
 
+static bool test_real_ret_identical_release_xid(void)
+{
+    /* Exact command/response seen on the real RET for Release 6. */
+    static const uint8_t captured[] = {
+        0x7E, 0x01, 0xBF, 0x81, 0xF0, 0x03,
+        0x05, 0x01, 0x06, 0xDE, 0xB5, 0x7E
+    };
+    HdlcFrame frame;
+    XidAddressingParams params;
+    uint8_t encoded[HDLC_MAX_FRAME];
+    size_t infoLen = 0;
+    size_t encodedLen = 0;
+
+    memset(&frame, 0, sizeof(frame));
+    memset(&params, 0, sizeof(params));
+
+    CHECK(hdlc_decode_frame(captured, sizeof(captured), &frame));
+    CHECK(frame.address == AISG_ADDR_ASSIGNED);
+    CHECK(hdlc_is_xid(frame.control));
+    CHECK(xid_parse_addressing_info(frame.info, frame.infoLen, &params));
+    CHECK(params.has3gppRelease);
+    CHECK(params.release == AISG_3GPP_RELEASE_ID);
+
+    /* Accepting the offered value produces a byte-identical XID response. */
+    memset(&frame, 0, sizeof(frame));
+    frame.address = AISG_ADDR_ASSIGNED;
+    frame.control = hdlc_xid_ctrl(true);
+    CHECK(xid_build_one_octet_info(AISG_XID_PI_3GPP_RELEASE,
+                                   AISG_3GPP_RELEASE_ID,
+                                   frame.info,
+                                   sizeof(frame.info),
+                                   &infoLen));
+    frame.infoLen = infoLen;
+    CHECK(hdlc_encode_frame(&frame,
+                            encoded,
+                            sizeof(encoded),
+                            &encodedLen));
+    CHECK(encodedLen == sizeof(captured));
+    CHECK(bytes_eq(encoded, captured, sizeof(captured)));
+
+    return true;
+}
+
 static bool test_retap_golden_packets(void)
 {
     RetapRequest req;
@@ -370,6 +413,7 @@ int main(void)
         { "serial_fill_and_shared_flags", test_serial_fill_and_shared_flags },
         { "xid_scan_and_assignment",     test_xid_scan_and_assignment },
         { "real_ret_scan_without_pi2",   test_real_ret_scan_response_without_pi2 },
+        { "real_ret_identical_release_xid", test_real_ret_identical_release_xid },
         { "retap_golden_packets",        test_retap_golden_packets },
         { "retap_config_limits",         test_retap_config_limits },
     };

--- a/nodes/apps/aisg/tests/protocol/test_protocol.c
+++ b/nodes/apps/aisg/tests/protocol/test_protocol.c
@@ -219,6 +219,41 @@ static bool test_xid_scan_and_assignment(void)
     return true;
 }
 
+static bool test_real_ret_scan_response_without_pi2(void)
+{
+    static const uint8_t raw[] = {
+        0x7E, 0x00, 0xBF, 0x81, 0xF0, 0x1C, 0x01, 0x13,
+        0x54, 0x43, 0x30, 0x30, 0x34, 0x42, 0x4C, 0x32,
+        0x33, 0x33, 0x37, 0x59, 0x31, 0x30, 0x30, 0x30,
+        0x39, 0x30, 0x31, 0x06, 0x02, 0x54, 0x43, 0x04,
+        0x01, 0x01, 0x00, 0x30, 0x7E
+    };
+    static const uint8_t expectedUid[] = {
+        0x54, 0x43, 0x30, 0x30, 0x34, 0x42, 0x4C, 0x32,
+        0x33, 0x33, 0x37, 0x59, 0x31, 0x30, 0x30, 0x30,
+        0x39, 0x30, 0x31
+    };
+    HdlcFrame frame;
+    XidAddressingParams params;
+
+    memset(&frame, 0, sizeof(frame));
+    memset(&params, 0, sizeof(params));
+
+    CHECK(hdlc_decode_frame(raw, sizeof(raw), &frame));
+    CHECK(frame.address == AISG_ADDR_DEFAULT);
+    CHECK(hdlc_is_xid(frame.control));
+    CHECK(xid_parse_addressing_info(frame.info, frame.infoLen, &params));
+    CHECK(params.hasUniqueId);
+    CHECK(params.uniqueIdLen == sizeof(expectedUid));
+    CHECK(bytes_eq(params.uniqueId, expectedUid, sizeof(expectedUid)));
+    CHECK(!params.hasAddress);
+    CHECK(params.hasVendorCode && params.vendorCode == 0x5443);
+    CHECK(params.hasDeviceType &&
+          params.deviceType == AISG_DEVICE_TYPE_SINGLE_RET);
+
+    return true;
+}
+
 static bool test_retap_golden_packets(void)
 {
     RetapRequest req;
@@ -334,6 +369,7 @@ int main(void)
         { "hdlc_roundtrip_and_escaping", test_hdlc_roundtrip_and_escaping },
         { "serial_fill_and_shared_flags", test_serial_fill_and_shared_flags },
         { "xid_scan_and_assignment",     test_xid_scan_and_assignment },
+        { "real_ret_scan_without_pi2",   test_real_ret_scan_response_without_pi2 },
         { "retap_golden_packets",        test_retap_golden_packets },
         { "retap_config_limits",         test_retap_config_limits },
     };

--- a/nodes/apps/aisg/tests/protocol/test_protocol.c
+++ b/nodes/apps/aisg/tests/protocol/test_protocol.c
@@ -10,6 +10,10 @@
 #include <stdbool.h>
 #include <string.h>
 #include <unistd.h>
+#include <pty.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <termios.h>
 
 #include "aisg_v2.h"
 #include "hdlc.h"
@@ -297,6 +301,103 @@ static bool test_real_ret_identical_release_xid(void)
     return true;
 }
 
+static bool test_identical_rr_poll_response(void)
+{
+    HdlcFrame poll;
+    HdlcFrame response;
+    uint8_t raw[HDLC_MAX_FRAME];
+    size_t rawLen = 0;
+
+    memset(&poll, 0, sizeof(poll));
+    memset(&response, 0, sizeof(response));
+
+    poll.address = AISG_ADDR_ASSIGNED;
+    poll.control = hdlc_rr_ctrl(4, true);
+
+    CHECK(poll.control == 0x91);
+    CHECK(hdlc_is_rr(poll.control));
+    CHECK(hdlc_poll_final(poll.control));
+    CHECK(hdlc_nr(poll.control) == 4);
+    CHECK(hdlc_encode_frame(&poll, raw, sizeof(raw), &rawLen));
+    CHECK(hdlc_decode_frame(raw, rawLen, &response));
+
+    /* A ready secondary with the same N(R) returns the identical RR frame. */
+    CHECK(response.address == poll.address);
+    CHECK(response.control == poll.control);
+    CHECK(response.infoLen == 0);
+
+    return true;
+}
+
+static bool test_keepalive_accepts_identical_rr(void)
+{
+    AisgBus bus;
+    SerialPort port;
+    struct termios tio;
+    uint8_t raw[64];
+    size_t total;
+    int flags;
+    int masterFd;
+    int slaveFd;
+    int status;
+    pid_t child;
+    ssize_t n;
+    size_t i;
+
+    CHECK(openpty(&masterFd, &slaveFd, NULL, NULL, NULL) == 0);
+    CHECK(tcgetattr(slaveFd, &tio) == 0);
+    cfmakeraw(&tio);
+    CHECK(tcsetattr(slaveFd, TCSANOW, &tio) == 0);
+
+    child = fork();
+    CHECK(child >= 0);
+    if (child == 0) {
+        close(slaveFd);
+        total = 0;
+        flags = 0;
+        while (total < sizeof(raw) && flags < 2) {
+            n = read(masterFd, &raw[total], sizeof(raw) - total);
+            if (n <= 0) {
+                _exit(2);
+            }
+            for (i = total; i < total + (size_t)n; i++) {
+                if (raw[i] == HDLC_FLAG) flags++;
+            }
+            total += (size_t)n;
+        }
+
+        /* Secondary turnaround, followed by a byte-identical RR response. */
+        usleep(AISG_MIN_TURNAROUND_US);
+        if (write(masterFd, raw, total) != (ssize_t)total) {
+            _exit(3);
+        }
+        /* Keep the PTY master open until the slave has consumed the reply. */
+        usleep(100000);
+        close(masterFd);
+        _exit(0);
+    }
+
+    close(masterFd);
+    memset(&port, 0, sizeof(port));
+    port.fd = slaveFd;
+    aisg_v2_bus_init(&bus, &port);
+    bus.deviceAddress = AISG_ADDR_ASSIGNED;
+    bus.state = AISG_L2_CONNECTED;
+    bus.ns = 4;
+    bus.nr = 4;
+    bus.lastActivityMs = 1;
+
+    CHECK(aisg_v2_keepalive(&bus));
+    CHECK(bus.state == AISG_L2_CONNECTED);
+    CHECK(bus.ns == 4 && bus.nr == 4);
+    CHECK(bus.lastError == AISG_ERROR_NONE);
+    CHECK(waitpid(child, &status, 0) == child);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    close(slaveFd);
+
+    return true;
+}
+
 static bool test_retap_golden_packets(void)
 {
     RetapRequest req;
@@ -414,6 +515,8 @@ int main(void)
         { "xid_scan_and_assignment",     test_xid_scan_and_assignment },
         { "real_ret_scan_without_pi2",   test_real_ret_scan_response_without_pi2 },
         { "real_ret_identical_release_xid", test_real_ret_identical_release_xid },
+        { "identical_rr_poll_response",  test_identical_rr_poll_response },
+        { "keepalive_accepts_identical_rr", test_keepalive_accepts_identical_rr },
         { "retap_golden_packets",        test_retap_golden_packets },
         { "retap_config_limits",         test_retap_config_limits },
     };


### PR DESCRIPTION
Fixes #1417

```
printf '%s\n' '{"id":"status-1","type":"get_status","payload":{}}' | socat -T 15 STDIO,ignoreeof UNIX-CONNECT:/tmp/aisg-ctrl.sock | jq .
{
  "id": "status-1",
  "ok": true,
  "code": "OK",
  "reason": "",
  "payload": {
    "mode": "operating",
    "busy": false,
    "present": true,
    "identified": true,
    "configured": true,
    "calibrated": true,
    "powerManaged": false,
    "transport": "raw-rs485",
    "model": "RET23-TC130D",
    "productNumber": "RET23-TC130D",
    "serialNumber": "004BL2337Y1000901",
    "hardwareVersion": "5.00",
    "softwareVersion": "5.0.4",
    "tiltKnown": true,
    "currentTiltDeg": 2,
    "linkState": "CONNECTED",
    "lastLinkError": "None",
    "hdlcMaxInfoLen": 74,
    "targetTiltKnown": true,
    "targetTiltDeg": 2
  }
}

```

tilt is ok too:
```
{
  "id": "move-10.0",
  "ok": true,
  "code": "OK",
  "reason": "",
  "payload": {
    "operationId": "op-tilt-001",
    "state": "running",
    "type": "set-tilt",
    "targetTiltDeg": 10,
    "currentTiltDeg": 10,
    "rawTiltTenthsDeg": 100
  }
}
{
  "id": "verify-10.0",
  "ok": true,
  "code": "OK",
  "reason": "",
  "payload": {
    "currentTiltDeg": 10,
    "rawTiltTenthsDeg": 100
  }
}
{
  "id": "alarms-at-10.0",
  "ok": true,
  "code": "OK",
  "reason": "",
  "payload": {
    "active": []
  }
}
{
  "id": "return-2.0",
  "ok": true,
  "code": "OK",
  "reason": "",
  "payload": {
    "operationId": "op-tilt-001",
    "state": "running",
    "type": "set-tilt",
    "targetTiltDeg": 2,
    "currentTiltDeg": 2,
    "rawTiltTenthsDeg": 20
  }
}
{
  "id": "verify-return-2.0",
  "ok": true,
  "code": "OK",
  "reason": "",
  "payload": {
    "currentTiltDeg": 2,
    "rawTiltTenthsDeg": 20
  }
}
{
  "id": "alarms-final",
  "ok": true,
  "code": "OK",
  "reason": "",
  "payload": {
    "active": []
  }
}
```
