### PR TITLE
FIX: sim/tc-086-deactivate-reactivate.yaml

### DIFF
--- a/nodes/apps/pcrf/pkg/controller/controller.go
+++ b/nodes/apps/pcrf/pkg/controller/controller.go
@@ -514,6 +514,12 @@ func (c *Controller) GetFlowsForImsi(ctx *gin.Context, req *api.GetFlowsForImsi)
 		return nil, fmt.Errorf("failed to get active session for Imsi %s. Error: %w", req.Imsi, err)
 	}
 
+	if s.FlowState == store.FlowsPaused {
+		log.Infof("Session for Imsi %s is paused; reporting flow as withdrawn", req.Imsi)
+
+		return nil, rest.HttpError{HttpCode: http.StatusNotFound, Message: "flow withdrawn (service paused)"}
+	}
+
 	fRx, err := c.store.GetFlowForMeter(s.RxMeterID.ID)
 	if err != nil {
 		log.Errorf("Failed to get RX flow for Imsi %s. Error: %v", req.Imsi, err)

--- a/nodes/apps/pcrf/pkg/controller/controller.go
+++ b/nodes/apps/pcrf/pkg/controller/controller.go
@@ -676,12 +676,56 @@ func (c *Controller) UpdateSubscriber(ctx *gin.Context, req *api.UpdateSubscribe
 				return err
 			}
 		}
