### PR TITLE
ukama-lab: vnode restart failure injection (#1575)

### DIFF
--- a/testing/lab/inc/runtime.h
+++ b/testing/lab/inc/runtime.h
@@ -70,6 +70,11 @@ int runtime_set_failure_control(runtime_t *rt,
                                 const char *target,
                                 int enabled,
                                 ulab_error_t *err);
+int runtime_failure_control_enabled(const runtime_t *rt,
+                                    const char *target);
+int runtime_hold_nodes(runtime_t *rt, const world_t *w,
+                       const selector_result_t *nodes,
+                       const char *target, ulab_error_t *err);
 int runtime_restore_failure_controls(runtime_t *rt, ulab_error_t *err);
 int runtime_set_node_version(runtime_t *rt, const char *version,
                              ulab_error_t *err);

--- a/testing/lab/scenarios/p0/console/sites/tc-023-failed-site-operation-releases-lock.yaml
+++ b/testing/lab/scenarios/p0/console/sites/tc-023-failed-site-operation-releases-lock.yaml
@@ -1,13 +1,17 @@
 version: 1
 name: p0-tc-023-failed-site-operation-releases-lock
-description: Enable the deployment site-restart failure hook, issue a restart, and verify the site operation lock eventually clears even when the operation fails or times out.
+description: >-
+  Hold a restarted virtual site offline and verify the backend releases its
+  site-operation lock after the restart times out.
 seed: 5023
 suite: p0
 priority: p0
-tags: [virtual, console, site, failure-control, requires-site-restart-failure-control, tc-023]
+tags: [virtual, console, site, restart, failure-control, tc-023]
 status: active
+
 provider:
   type: virtual
+
 world:
   networks: 1
   sites_per_network: 1
@@ -16,29 +20,39 @@ world:
     amplifier: 1
     controller: 1
   ues_per_site: 0
+
 setup:
   create_via_bff: [networks, sites, nodes, node_site_links]
+
 runtime:
   start: [nodes]
   wait: [nodes_ready]
 
 phases:
-  - name: force_site_restart_failure
+  - name: start_failed_site_restart
     events:
       - type: failure_control
         target: site_restart
         state: on
       - type: restart_site
         sites: all
-        expect:
-          result: any
+    checks:
+      - type: site_operation_status_equals
+        sites: all
+        busy: true
+        timeout_seconds: 60
+
+  - name: wait_for_site_restart_timeout
     checks:
       - type: site_operation_status_equals
         sites: all
         busy: false
         timeout_seconds: 300
-  - name: restore_site_restart
+
+  - name: restore_site
     events:
       - type: failure_control
         target: site_restart
         state: off
+      - type: wait_nodes_ready
+        nodes: all

--- a/testing/lab/scenarios/p0/console/sites/tc-023-failed-site-operation-releases-lock.yaml
+++ b/testing/lab/scenarios/p0/console/sites/tc-023-failed-site-operation-releases-lock.yaml
@@ -1,8 +1,6 @@
 version: 1
 name: p0-tc-023-failed-site-operation-releases-lock
-description: >-
-  Hold a restarted virtual site offline and verify the backend releases its
-  site-operation lock after the restart times out.
+description: Hold a restarted virtual site offline and verify the backend releases its site-operation lock after the restart times out.
 seed: 5023
 suite: p0
 priority: p0

--- a/testing/lab/scenarios/p0/node/restart/tc-044-failed-node-restart-releases-lock.yaml
+++ b/testing/lab/scenarios/p0/node/restart/tc-044-failed-node-restart-releases-lock.yaml
@@ -1,13 +1,15 @@
 version: 1
 name: p0-tc-044-failed-node-restart-releases-lock
-description: Enable the deployment node-restart failure hook, issue a controller restart, and verify its operation lock eventually clears after failure or timeout.
+description: Hold a restarted controller offline and verify the backend releases its node-operation lock after the restart times out.
 seed: 5044
 suite: p0
 priority: p0
-tags: [virtual, node, restart, failure-control, requires-node-restart-failure-control, tc-044]
+tags: [virtual, node, restart, failure-control, tc-044]
 status: active
+
 provider:
   type: virtual
+
 world:
   networks: 1
   sites_per_network: 1
@@ -16,14 +18,16 @@ world:
     amplifier: 1
     controller: 1
   ues_per_site: 0
+
 setup:
   create_via_bff: [networks, sites, nodes, node_site_links]
+
 runtime:
   start: [nodes]
   wait: [nodes_ready]
 
 phases:
-  - name: force_node_restart_failure
+  - name: start_failed_restart
     events:
       - type: failure_control
         target: node_restart
@@ -31,16 +35,25 @@ phases:
       - type: restart_nodes
         type_selector: controller
         count_per_network: 1
-        expect:
-          result: any
+    checks:
+      - type: node_operation_status_equals
+        type_selector: controller
+        count_per_network: 1
+        busy: true
+        timeout_seconds: 60
+
+  - name: wait_for_restart_timeout
     checks:
       - type: node_operation_status_equals
         type_selector: controller
         count_per_network: 1
         busy: false
         timeout_seconds: 300
-  - name: restore_node_restart
+
+  - name: restore_controller
     events:
       - type: failure_control
         target: node_restart
         state: off
+      - type: wait_nodes_ready
+        nodes: all

--- a/testing/lab/scenarios/p0/software-update/tc-062-update-timeout-releases-lock.yaml
+++ b/testing/lab/scenarios/p0/software-update/tc-062-update-timeout-releases-lock.yaml
@@ -1,13 +1,15 @@
 version: 1
 name: p0-tc-062-update-timeout-releases-lock
-description: Enable the software-timeout hook, request a controller update, and verify the node operation lock clears after the timeout without relying on the existing WIP update-failure scenarios.
+description: Hold the controller offline after an update request and verify the backend releases its node-operation lock after timeout.
 seed: 5062
 suite: p0
 priority: p0
-tags: [virtual, software-update, timeout, failure-control, requires-software-timeout-failure-control, tc-062]
+tags: [virtual, software-update, timeout, failure-control, tc-062]
 status: active
+
 provider:
   type: virtual
+
 world:
   networks: 1
   sites_per_network: 1
@@ -16,8 +18,10 @@ world:
     amplifier: 1
     controller: 1
   ues_per_site: 0
+
 setup:
   create_via_bff: [networks, sites, nodes, node_site_links]
+
 runtime:
   start: [nodes]
   wait: [nodes_ready]
@@ -38,7 +42,8 @@ phases:
         status: update_available
         desired_version: ${ULAB_SOFTWARE_TARGET_VERSION}
         timeout_seconds: 120
-  - name: force_timeout
+
+  - name: start_update_timeout
     events:
       - type: failure_control
         target: software_timeout
@@ -48,16 +53,25 @@ phases:
         count_per_network: 1
         app: example
         tag: ${ULAB_SOFTWARE_TARGET_VERSION}
-        expect:
-          result: any
+    checks:
+      - type: node_operation_status_equals
+        type_selector: controller
+        count_per_network: 1
+        busy: true
+        timeout_seconds: 60
+
+  - name: wait_for_update_timeout
     checks:
       - type: node_operation_status_equals
         type_selector: controller
         count_per_network: 1
         busy: false
         timeout_seconds: 300
-  - name: restore_updates
+
+  - name: restore_controller
     events:
       - type: failure_control
         target: software_timeout
         state: off
+      - type: wait_nodes_ready
+        nodes: all

--- a/testing/lab/src/event_runtime.c
+++ b/testing/lab/src/event_runtime.c
@@ -21,6 +21,11 @@
 #define NODE_CONNECTIVITY_POLL_DEFAULT_SEC 2u
 #define NODE_CONNECTIVITY_POLL_MAX_SEC     30u
 
+static int site_node_selection(const world_t *world,
+                               const site_t *site,
+                               selector_result_t *nodes,
+                               ulab_error_t *err);
+
 static int event_state_enabled(const event_spec_t *event, int *enabled,
                                ulab_error_t *err) {
     if (ulab_streq(event->status, "on") ||
@@ -297,11 +302,23 @@ static int event_restart_nodes(event_ctx_t *ctx,
 
     for (i = 0; i < res.count; i++) {
         node_t *node;
+        selector_result_t selected;
 
         node = &ctx->world->nodes[res.idx[i]];
         if (bff_restart_node(ctx->bff, node, err)) {
             selector_result_free(&res);
             return ULAB_ERR;
+        }
+
+        if (runtime_failure_control_enabled(ctx->runtime,
+                                            "node_restart")) {
+            selected.idx = &res.idx[i];
+            selected.count = 1;
+            if (runtime_hold_nodes(ctx->runtime, ctx->world, &selected,
+                                   "node_restart", err)) {
+                selector_result_free(&res);
+                return ULAB_ERR;
+            }
         }
     }
 
@@ -582,6 +599,21 @@ static int event_restart_site(event_ctx_t *ctx,
             selector_result_free(&sites);
             return ULAB_ERR;
         }
+
+        if (runtime_failure_control_enabled(ctx->runtime,
+                                            "site_restart")) {
+            selector_result_t nodes;
+
+            memset(&nodes, 0, sizeof(nodes));
+            if (site_node_selection(ctx->world, site, &nodes, err) ||
+                runtime_hold_nodes(ctx->runtime, ctx->world, &nodes,
+                                   "site_restart", err)) {
+                selector_result_free(&nodes);
+                selector_result_free(&sites);
+                return ULAB_ERR;
+            }
+            selector_result_free(&nodes);
+        }
     }
 
     selector_result_free(&sites);
@@ -771,6 +803,19 @@ static int event_software_update(event_ctx_t *ctx,
                                 event->tag, err)) {
             selector_result_free(&res);
             return ULAB_ERR;
+        }
+
+        if (runtime_failure_control_enabled(ctx->runtime,
+                                            "software_timeout")) {
+            selector_result_t selected;
+
+            selected.idx = &res.idx[i];
+            selected.count = 1;
+            if (runtime_hold_nodes(ctx->runtime, ctx->world, &selected,
+                                   "software_timeout", err)) {
+                selector_result_free(&res);
+                return ULAB_ERR;
+            }
         }
     }
 

--- a/testing/lab/src/runtime.c
+++ b/testing/lab/src/runtime.c
@@ -1218,6 +1218,64 @@ static const failure_control_def_t *failure_control_def(
     return NULL;
 }
 
+static int native_virtual_failure_control(const runtime_t *rt,
+                                          const char *target) {
+    if (rt == NULL || !ulab_streq(rt->provider, "virtual")) {
+        return 0;
+    }
+
+    return ulab_streq(target, "node_restart") ||
+           ulab_streq(target, "site_restart") ||
+           ulab_streq(target, "software_timeout");
+}
+
+int runtime_failure_control_enabled(const runtime_t *rt,
+                                    const char *target) {
+    const failure_control_def_t *def;
+
+    if (rt == NULL || target == NULL) {
+        return 0;
+    }
+
+    def = failure_control_def(target);
+    return def != NULL && (rt->failure_controls & def->bit) != 0;
+}
+
+int runtime_hold_nodes(runtime_t *rt, const world_t *w,
+                       const selector_result_t *nodes,
+                       const char *target, ulab_error_t *err) {
+    size_t i;
+
+    if (rt == NULL || w == NULL || nodes == NULL || target == NULL) {
+        snprintf(err->msg, sizeof(err->msg),
+                 "hold nodes requires runtime, world, nodes, and target");
+        return ULAB_ERR;
+    }
+
+    for (i = 0; i < nodes->count; i++) {
+        const node_t *node;
+        char args[ULAB_MAX_ARGS];
+        int rc;
+
+        node = &w->nodes[nodes->idx[i]];
+        rc = snprintf(args, sizeof(args), "%s %s %s",
+                      target, node->id, rt->run_dir);
+        if (rc < 0 || (size_t)rc >= sizeof(args)) {
+            snprintf(err->msg, sizeof(err->msg),
+                     "hold-node args too long for node %.128s", node->id);
+            return ULAB_ERR;
+        }
+
+        ulab_status("FAULT", "hold node=%s target=%s",
+                    node->bff_id, target);
+        if (run_script(rt, "hold-node.sh", args, err)) {
+            return ULAB_ERR;
+        }
+    }
+
+    return ULAB_OK;
+}
+
 int runtime_set_failure_control(runtime_t *rt,
                                 const char *target,
                                 int enabled,
@@ -1239,18 +1297,33 @@ int runtime_set_failure_control(runtime_t *rt,
         return ULAB_ERR;
     }
 
-    rc = snprintf(args, sizeof(args), "%s %s", target,
-                  enabled ? "on" : "off");
-    if (rc < 0 || (size_t)rc >= sizeof(args)) {
-        snprintf(err->msg, sizeof(err->msg),
-                 "failure control arguments too long");
-        return ULAB_ERR;
-    }
-
     ulab_status("FAULT", "%s failure %s", target,
                 enabled ? "on" : "off");
-    if (run_script(rt, "test-control.sh", args, err)) {
-        return ULAB_ERR;
+
+    if (native_virtual_failure_control(rt, target)) {
+        if (!enabled) {
+            rc = snprintf(args, sizeof(args), "%s %s",
+                          target, rt->run_dir);
+            if (rc < 0 || (size_t)rc >= sizeof(args)) {
+                snprintf(err->msg, sizeof(err->msg),
+                         "failure control arguments too long");
+                return ULAB_ERR;
+            }
+            if (run_script(rt, "release-held-nodes.sh", args, err)) {
+                return ULAB_ERR;
+            }
+        }
+    } else {
+        rc = snprintf(args, sizeof(args), "%s %s", target,
+                      enabled ? "on" : "off");
+        if (rc < 0 || (size_t)rc >= sizeof(args)) {
+            snprintf(err->msg, sizeof(err->msg),
+                     "failure control arguments too long");
+            return ULAB_ERR;
+        }
+        if (run_script(rt, "test-control.sh", args, err)) {
+            return ULAB_ERR;
+        }
     }
 
     if (enabled) {


### PR DESCRIPTION
Fix #1575 

```
➜  lab git:(ukama-lab_1575_2) ✗ ULAB_OVS_ALLOW_UNMETERED_FALLBACK=1 ./bin/ukama-lab validate scenarios/p0/node/restart/tc-044-failed-node-restart-releases-lock.yaml \
  --sim-type ukama_data \
  --warehouse-url http://warehouse-ukama.udev.ukama.com \
  --factory-url http://factory-ukama.udev.ukama.com \
  --bff https://bff.udev.ukama.com/gateway/graphql \
  --out runs \
  --verbose \
  --repo /home/kashif/work/ukama/repos/ukama/

SCENARIO   p0-tc-044-failed-node-restart-releases-lock
PURPOSE    Hold a restarted controller offline and verify the backend releases its node-operation lock after the restart times out.
WORLD      networks=1 sites=1 nodes=3 ues=0
WORLD      subscribers=0 packages=0
NET        ensure lab podman network
SITE       factory/build/start site node bundles
SITE       factory/build/start site-001
SITE       site-001 tnode=uk-sa2632-tnode-v0-1224 cnode=uk-sa2632-cnode-v0-1224 anode=uk-sa2632-anode-v0-1224
NODE       wait nodes ready
NODE       wait ready lab-p0-tc-044-failed-node-restart-releases-lock-5044-1786051885-tower-site-001-001
NODE       wait ready lab-p0-tc-044-failed-node-restart-releases-lock-5044-1786051885-amplifier-site-001-001
NODE       wait ready lab-p0-tc-044-failed-node-restart-releases-lock-5044-1786051885-controller-site-001-001
BACKEND    creating backend world resources
NETWORK    add network net-001
BACKEND    site site-001 anchor online uk-sa2632-tnode-v0-1224 lat=-999.000000 lng=-999.000000
SITE       add site site-001
PHASE      start_failed_restart
EVENT      failure_control
FAULT      node_restart failure on
PASS       event start_failed_restart/failure_control: ok
EVENT      restart_nodes
FAULT      hold node=uk-sa2632-cnode-v0-1224 target=node_restart
PASS       event start_failed_restart/restart_nodes: ok
PHASE      wait_for_restart_timeout
PHASE      restore_controller
EVENT      failure_control
FAULT      node_restart failure off
PASS       event restore_controller/failure_control: ok
EVENT      wait_nodes_ready
NODE       wait ready lab-p0-tc-044-failed-node-restart-releases-lock-5044-1786051885-tower-site-001-001
NODE       wait ready lab-p0-tc-044-failed-node-restart-releases-lock-5044-1786051885-amplifier-site-001-001
NODE       wait ready lab-p0-tc-044-failed-node-restart-releases-lock-5044-1786051885-controller-site-001-001
PASS       event restore_controller/wait_nodes_ready: ok
VERIFY     run checks
PASS       node_operation_status_equals: matched=1/1 busy=true has_operation=true type=RestartNode status=RUNNING
PASS       node_operation_status_equals: matched=1/1 busy=false has_operation=false type= status=
CLEANUP    detach UE sessions
CLEANUP    cleanup UE containers
CLEANUP    delete backend resources
CLEANUP    stop media/nodes/network
PASS       events=4 checks=2 artifacts=runs/lab-p0-tc-044-failed-node-restart-releases-lock-5044-1786051885

```