### PR TITLE
ci: fix sonar scan project-key typo and add missing project-key inputs

### DIFF
--- a/.github/actions/build-go/action.yaml
+++ b/.github/actions/build-go/action.yaml
@@ -8,6 +8,9 @@ inputs:
   working-directory:
     description: The working directory for the application
     required: true
+  project-key:
+    description: Sonarcloud project key, used to name the code coverage artifact
+    required: true
   github-bot-token:
     description: The github bot token
     required: true
@@ -59,14 +62,14 @@ runs:
 
   - name: Test
     shell: bash
-    run: go test -v ./... -coverprofile=code-coverage-${{ inputs.project-Key }}-${{ github.run_number }}.out
+    run: go test -v ./... -coverprofile=code-coverage-${{ inputs.project-key }}-${{ github.run_number }}.out
     working-directory: ${{ inputs.working-directory }}
 
   - name: Archive code coverage results
     uses: actions/upload-artifact@v4
     with:
-      name: code-coverage-${{ inputs.project-Key }}-${{ github.run_number }}
-      path: ${{ inputs.working-directory }}/code-coverage-${{ inputs.project-Key }}-${{ github.run_number }}.out
+      name: code-coverage-${{ inputs.project-key }}-${{ github.run_number }}
+      path: ${{ inputs.working-directory }}/code-coverage-${{ inputs.project-key }}-${{ github.run_number }}.out
 
   - name: Configure AWS credentials
     uses: aws-actions/configure-aws-credentials@v1

--- a/.github/actions/sonar-go/action.yaml
+++ b/.github/actions/sonar-go/action.yaml
@@ -32,7 +32,7 @@ runs:
   - name: Download code coverage results
     uses: actions/download-artifact@v4
     with:
-      name: code-coverage-${{ inputs.project-Key }}-${{ github.run_number }}
+      name: code-coverage-${{ inputs.project-key }}-${{ github.run_number }}
       path: ${{ inputs.working-directory }}
 
   - name: SonarCloud Scan
@@ -46,7 +46,7 @@ runs:
         -Dsonar.organization=ukama
         -Dsonar.projectKey=${{ inputs.project-key }}
         -Dsonar.projectName=${{ inputs.working-directory }}
-        -Dsonar.go.coverage.reportPaths=code-coverage-${{ inputs.project-Key }}-${{ github.run_number }}.out
+        -Dsonar.go.coverage.reportPaths=code-coverage-${{ inputs.project-key }}-${{ github.run_number }}.out
         -Dsonar.test.exclusions=tests/**
         -Dsonar.tests=tests/
         -Dsonar.verbose=true

--- a/.github/workflows/pr-release-template.yaml.templ
+++ b/.github/workflows/pr-release-template.yaml.templ
@@ -17,6 +17,7 @@ jobs:
       with:
         registry-name: {{SYSTEM_NAME}}/{{SERVICE_NAME}}
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_{{SYSTEM_NAME}}_{{SERVICE_NAME}}
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-analytics-aggregator.yaml
+++ b/.github/workflows/systems-analytics-aggregator.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         registry-name: analytics/aggregator
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_analytics_aggregator
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-analytics-analysis.yaml
+++ b/.github/workflows/systems-analytics-analysis.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         registry-name: analytics/analysis
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_analytics_analysis
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-analytics-api-gateway.yaml
+++ b/.github/workflows/systems-analytics-api-gateway.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         registry-name: analytics/api-gateway
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_analytics_api-gateway
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-analytics-ingest.yaml
+++ b/.github/workflows/systems-analytics-ingest.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         registry-name: analytics/ingest
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_analytics_ingest
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-init-reflector.yaml
+++ b/.github/workflows/systems-init-reflector.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         registry-name: init/reflector
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_init_reflector
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-messaging-broadcaster.yaml
+++ b/.github/workflows/systems-messaging-broadcaster.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         registry-name: messaging/broadcaster
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_messaging_broadcaster
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-node-operation-monitor.yaml
+++ b/.github/workflows/systems-node-operation-monitor.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         registry-name: node/operation-monitor
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_node_operation-monitor
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-node-site-controller.yaml
+++ b/.github/workflows/systems-node-site-controller.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         registry-name: node/site-controller
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_node_site-controller
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-operation-api-gateway.yaml
+++ b/.github/workflows/systems-operation-api-gateway.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         registry-name: operation/api-gateway
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_operation_api-gateway
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-operation-manager.yaml
+++ b/.github/workflows/systems-operation-manager.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         registry-name: operation/manager
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_operation_manager
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/systems-services-initClient.yaml
+++ b/.github/workflows/systems-services-initClient.yaml
@@ -110,6 +110,7 @@ jobs:
       with:
         registry-name: services/initclient
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_services_initclient
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/testing-services-dummy-dcontroller.yaml
+++ b/.github/workflows/testing-services-dummy-dcontroller.yaml
@@ -25,6 +25,7 @@ jobs:
      with:
       registry-name: dummy/dcontroller
       working-directory: ${{ env.working-directory }}
+      project-key: ukama_systems_dummy_dcontroller
       github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
       aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
       aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/.github/workflows/workflow-template.yaml.templ
+++ b/.github/workflows/workflow-template.yaml.templ
@@ -22,6 +22,7 @@ jobs:
       with:
         registry-name: {{SYSTEM_NAME}}/{{SERVICE_NAME}}
         working-directory: ${{ env.working-directory }}
+        project-key: ukama_systems_{{SYSTEM_NAME}}_{{SERVICE_NAME}}
         github-bot-token: ${{ secrets.UKAMA_BOT_GITHUB_TOKEN }}
         aws-secret-key: ${{ secrets.AWS_REGISTRY_SECRET_ACCESS_KEY }}
         aws-access-key: ${{ secrets.AWS_REGISTRY_ACCESS_KEY_ID }}

--- a/systems/node/site-controller/go.mod
+++ b/systems/node/site-controller/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/ukama/ukama/systems/common v0.0.0-00010101000000-000000000000
 	github.com/ukama/ukama/systems/node/controller v0.0.0-00010101000000-000000000000
 	github.com/ukama/ukama/systems/node/health v0.0.0-00010101000000-000000000000
-	google.golang.org/grpc v1.82.0
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.31.2

--- a/systems/node/site-controller/go.sum
+++ b/systems/node/site-controller/go.sum
@@ -840,8 +840,8 @@ google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKa
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
Extracted from grpc-svcs-status-check. CI-only changes: fixes the project-Key → project-key case typo in the sonar-go action, adds missing project-key inputs to 14 workflows, and updates the build-go action and workflow templates. No code changes.