### PR TITLE
Nodes/pcrf: update policy/sub reveser lookups. Fixes #1659

### DIFF
--- a/nodes/apps/pcrf/pkg/controller/controller.go
+++ b/nodes/apps/pcrf/pkg/controller/controller.go
@@ -302,18 +302,18 @@ func (c *Controller) CreateSession(ctx *gin.Context, req *api.CreateSession) err
 			log.Warnf("Subscriber %s not found on local node: %v", req.ImsiStr, err)
 			log.Infof("Fetching subscriber %s from remote asr", req.ImsiStr)
 
-			sub, err := c.rc.GetSubscriberProfile(req.ImsiStr)
-			if err != nil {
-				log.Errorf("Subscriber %s not found in remote asr either: %v", req.ImsiStr, err)
+			remoteSub, rerr := c.rc.GetSubscriberProfile(req.ImsiStr)
+			if rerr != nil {
+				log.Errorf("Subscriber %s not found in remote asr either: %v", req.ImsiStr, rerr)
 
 				return fmt.Errorf("subscriber %s not found either locally, nor in remote asr %w",
-					req.ImsiStr, err)
+					req.ImsiStr, rerr)
 			}
 
 			log.Infof("Subscriber %s found in remote asr", req.ImsiStr)
 			log.Infof("Registering subscriber %s in local node", req.ImsiStr)
 
-			_, err = c.store.CreateSubscriber(sub.Imsi, &sub.Policy, &sub.ReRoute, nil)
+			sub, err = c.store.CreateSubscriber(remoteSub.Imsi, &remoteSub.Policy, &remoteSub.ReRoute, nil)
 			if err != nil {
 				log.Errorf("Failed to create missing subscriber with imsi %s. Error: %v", req.Imsi, err)
 
@@ -321,9 +321,31 @@ func (c *Controller) CreateSession(ctx *gin.Context, req *api.CreateSession) err
 			}
 
 		case errors.Is(err, store.ErrPolicyInvalid):
-			log.Errorf("Subscriber %s has no valid policy: %v", req.ImsiStr, err)
+			log.Warnf("Subscriber %s has stale/invalid policy locally: %v", req.ImsiStr, err)
+			log.Infof("Reverse-looking up current policy for subscriber %s from remote asr", req.ImsiStr)
 
-			return fmt.Errorf("subscriber %s has no valid policy: %w", req.ImsiStr, err)
+			remoteSub, rerr := c.rc.GetSubscriberProfile(req.ImsiStr)
+			if rerr != nil {
+				log.Errorf("Reverse lookup failed for subscriber %s: %v", req.ImsiStr, rerr)
+
+				return fmt.Errorf("subscriber %s has no valid policy locally and reverse lookup failed: %w",
+					req.ImsiStr, err)
+			}
+
+			if _, rerr := c.store.UpdateSubscriber(remoteSub.Imsi, &remoteSub.Policy); rerr != nil {
+				log.Errorf("Failed to apply reverse-looked-up policy for subscriber %s: %v", req.ImsiStr, rerr)
+
+				return fmt.Errorf("failed to refresh policy for subscriber %s from remote asr: %w",
+					req.ImsiStr, rerr)
+			}
+
+			sub, err = c.validateSubscriber(req.ImsiStr)
+			if err != nil {
+				log.Errorf("Subscriber %s still has no valid policy after reverse lookup: %v", req.ImsiStr, err)
+
+				return fmt.Errorf("subscriber %s has no valid policy even after reverse lookup: %w",
+					req.ImsiStr, err)
+			}
 
 		case errors.Is(err, store.ErrDataCapExceeded):
 			log.Errorf("Subscriber %s exceeded data cap: %v", req.ImsiStr, err)

--- a/nodes/apps/pcrf/pkg/controller/controller.go
+++ b/nodes/apps/pcrf/pkg/controller/controller.go
@@ -320,7 +320,7 @@ func (c *Controller) CreateSession(ctx *gin.Context, req *api.CreateSession) err
 				return fmt.Errorf("failed to create missing subscriber with imsi %s. Error: %w", req.Imsi, err)
 			}
 
-		case errors.Is(err, store.ErrPolicyInvalid):
+		case errors.Is(err, store.ErrPolicyInvalid), errors.Is(err, store.ErrDataCapExceeded):
 			log.Warnf("Subscriber %s has stale/invalid policy locally: %v", req.ImsiStr, err)
 			log.Infof("Reverse-looking up current policy for subscriber %s from remote asr", req.ImsiStr)
 
@@ -346,11 +346,6 @@ func (c *Controller) CreateSession(ctx *gin.Context, req *api.CreateSession) err
 				return fmt.Errorf("subscriber %s has no valid policy even after reverse lookup: %w",
 					req.ImsiStr, err)
 			}