+	} else if *req.IsServiceOn {
+		// No live session to resume
+		if err := c.recreateSessionFromHistory(ctx, sub); err != nil {
+			return err
+		}
 	}
 
 	if err := c.store.UpdateSubscriberServiceStatus(sub, *req.IsServiceOn); err != nil {
 		log.Errorf("Failed to update service status for imsi %s. Error: %v", req.Imsi, err)
 
 		return fmt.Errorf("failed to update service status for imsi %s. Error: %w", req.Imsi, err)
+	}
+
+	return nil
+}
+
+func (c *Controller) recreateSessionFromHistory(ctx *gin.Context, sub *store.Subscriber) error {
+	sessions, err := c.store.GetSessionsByImsi(sub.Imsi)
+	if err != nil {
+		log.Errorf("Failed to get session history for imsi %s. Error: %v", sub.Imsi, err)
+
+		return fmt.Errorf("failed to get session history for imsi %s. Error: %w", sub.Imsi, err)
+	}
+
+	if len(sessions) == 0 {
+		log.Infof("No session history for imsi %s; nothing to recreate until next UE attach", sub.Imsi)
+
+		return nil
+	}
+
+	last := sessions[0]
+	for _, se := range sessions[1:] {
+		if se.ID > last.ID {
+			last = se
+		}
+	}
+
+	sub.ServiceOn = true
+
+	s, rxF, txF, err := c.store.CreateSession(sub, last.UeIpAddr, c.nodeId)
+	if err != nil {
+		log.Errorf("Failed to recreate session for imsi %s. Error: %v", sub.Imsi, err)
+
+		return fmt.Errorf("failed to recreate session for imsi %s. Error: %w", sub.Imsi, err)
+	}
+
+	if err := c.sm.CreateSesssion(ctx, sub, s, rxF, txF); err != nil {
+		log.Errorf("Failed to wire up recreated session for imsi %s. Error: %v", sub.Imsi, err)
+
+		return fmt.Errorf("failed to wire up recreated session for imsi %s. Error: %w", sub.Imsi, err)
 	}
 
 	return nil

--- a/nodes/apps/pcrf/pkg/controller/controller.go
+++ b/nodes/apps/pcrf/pkg/controller/controller.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/ukama/ukama/nodes/apps/pcrf/pkg/controller/session"
 	"github.com/ukama/ukama/nodes/apps/pcrf/pkg/controller/store"
 	"github.com/ukama/ukama/nodes/apps/pcrf/pkg/datapath"
+	"github.com/ukama/ukama/systems/common/rest"
 	"github.com/ukama/ukama/systems/common/uuid"
 
 	log "github.com/sirupsen/logrus"
@@ -488,6 +490,12 @@ func (c *Controller) GetFlowsForImsi(ctx *gin.Context, req *api.GetFlowsForImsi)
 
 	_, err := c.store.GetSubscriber(req.Imsi)
 	if err != nil {
+		if errors.Is(err, store.ErrSubscriberNotFound) {
+			log.Infof("No subscriber for Imsi %s; reporting flow as withdrawn", req.Imsi)
+
+			return nil, rest.HttpError{HttpCode: http.StatusNotFound, Message: "subscriber not found"}
+		}
+
 		log.Errorf("Failed to get subscriber with Imsi %s. Error: %v", req.Imsi, err)
 
 		return nil, fmt.Errorf("failed to get subscriber with Imsi %s. Error: %w", req.Imsi, err)
@@ -495,6 +503,12 @@ func (c *Controller) GetFlowsForImsi(ctx *gin.Context, req *api.GetFlowsForImsi)
 
 	s, err := c.store.GetActiveSessionByImsi(req.Imsi)
 	if err != nil {
+		if errors.Is(err, store.ErrSessionNotFound) {
+			log.Infof("No active session for Imsi %s; reporting flow as withdrawn", req.Imsi)
+
+			return nil, rest.HttpError{HttpCode: http.StatusNotFound, Message: "active session not found"}
+		}
+
 		log.Errorf("Failed to get active session for Imsi %s. Error: %v", req.Imsi, err)
 
 		return nil, fmt.Errorf("failed to get active session for Imsi %s. Error: %w", req.Imsi, err)

--- a/nodes/apps/pcrf/pkg/controller/store/store.go
+++ b/nodes/apps/pcrf/pkg/controller/store/store.go
@@ -31,6 +31,7 @@ const PCRFDB = "/ukama/apps/db/pcrf.db"
 
 var (
 	ErrSubscriberNotFound = errors.New("subscriber not found")
+	ErrSessionNotFound    = errors.New("active session not found")
 	ErrPolicyInvalid      = errors.New("policy invalid for subscriber")
 	ErrDataCapExceeded    = errors.New("data cap exceeded")
 )
@@ -1145,6 +1146,10 @@ func (s *Store) GetActiveSessionByImsi(imsi string) (*Session, error) {
 	SELECT id, node_id, subscriber_id, policy_id, apnname, ueipaddr, starttime, endtime , txbytes , rxbytes , totalbytes , txmeter_id, rxmeter_id, state, flowstate, sync, updatedat FROM sessions WHERE subscriber_id = (SELECT id FROM subscribers WHERE imsi = ?) AND state = 1
 	`, imsi).Scan(&session.ID, &session.NodeId, &session.SubscriberID.ID, &bid, &session.ApnName, &session.UeIpAddr, &session.StartTime, &session.EndTime, &session.TxBytes, &session.RxBytes, &session.TotalBytes, &session.TxMeterID.ID, &session.RxMeterID.ID, &session.State, &session.FlowState, &session.Sync, &session.UpdatedAt)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: imsi %s", ErrSessionNotFound, imsi)
+		}
+
 		return nil, err
 	}
 

--- a/nodes/ukamaOS/distro/system/meshd/src/network.c
+++ b/nodes/ukamaOS/distro/system/meshd/src/network.c
@@ -55,6 +55,8 @@ STATIC void setup_webservice_endpoints(Config *config, UInst *instance) {
 			     &callback_forward_service, config);
   ulfius_add_endpoint_by_val(instance, "PUT", PREFIX_FWDSERVICE, NULL, 0,
 			     &callback_forward_service, config);
+  ulfius_add_endpoint_by_val(instance, "PATCH", PREFIX_FWDSERVICE, NULL, 0,
+			     &callback_forward_service, config);
   ulfius_add_endpoint_by_val(instance, "DELETE", PREFIX_FWDSERVICE, NULL, 0,
 			     &callback_forward_service, config);
 

--- a/systems/messaging/mesh/src/network.c
+++ b/systems/messaging/mesh/src/network.c
@@ -167,6 +167,8 @@ static void setup_forward_endpoints(Config *config, UInst *instance) {
 							   &callback_forward, config);
     ulfius_add_endpoint_by_val(instance, "PUT", EP_FORWARD, NULL, 0,
 							   &callback_forward, config);
+    ulfius_add_endpoint_by_val(instance, "PATCH", EP_FORWARD, NULL, 0,
+							   &callback_forward, config);
     ulfius_add_endpoint_by_val(instance, "DELETE", EP_FORWARD, NULL, 0,
 							   &callback_forward, config);
 

--- a/testing/lab/scripts/verify-ue-policy-block.sh
+++ b/testing/lab/scripts/verify-ue-policy-block.sh
@@ -36,7 +36,7 @@ require_value() {
 
 require_value UE_CONTAINER
 require_value TNODE_CONTAINER
-require_value TNODE_IP
+require_value TOWER_IP
 require_value MEDIA_CONTAINER
 require_value MEDIA_IP
 require_value IMSI
@@ -51,8 +51,8 @@ if ! podman exec "$UE_CONTAINER" ip route get "$MEDIA_IP" 2>/dev/null | \
 fi
 
 if ! podman exec "$MEDIA_CONTAINER" ip route get "$UE_IP" 2>/dev/null | \
-    grep -q "via $TNODE_IP"; then
-    echo "media return route is not using site tower: ue=$UE_KEY via=$TNODE_IP" >&2
+    grep -q "via $TOWER_IP"; then
+    echo "media return route is not using site tower: ue=$UE_KEY via=$TOWER_IP" >&2
     exit 1
 fi
 

--- a/testing/lab/src/check_runtime.c
+++ b/testing/lab/src/check_runtime.c
@@ -429,7 +429,8 @@ int check_runtime(check_ctx_t *ctx, const check_spec_t *check,
             sleep(1);
         } while (1);
 
-        if (expected && check->type == CHECK_TRAFFIC_BLOCKED) {
+        if (expected && (check->type == CHECK_TRAFFIC_BLOCKED ||
+                        check->type == CHECK_TRAFFIC_UNAVAILABLE)) {
             memset(&session_err, 0, sizeof(session_err));
             if (runtime_verify_ue_policy_blocks(ctx->runtime, ctx->world,
                                                 &sel, &session_err) != ULAB_OK) {
@@ -447,7 +448,8 @@ int check_runtime(check_ctx_t *ctx, const check_spec_t *check,
                           sizeof(res->detail) - (size_t)n,
                           " traffic_error=%.256s", tmp.msg);
         }
-        if (!expected && check->type == CHECK_TRAFFIC_BLOCKED &&
+        if (!expected && (check->type == CHECK_TRAFFIC_BLOCKED ||
+                         check->type == CHECK_TRAFFIC_UNAVAILABLE) &&
             n > 0 && (size_t)n < sizeof(res->detail) && session_err.msg[0]) {
             snprintf(res->detail + n,
                      sizeof(res->detail) - (size_t)n,


### PR DESCRIPTION
This PR fixes #1628 and closes #1628  by providing the following:

- various fixes
-
Now passing :

```
SCENARIO   p0-console-sim-deactivate-reactivate
PURPOSE    Deactivate a customer's SIM through BFF, verify attachment and traffic are blocked while package history remains, then reactivate it and restore service.
WORLD      networks=1 sites=1 nodes=3 ues=1
WORLD      subscribers=1 packages=1
NET        ensure lab podman network
SITE       factory/build/start site node bundles
SITE       factory/build/start site-001
SITE       site-001 tnode=uk-sa2634-tnode-v0-5a2f cnode=uk-sa2634-cnode-v0-5a2f anode=uk-sa2634-anode-v0-5a2f
NODE       wait nodes ready
NODE       wait ready lab-p0-console-sim-deactivate-reactivate-4811-1787700174-tower-site-001-001
NODE       wait ready lab-p0-console-sim-deactivate-reactivate-4811-1787700174-amplifier-site-001-001
NODE       wait ready lab-p0-console-sim-deactivate-reactivate-4811-1787700174-controller-site-001-001
BACKEND    creating backend world resources
NETWORK    add network net-001
BACKEND    waiting site site-001 anchor online/location
BACKEND    waiting site site-001 anchor online/location
BACKEND    waiting site site-001 anchor online/location
BACKEND    waiting site site-001 anchor online/location
BACKEND    site site-001 anchor online uk-sa2634-tnode-v0-5a2f lat=33.942810 lng=-118.410000
SITE       add site site-001
FACTORY    batch BATCH-ULAB-lab-p0-console-sim-deactivate-reactivate-4811-1787700174 count=1
FACTORY    add ue-000001 iccid=8910302425262465061 imsi=001010526246506
FACTORY    wait batch BATCH-ULAB-lab-p0-console-sim-deactivate-reactivate-4811-1787700174 count=1
FACTORY    export runs/lab-p0-console-sim-deactivate-reactivate-4811-1787700174/factory-sims.csv
FACTORY    ue ue-000001 iccid=8910302425262465061 imsi=001010526246506
SIMPOOL    upload runs/lab-p0-console-sim-deactivate-reactivate-4811-1787700174/factory-sims.csv type=ukama_data
SIMPOOL    get unassigned sims type=ukama_data
SIMPOOL    match ue ue-000001 iccid=8910302425262465061 imsi=001010526246506 pool=101
PACKAGE    add package sim_plan__net-001
SUBSCRIBER add subscriber sub-000001
SIM        allocate sim ue-000001 iccid=8910302425262465061
SIM        verify sim package ue-000001 package=sim_plan__net-001
PHASE      establish_active_sim
EVENT      toggle_service
SERVICE    on
SERVICE    wait on lab-p0-console-sim-deactivate-reactivate-4811-1787700174-tower-site-001-001
PASS       event establish_active_sim/toggle_service: ok
EVENT      start_ues
MEDIA      start/ensure media target
MEDIA      wait ready
UE         start ue-000001 imsi=001010526246506 iccid=8910302425262465061 ip=192.168.8.2 site=site-001
PASS       event establish_active_sim/start_ues: ok
EVENT      wait_ues_attached
PASS       event establish_active_sim/wait_ues_attached: ok
PASS       traffic_allowed: ues=1 amount_mb=1 runtime_rc=0 attempts=1
PHASE      deactivate_sim
EVENT      toggle_sim_status
PASS       event deactivate_sim/toggle_sim_status: ok
EVENT      wait_sim_status
SIM        wait status=service_off sims=1 timeout=120s
SIM        da51369b-b8a0-4425-892f-fb5d457f47f9 status=service_off
PASS       event deactivate_sim/wait_sim_status: ok
PASS       traffic_unavailable: ues=1 amount_mb=1 runtime_rc=1 attempts=3 traffic_error=script failed: traffic.sh; see runs/lab-p0-console-sim-deactivate-reactivate-4811-1787700174/0014-traffic.sh.log
PHASE      reactivate_sim
EVENT      toggle_sim_status
PASS       event reactivate_sim/toggle_sim_status: ok
EVENT      wait_sim_status
SIM        wait status=service_on sims=1 timeout=120s
SIM        da51369b-b8a0-4425-892f-fb5d457f47f9 status=service_on
PASS       event reactivate_sim/wait_sim_status: ok
EVENT      wait_ues_attached
PASS       event reactivate_sim/wait_ues_attached: ok
PASS       traffic_allowed: ues=1 amount_mb=1 runtime_rc=0 attempts=32
UE         detach sessions before validation checks
CDR        wait 5 sec for PCRF CDR publisher
VERIFY     run checks
CHECK      package_state package=sim_plan expected=active timeout=30s poll=5s
PASS       package_state: package_state=1/1 expected=active
CHECK      package_assignment_count package=sim_plan expected=1 timeout=300s poll=5s
PASS       package_assignment_count: package_assignment_count=1/1 expected=1
CHECK      package_state package=sim_plan expected=active timeout=30s poll=5s
PASS       package_state: package_state=1/1 expected=active
CLEANUP    detach UE sessions
CLEANUP    cleanup UE containers
CLEANUP    delete backend resources
CLEANUP    stop media/nodes/network
PASS       events=8 checks=6 artifacts=runs/lab-p0-console-sim-deactivate-reactivate-4811-1787700174
```

