### PR TITLE
ukama-agent/cdr: fix typo.

### DIFF
--- a/systems/ukama-agent/cdr/pkg/config.go
+++ b/systems/ukama-agent/cdr/pkg/config.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	DataUsage = "data_usage"
-	CountType = "count"
+	CountType = "counter"
 )
 
 type Config struct {


### PR DESCRIPTION
Fixes a typo in uk-agent cdr's config.