-
-		case errors.Is(err, store.ErrDataCapExceeded):
-			log.Errorf("Subscriber %s exceeded data cap: %v", req.ImsiStr, err)
-
-			return fmt.Errorf("subscriber %s exceeded data cap: %w", req.ImsiStr, err)
 
 		default:
 			log.Errorf("Failed to validate subscriber %s: %v", req.ImsiStr, err)

--- a/nodes/apps/pcrf/pkg/controller/store/store.go
+++ b/nodes/apps/pcrf/pkg/controller/store/store.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mattn/go-sqlite3"
@@ -38,6 +39,11 @@ var (
 
 type Store struct {
 	db *sql.DB
+
+	// policyMu guards read-compare-write sequences on a subscriber's policy so a
+	// reverse-lookup refresh and a delayed nodefeeder push can't interleave and
+	// let a stale policy clobber a fresher one.
+	policyMu sync.Mutex
 }
 
 // Initialization of the SQLite database and tables (assumed to be done separately)
@@ -552,6 +558,14 @@ func (s *Store) CreateUsage(sub *Subscriber) error {
 
 /* Create a subscriber */
 func (s *Store) CreateSubscriber(imsi string, p *api.Policy, ip *string, d *api.UsageDetails) (*Subscriber, error) {
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+
+	return s.createSubscriberLocked(imsi, p, ip, d)
+}
+
+// createSubscriberLocked assumes the caller already holds policyMu.
+func (s *Store) createSubscriberLocked(imsi string, p *api.Policy, ip *string, d *api.UsageDetails) (*Subscriber, error) {
 	var reouteId *int = nil
 
 	/* create a policy */
@@ -601,19 +615,43 @@ func (s *Store) CreateSubscriber(imsi string, p *api.Policy, ip *string, d *api.
 }
 
 func (s *Store) UpdateSubscriber(imsi string, p *api.Policy) (*Subscriber, error) {
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+
 	sub, err := s.GetSubscriber(imsi)
 	if err != nil {
 		log.Errorf("Failed to get subscriber %s from db. Error: %v", imsi, err)
 
 		if errors.Is(err, ErrSubscriberNotFound) {
 			log.Infof("Converting request to add subscriber for %s", imsi)
-			return s.CreateSubscriber(imsi, p, nil, nil)
+			return s.createSubscriberLocked(imsi, p, nil, nil)
 		}
 
 		return nil, fmt.Errorf("failed to get subscriber %s from db. Error: %w", imsi, err)
 	}
 
+	// A newer policy (reverse-lookup refresh, or a rollover push) may already be
+	// applied by the time this write lands. Reject an incoming policy that's
+	// older than what's already stored so a delayed/out-of-order push can't
+	// clobber a fresher one.
+	if p.StartTime < sub.PolicyID.StartTime {
+		log.Warnf("Ignoring stale policy update for subscriber %s: incoming policy start_time %d is older than stored policy start_time %d",
+			imsi, p.StartTime, sub.PolicyID.StartTime)
+
+		return sub, nil
+	}
+
 	if sub.PolicyID.ID == p.Uuid {
+		// Same policy: start_time can't distinguish ordering between two
+		// consumed-data updates (redelivery/retry can reorder them), so guard
+		// separately on consumed bytes, which only ever grow within a policy.
+		if p.Consumed < sub.PolicyID.Consumed {
+			log.Warnf("Ignoring stale consumed-data update for subscriber %s policy %s: incoming consumed %d is less than stored consumed %d",
+				imsi, sub.PolicyID.ID, p.Consumed, sub.PolicyID.Consumed)
+
+			return sub, nil
+		}
+
 		log.Debugf("Updating policy %s for subscriber %s", sub.PolicyID.ID, imsi)
 
 		sub.PolicyID.Consumed = p.Consumed
@@ -627,7 +665,7 @@ func (s *Store) UpdateSubscriber(imsi string, p *api.Policy) (*Subscriber, error
 		}
 	} else {
 		log.Debugf("Need to create a new policy %s for subscriber %s", p.Uuid, imsi)
-		return s.CreateSubscriber(imsi, p, nil, nil)
+		return s.createSubscriberLocked(imsi, p, nil, nil)
 	}
 
 	/* Rereading sub from db */

--- a/nodes/apps/pcrf/pkg/controller/store/store_test.go
+++ b/nodes/apps/pcrf/pkg/controller/store/store_test.go
@@ -152,3 +152,83 @@ func TestStore_Migration_UpgradesPreExistingSchema(t *testing.T) {
 
 	assert.NoError(t, upgraded.CreateTables())
 }
+
+func TestStore_UpdateSubscriber_RejectsOlderPolicyRollover(t *testing.T) {
+	s := newSharedTestStore(t)
+
+	now := time.Now()
+	current := &api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      1_000_000,
+		Burst:     100,
+		StartTime: now.Unix(),
+		EndTime:   now.Add(time.Hour).Unix(),
+	}
+
+	sub, err := s.CreateSubscriber("999991000000002", current, nil, nil)
+	assert.NoError(t, err)
+
+	newer := &api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      2_000_000,
+		Burst:     100,
+		StartTime: now.Add(time.Minute).Unix(),
+		EndTime:   now.Add(2 * time.Hour).Unix(),
+	}
+	_, err = s.UpdateSubscriber(sub.Imsi, newer)
+	assert.NoError(t, err)
+
+	got, err := s.GetSubscriber(sub.Imsi)
+	assert.NoError(t, err)
+	assert.Equal(t, newer.Uuid, got.PolicyID.ID, "rollover to a genuinely newer policy must apply")
+
+	// A delayed push for the original (older) rollover arrives after the newer
+	// one already landed - it must not clobber the newer policy.
+	stale := &api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      500_000,
+		Burst:     100,
+		StartTime: now.Add(-time.Minute).Unix(),
+		EndTime:   now.Add(30 * time.Minute).Unix(),
+	}
+	_, err = s.UpdateSubscriber(sub.Imsi, stale)
+	assert.NoError(t, err)
+
+	got, err = s.GetSubscriber(sub.Imsi)
+	assert.NoError(t, err)
+	assert.Equal(t, newer.Uuid, got.PolicyID.ID, "a stale/delayed policy push must not overwrite a newer policy")
+}
+
+func TestStore_UpdateSubscriber_RejectsOlderConsumedForSamePolicy(t *testing.T) {
+	s := newSharedTestStore(t)
+
+	now := time.Now()
+	policy := &api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      1_000_000,
+		Burst:     100,
+		StartTime: now.Unix(),
+		EndTime:   now.Add(time.Hour).Unix(),
+	}
+
+	sub, err := s.CreateSubscriber("999991000000003", policy, nil, nil)
+	assert.NoError(t, err)
+
+	ahead := &api.Policy{Uuid: policy.Uuid, Data: policy.Data, Consumed: 500_000, StartTime: policy.StartTime, EndTime: policy.EndTime}
+	_, err = s.UpdateSubscriber(sub.Imsi, ahead)
+	assert.NoError(t, err)
+
+	got, err := s.GetSubscriber(sub.Imsi)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(500_000), got.PolicyID.Consumed)
+
+	// A redelivered/retried update for the same policy carrying an older
+	// consumed value must not regress consumed bytes backwards.
+	behind := &api.Policy{Uuid: policy.Uuid, Data: policy.Data, Consumed: 100_000, StartTime: policy.StartTime, EndTime: policy.EndTime}
+	_, err = s.UpdateSubscriber(sub.Imsi, behind)
+	assert.NoError(t, err)
+
+	got, err = s.GetSubscriber(sub.Imsi)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(500_000), got.PolicyID.Consumed, "an out-of-order consumed-data update must not regress consumed bytes")
+}

