### PR TITLE
FIX: tc-106-multiple-session-usage.yaml #1639

### DIFF
--- a/nodes/apps/pcrf/pkg/controller/controller.go
+++ b/nodes/apps/pcrf/pkg/controller/controller.go
@@ -350,8 +350,6 @@ func (c *Controller) CreateSession(ctx *gin.Context, req *api.CreateSession) err
 			return fmt.Errorf("failed to end session on bridge for subscriber %s. Error: %w",
 				req.ImsiStr, err)
 		}
-
-		return nil
 	}
 
 	s, rxF, txF, err := c.store.CreateSession(sub, req.IpStr, c.nodeId)

--- a/nodes/apps/pcrf/pkg/controller/session/session.go
+++ b/nodes/apps/pcrf/pkg/controller/session/session.go
@@ -173,7 +173,7 @@ func (s *sessionManager) storeStats(imsi string, lastStats bool) error {
 			}
 
 			threshold := s.idle
-			if sc.s.TotalBytes == 0 {
+			if tNow-int64(sc.s.StartTime) < int64(s.newSessionGrace.Seconds()) {
 				threshold = s.newSessionGrace
 			}
 


### PR DESCRIPTION
This PR fixes #1639 and closes #1639 byt providing the following: 

- various fixes