--- a/testing/lab/scenarios/p0/data-package/policy/tc-116-reattach-recovers-policy-after-missed-push.yaml
+++ b/testing/lab/scenarios/p0/data-package/policy/tc-116-reattach-recovers-policy-after-missed-push.yaml
@@ -68,6 +68,9 @@ phases:
         seconds: 300
       - type: wait_nodes_ready
         nodes: all
+      - type: toggle_service
+        sites: all
+        state: on
       - type: start_ues
         ues: all
       - type: wait_ues_attached

--- a/testing/lab/scenarios/p0/data-package/policy/tc-116-reattach-recovers-policy-after-missed-push.yaml
+++ b/testing/lab/scenarios/p0/data-package/policy/tc-116-reattach-recovers-policy-after-missed-push.yaml
@@ -1,0 +1,100 @@
+version: 1
+name: p0-reattach-recovers-policy-after-missed-push
+description: >
+  Deterministically force the node offline for the entire window in which its
+  package expires and the queued successor package rolls over, so the
+  ASR-to-node policy push is guaranteed to miss the node (not merely racing
+  it). On reattach, the node must reverse-lookup the current policy from ASR
+  rather than rejecting the attach on its stale local copy.
+seed: 4525
+suite: p0
+priority: p0
+tags: [virtual, data-package, policy, restart, reattach]
+status: active
+provider:
+  type: virtual
+world:
+  networks: 1
+  sites_per_network: 1
+  nodes_per_site:
+    tower: 1
+    amplifier: 1
+    controller: 1
+  ues_per_site: 1
+packages:
+  - ref: current_plan
+    name: Missed Push Current
+    data_mb: 10
+    duration_minutes: 2
+    amount: 1.00
+    assign_percent: 100
+  - ref: successor_plan
+    name: Missed Push Successor
+    data_mb: 10
+    duration_minutes: 10
+    amount: 2.00
+    assign_percent: 0
+setup:
+  create_via_bff: [networks, sites, nodes, node_site_links, packages, subscribers, sims]
+runtime:
+  start: [nodes]
+  wait: [nodes_ready]
+phases:
+  - name: miss_the_push_and_reattach
+    events:
+      - type: toggle_service
+        sites: all
+        state: on
+      - type: start_ues
+        ues: all
+      - type: wait_ues_attached
+        ues: all
+      # Queue the successor while current_plan is still active, so its
+      # eventual expiration has somewhere to roll over to.
+      - type: purchase_package
+        ues: all
+        package: successor_plan
+      - type: traffic
+        ues: all
+        amount_mb: 1
+      - type: wait_node_connectivity
+        nodes: all
+        connectivity: Online
+        seconds: 120
+      - type: restart_nodes
+        nodes: all
+      - type: wait_node_connectivity
+        nodes: all
+        connectivity: Offline
+        seconds: 120
+      # current_plan's 2-minute duration must fully elapse while the node is
+      # confirmed offline: ASR's own policy-control loop detects the time
+      # expiry from its clock alone (no node involvement needed to trigger
+      # it), rolls over to successor_plan, and broadcasts the new policy to
+      # the node - a broadcast the node cannot possibly receive right now.
+      - type: wait
+        seconds: 150
+      - type: wait_node_connectivity
+        nodes: all
+        connectivity: Online
+        seconds: 300
+      - type: wait_nodes_ready
+        nodes: all
+      # The node comes back up still holding current_plan's now-expired
+      # policy, and never received the successor_plan push. Reattaching here
+      # must only succeed via a reverse-lookup to ASR, not the missed push.
+      - type: start_ues
+        ues: all
+      - type: wait_ues_attached
+        ues: all
+      - type: traffic
+        ues: all
+        amount_mb: 1
+    checks:
+      - type: package_state
+        ues: all
+        package: successor_plan
+        expected: active
+      - type: usage_per_sim
+        ues: all
+        expected: from_model

--- a/testing/lab/scenarios/p0/data-package/policy/tc-116-reattach-recovers-policy-after-missed-push.yaml
+++ b/testing/lab/scenarios/p0/data-package/policy/tc-116-reattach-recovers-policy-after-missed-push.yaml
@@ -1,11 +1,6 @@
 version: 1
 name: p0-reattach-recovers-policy-after-missed-push
-description: >
-  Deterministically force the node offline for the entire window in which its
-  package expires and the queued successor package rolls over, so the
-  ASR-to-node policy push is guaranteed to miss the node (not merely racing
-  it). On reattach, the node must reverse-lookup the current policy from ASR
-  rather than rejecting the attach on its stale local copy.
+description: Deterministically force the node offline for the entire window in which its package expires and the queued successor package rolls over, so the ASR-to-node policy push is guaranteed to miss the node. On reattach, the node must reverse-lookup the current policy from ASR rather than rejecting the attach on its stale local copy.
 seed: 4525
 suite: p0
 priority: p0
@@ -49,8 +44,6 @@ phases:
         ues: all
       - type: wait_ues_attached
         ues: all
-      # Queue the successor while current_plan is still active, so its
-      # eventual expiration has somewhere to roll over to.
       - type: purchase_package
         ues: all
         package: successor_plan
@@ -67,11 +60,6 @@ phases:
         nodes: all
         connectivity: Offline
         seconds: 120
-      # current_plan's 2-minute duration must fully elapse while the node is
-      # confirmed offline: ASR's own policy-control loop detects the time
-      # expiry from its clock alone (no node involvement needed to trigger
-      # it), rolls over to successor_plan, and broadcasts the new policy to
-      # the node - a broadcast the node cannot possibly receive right now.
       - type: wait
         seconds: 150
       - type: wait_node_connectivity
@@ -80,9 +68,6 @@ phases:
         seconds: 300
       - type: wait_nodes_ready
         nodes: all
-      # The node comes back up still holding current_plan's now-expired
-      # policy, and never received the successor_plan push. Reattaching here
-      # must only succeed via a reverse-lookup to ASR, not the missed push.
       - type: start_ues
         ues: all
       - type: wait_ues_attached


### PR DESCRIPTION
This PR fixes #1659 and closes #1659 by providing the following:

- updates  revere lookup flow.