### PR TITLE
Fix Usage counter inflated on policy rollover. Fixes #1663

### DIFF
--- a/nodes/apps/pcrf/pkg/client/policy.go
+++ b/nodes/apps/pcrf/pkg/client/policy.go
@@ -10,7 +10,9 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/ukama/ukama/nodes/apps/pcrf/pkg/api"
@@ -21,6 +23,8 @@ import (
 
 const ProfileEndpoint = "/v1/asr"
 const CDREndpoint = "/v1/cdr"
+
+var ErrRemoteSubscriberNotFound = errors.New("remote subscriber not found")
 
 type RemoteController interface {
 	GetSubscriberProfile(imsi string) (*api.Spr, error)
@@ -88,6 +92,14 @@ func (r *remoteControllerClient) GetSubscriberProfile(imsi string) (*api.Spr, er
 		log.Errorf("GetPolicy failure. error: %v", err)
 
 		return nil, fmt.Errorf("GetPolicy failure: %w", err)
+	}
+
+	if resp.StatusCode() == http.StatusNotFound {
+		return nil, fmt.Errorf("%w: imsi %s", ErrRemoteSubscriberNotFound, imsi)
+	}
+
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, fmt.Errorf("remote asr returned http %d for imsi %s", resp.StatusCode(), imsi)
 	}
 
 	err = json.Unmarshal(resp.Body(), &spr)

--- a/nodes/apps/pcrf/pkg/client/policy_test.go
+++ b/nodes/apps/pcrf/pkg/client/policy_test.go
@@ -1,0 +1,74 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2023-present, Ukama Inc.
+ */
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ukama/ukama/systems/common/rest"
+)
+
+func newTestRemoteControllerClient(t *testing.T, srv *httptest.Server) *remoteControllerClient {
+	t.Helper()
+
+	u, err := url.Parse(srv.URL)
+	assert.NoError(t, err)
+
+	return &remoteControllerClient{
+		u: u,
+		R: rest.NewRestyClient(u, false),
+	}
+}
+
+func TestGetSubscriberProfile_NotFound_ReturnsErrRemoteSubscriberNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestRemoteControllerClient(t, srv)
+
+	_, err := c.GetSubscriberProfile("999991000000099")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRemoteSubscriberNotFound))
+}
+
+func TestGetSubscriberProfile_OtherErrorStatus_ReturnsPlainError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestRemoteControllerClient(t, srv)
+
+	_, err := c.GetSubscriberProfile("999991000000099")
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, ErrRemoteSubscriberNotFound))
+}
+
+func TestGetSubscriberProfile_Success_ReturnsProfile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"imsi":"999991000000099","reroute":"http://localhost:8085"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestRemoteControllerClient(t, srv)
+
+	spr, err := c.GetSubscriberProfile("999991000000099")
+	assert.NoError(t, err)
+	assert.Equal(t, "999991000000099", spr.Imsi)
+}

--- a/nodes/apps/pcrf/pkg/controller/controller.go
+++ b/nodes/apps/pcrf/pkg/controller/controller.go
@@ -282,6 +282,16 @@ func (c *Controller) serviceEnabled() bool {
 	return c.serviceOn
 }
 
+func remoteLookupHttpError(imsi string, rerr error) error {
+	if errors.Is(rerr, client.ErrRemoteSubscriberNotFound) {
+		return rest.HttpError{HttpCode: http.StatusNotFound,
+			Message: fmt.Sprintf("subscriber %s not found", imsi)}
+	}
+
+	return rest.HttpError{HttpCode: http.StatusServiceUnavailable,
+		Message: fmt.Sprintf("subscriber %s: remote asr lookup failed", imsi)}
+}
+
 func (c *Controller) CreateSession(ctx *gin.Context, req *api.CreateSession) error {
 	var sub *store.Subscriber
 	var err error
@@ -306,8 +316,7 @@ func (c *Controller) CreateSession(ctx *gin.Context, req *api.CreateSession) err
 			if rerr != nil {
 				log.Errorf("Subscriber %s not found in remote asr either: %v", req.ImsiStr, rerr)
 
-				return fmt.Errorf("subscriber %s not found either locally, nor in remote asr %w",
-					req.ImsiStr, rerr)
+				return remoteLookupHttpError(req.ImsiStr, rerr)
 			}
 
 			log.Infof("Subscriber %s found in remote asr", req.ImsiStr)
@@ -317,7 +326,8 @@ func (c *Controller) CreateSession(ctx *gin.Context, req *api.CreateSession) err
 			if err != nil {
 				log.Errorf("Failed to create missing subscriber with imsi %s. Error: %v", req.Imsi, err)
 
-				return fmt.Errorf("failed to create missing subscriber with imsi %s. Error: %w", req.Imsi, err)
+				return rest.HttpError{HttpCode: http.StatusInternalServerError,
+					Message: fmt.Sprintf("failed to create missing subscriber with imsi %s", req.Imsi)}
 			}
 
 		case errors.Is(err, store.ErrPolicyInvalid), errors.Is(err, store.ErrDataCapExceeded):
@@ -328,29 +338,29 @@ func (c *Controller) CreateSession(ctx *gin.Context, req *api.CreateSession) err
 			if rerr != nil {
 				log.Errorf("Reverse lookup failed for subscriber %s: %v", req.ImsiStr, rerr)
 
-				return fmt.Errorf("subscriber %s has no valid policy locally and reverse lookup failed: %w",
-					req.ImsiStr, rerr)
+				return remoteLookupHttpError(req.ImsiStr, rerr)
 			}
 
 			if _, rerr := c.store.UpdateSubscriber(remoteSub.Imsi, &remoteSub.Policy); rerr != nil {
 				log.Errorf("Failed to apply reverse-looked-up policy for subscriber %s: %v", req.ImsiStr, rerr)
 
-				return fmt.Errorf("failed to refresh policy for subscriber %s from remote asr: %w",
-					req.ImsiStr, rerr)
+				return rest.HttpError{HttpCode: http.StatusInternalServerError,
+					Message: fmt.Sprintf("failed to refresh policy for subscriber %s from remote asr", req.ImsiStr)}
 			}
 
 			sub, err = c.validateSubscriber(req.ImsiStr)
 			if err != nil {
 				log.Errorf("Subscriber %s still has no valid policy after reverse lookup: %v", req.ImsiStr, err)
 
-				return fmt.Errorf("subscriber %s has no valid policy even after reverse lookup: %w",
-					req.ImsiStr, err)
+				return rest.HttpError{HttpCode: http.StatusForbidden,
+					Message: fmt.Sprintf("subscriber %s has no valid policy even after reverse lookup", req.ImsiStr)}
 			}
 
 		default:
 			log.Errorf("Failed to validate subscriber %s: %v", req.ImsiStr, err)
 
-			return fmt.Errorf("failed to validate subscriber %s: %v", req.ImsiStr, err)
+			return rest.HttpError{HttpCode: http.StatusInternalServerError,
+				Message: fmt.Sprintf("failed to validate subscriber %s", req.ImsiStr)}
 		}
 	}
 

--- a/nodes/apps/pcrf/pkg/controller/controller.go
+++ b/nodes/apps/pcrf/pkg/controller/controller.go
@@ -329,7 +329,7 @@ func (c *Controller) CreateSession(ctx *gin.Context, req *api.CreateSession) err
 				log.Errorf("Reverse lookup failed for subscriber %s: %v", req.ImsiStr, rerr)
 
 				return fmt.Errorf("subscriber %s has no valid policy locally and reverse lookup failed: %w",
-					req.ImsiStr, err)
+					req.ImsiStr, rerr)
 			}
 
 			if _, rerr := c.store.UpdateSubscriber(remoteSub.Imsi, &remoteSub.Policy); rerr != nil {

--- a/nodes/apps/pcrf/pkg/controller/controller_test.go
+++ b/nodes/apps/pcrf/pkg/controller/controller_test.go
@@ -10,6 +10,7 @@ package controller
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -22,7 +23,9 @@ import (
 
 	"github.com/ukama/ukama/nodes/apps/pcrf/mocks"
 	"github.com/ukama/ukama/nodes/apps/pcrf/pkg/api"
+	"github.com/ukama/ukama/nodes/apps/pcrf/pkg/client"
 	"github.com/ukama/ukama/nodes/apps/pcrf/pkg/controller/store"
+	"github.com/ukama/ukama/systems/common/rest"
 	"github.com/ukama/ukama/systems/common/uuid"
 )
 
@@ -376,4 +379,82 @@ func TestController_CreateSession_IgnoresServiceStatus(t *testing.T) {
 	// CreateSession must not gate on ServiceOn anywhere in its path.
 	err := c.CreateSession(&gin.Context{}, req)
 	assert.NoError(t, err)
+}
+
+func TestController_CreateSession_UnknownSubscriber_RemoteNotFound_Returns404(t *testing.T) {
+	s := newTestStore(t)
+	sm := mocks.NewSessionManager(t)
+	rc := mocks.NewRemoteController(t)
+
+	imsi := "999992000000011"
+	rc.On("GetSubscriberProfile", imsi).Return(nil, client.ErrRemoteSubscriberNotFound).Once()
+
+	c := &Controller{store: s, sm: sm, rc: rc, serviceOn: true}
+
+	err := c.CreateSession(&gin.Context{}, &api.CreateSession{ImsiStr: imsi, IpStr: "10.10.10.51"})
+	assert.Error(t, err)
+
+	httpErr, ok := err.(rest.HttpError)
+	assert.True(t, ok, "expected rest.HttpError, got %T: %v", err, err)
+	assert.Equal(t, http.StatusNotFound, httpErr.HttpCode)
+}
+
+func TestController_CreateSession_UnknownSubscriber_RemoteLookupFails_Returns503(t *testing.T) {
+	s := newTestStore(t)
+	sm := mocks.NewSessionManager(t)
+	rc := mocks.NewRemoteController(t)
+
+	imsi := "999992000000012"
+	rc.On("GetSubscriberProfile", imsi).Return(nil, fmt.Errorf("connection refused")).Once()
+
+	c := &Controller{store: s, sm: sm, rc: rc, serviceOn: true}
+
+	err := c.CreateSession(&gin.Context{}, &api.CreateSession{ImsiStr: imsi, IpStr: "10.10.10.52"})
+	assert.Error(t, err)
+
+	httpErr, ok := err.(rest.HttpError)
+	assert.True(t, ok, "expected rest.HttpError, got %T: %v", err, err)
+	assert.Equal(t, http.StatusServiceUnavailable, httpErr.HttpCode)
+}
+
+func TestController_CreateSession_StillInvalidAfterReverseLookup_Returns403(t *testing.T) {
+	s := newTestStore(t)
+	sm := mocks.NewSessionManager(t)
+	rc := mocks.NewRemoteController(t)
+
+	imsi := "999992000000013"
+	now := time.Now()
+
+	expiredPolicy := &api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      1_000_000,
+		Burst:     100,
+		StartTime: now.Add(-time.Hour).Unix(),
+		EndTime:   now.Add(-time.Minute).Unix(),
+	}
+	ip := "192.168.9.13"
+	_, err := s.CreateSubscriber(imsi, expiredPolicy, &ip, nil)
+	assert.NoError(t, err)
+
+	stillExpiredRemotePolicy := api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      1_000_000,
+		Burst:     100,
+		StartTime: now.Add(-time.Second).Unix(),
+		EndTime:   now.Add(-time.Second).Unix(),
+	}
+	rc.On("GetSubscriberProfile", imsi).Return(&api.Spr{
+		Imsi:    imsi,
+		Policy:  stillExpiredRemotePolicy,
+		ReRoute: ip,
+	}, nil).Once()
+
+	c := &Controller{store: s, sm: sm, rc: rc, serviceOn: true}
+
+	err = c.CreateSession(&gin.Context{}, &api.CreateSession{ImsiStr: imsi, IpStr: "10.10.10.53"})
+	assert.Error(t, err)
+
+	httpErr, ok := err.(rest.HttpError)
+	assert.True(t, ok, "expected rest.HttpError, got %T: %v", err, err)
+	assert.Equal(t, http.StatusForbidden, httpErr.HttpCode)
 }

--- a/nodes/apps/pcrf/pkg/controller/store/store.go
+++ b/nodes/apps/pcrf/pkg/controller/store/store.go
@@ -785,6 +785,18 @@ func (s *Store) ValidateDataCapLimits(imsi string, p *Policy) error {
 }
 
 func (s *Store) CreateSession(subscriber *Subscriber, ueIpAddr string, nodeId string) (*Session, *Flow, *Flow, error) {
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+
+	subscriberID := subscriber.ID
+
+	subscriber, err := s.GetSubscriberByID(subscriberID)
+	if err != nil {
+		log.Errorf("Error getting subscriber %d for session create. Error: %v", subscriberID, err)
+
+		return nil, nil, nil, fmt.Errorf("error getting subscriber %d for session create. Error: %w", subscriberID, err)
+	}
+
 	/* TODO: Check if required here vaildate if user has enough data */
 	usage, err := s.GetUsageByImsi(subscriber.Imsi)
 	if err != nil {
@@ -872,6 +884,9 @@ func (s *Store) CreateSession(subscriber *Subscriber, ueIpAddr string, nodeId st
 }
 
 func (s *Store) EndSession(session *Session) error {
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+
 	// Update session with TX, RX, and Total bytes
 	t := uint64(time.Now().Unix())
 	session.EndTime = t
@@ -893,6 +908,13 @@ func (s *Store) EndSession(session *Session) error {
 		log.Errorf("Error updating session usage for subscriber %s. Error: %v", subscriber.Imsi, err)
 
 		return fmt.Errorf("error updating session usage for subscriber %s. Error: %w", subscriber.Imsi, err)
+	}
+
+	if session.PolicyID.ID != subscriber.PolicyID.ID {
+		log.Warnf("Session %d for subscriber %s ended under policy %s, which the subscriber has since rolled over from (now on %s); not counting its %d bytes against the current policy's usage",
+			session.ID, subscriber.Imsi, session.PolicyID.ID, subscriber.PolicyID.ID, session.TotalBytes)
+
+		return nil
 	}
 
 	usage, err := s.GetUsageByImsi(subscriber.Imsi)

--- a/nodes/apps/pcrf/pkg/controller/store/store_test.go
+++ b/nodes/apps/pcrf/pkg/controller/store/store_test.go
@@ -232,3 +232,118 @@ func TestStore_UpdateSubscriber_RejectsOlderConsumedForSamePolicy(t *testing.T) 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(500_000), got.PolicyID.Consumed, "an out-of-order consumed-data update must not regress consumed bytes")
 }
+
+func TestStore_EndSession_DoesNotCountUsageFromSupersededPolicy(t *testing.T) {
+	s := newSharedTestStore(t)
+
+	now := time.Now()
+	policyA := &api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      1_000_000,
+		Burst:     100,
+		StartTime: now.Unix(),
+		EndTime:   now.Add(time.Hour).Unix(),
+	}
+	ip := "192.168.9.201"
+
+	sub, err := s.CreateSubscriber("999991000000004", policyA, &ip, nil)
+	assert.NoError(t, err)
+
+	session, _, _, err := s.CreateSession(sub, "10.10.10.30", "node1")
+	assert.NoError(t, err)
+
+	policyB := &api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      500_000,
+		Burst:     100,
+		StartTime: now.Add(time.Minute).Unix(),
+		EndTime:   now.Add(2 * time.Hour).Unix(),
+	}
+	_, err = s.UpdateSubscriber(sub.Imsi, policyB)
+	assert.NoError(t, err)
+
+	session.TxBytes = 300_000
+	session.RxBytes = 300_000
+	assert.NoError(t, s.EndSession(session))
+
+	usage, err := s.GetUsageByImsi(sub.Imsi)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), usage.Data, "a session ending under a policy the subscriber has since rolled over from must not count against the new policy's usage")
+
+	rolled, err := s.GetSubscriber(sub.Imsi)
+	assert.NoError(t, err)
+
+	fresh, _, _, err := s.CreateSession(rolled, "10.10.10.31", "node1")
+	assert.NoError(t, err)
+
+	fresh.TxBytes = 50_000
+	fresh.RxBytes = 50_000
+	assert.NoError(t, s.EndSession(fresh))
+
+	usage, err = s.GetUsageByImsi(sub.Imsi)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(100_000), usage.Data, "a session ending under the subscriber's current policy must still count normally")
+}
+
+func TestStore_CreateSession_UsesFreshServiceStatus(t *testing.T) {
+	s := newSharedTestStore(t)
+
+	policy := &api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      1_000_000,
+		Burst:     100,
+		StartTime: time.Now().Unix(),
+		EndTime:   time.Now().Add(time.Hour).Unix(),
+	}
+	ip := "192.168.9.202"
+
+	sub, err := s.CreateSubscriber("999991000000005", policy, &ip, nil)
+	assert.NoError(t, err)
+
+	stale, err := s.GetSubscriber(sub.Imsi)
+	assert.NoError(t, err)
+	assert.True(t, stale.ServiceOn)
+
+	assert.NoError(t, s.UpdateSubscriberServiceStatus(sub, false))
+
+	ns, _, _, err := s.CreateSession(stale, "10.10.10.40", "node1")
+	assert.NoError(t, err)
+	assert.Equal(t, FlowsPaused, ns.FlowState,
+		"CreateSession must use the subscriber's current service state, not a caller-held stale snapshot")
+}
+
+func TestStore_CreateSession_UsesFreshPolicyForCapCheck(t *testing.T) {
+	s := newSharedTestStore(t)
+
+	now := time.Now()
+	policyA := &api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      1_000_000,
+		Burst:     100,
+		StartTime: now.Unix(),
+		EndTime:   now.Add(time.Hour).Unix(),
+	}
+	ip := "192.168.9.203"
+
+	sub, err := s.CreateSubscriber("999991000000006", policyA, &ip, nil)
+	assert.NoError(t, err)
+
+	stale, err := s.GetSubscriber(sub.Imsi)
+	assert.NoError(t, err)
+
+	policyB := &api.Policy{
+		Uuid:      uuid.NewV4(),
+		Data:      500_000,
+		Burst:     100,
+		StartTime: now.Add(time.Minute).Unix(),
+		EndTime:   now.Add(2 * time.Hour).Unix(),
+	}
+	_, err = s.UpdateSubscriber(sub.Imsi, policyB)
+	assert.NoError(t, err)
+
+	ns, _, _, err := s.CreateSession(stale, "10.10.10.41", "node1")
+	assert.NoError(t, err)
+	assert.Equal(t, policyB.Uuid, ns.PolicyID.ID,
+		"session must be created under the subscriber's current policy, not the caller's stale snapshot")
+	assert.Equal(t, FlowsActive, ns.FlowState, "fresh policy with zero usage must not be born paused")
+}

--- a/testing/lab/scenarios/p0/usage/accounting/tc-195-session-outlives-rollover-inflates-usage.yaml
+++ b/testing/lab/scenarios/p0/usage/accounting/tc-195-session-outlives-rollover-inflates-usage.yaml
@@ -59,14 +59,14 @@ phases:
         ues: all
       - type: wait_ues_attached
         ues: all
+      - type: traffic
+        ues: all
+        amount_mb: 1
     checks:
       - type: package_state
         ues: all
         package: successor_plan
         expected: active
-      - type: traffic_allowed
-        ues: all
-        amount_mb: 1
       - type: usage_per_sim
         ues: all
         expected: from_model

--- a/testing/lab/scenarios/p0/usage/accounting/tc-195-session-outlives-rollover-inflates-usage.yaml
+++ b/testing/lab/scenarios/p0/usage/accounting/tc-195-session-outlives-rollover-inflates-usage.yaml
@@ -1,0 +1,72 @@
+version: 1
+name: p0-session-outlives-rollover-inflates-usage
+description: Keep a UE session open across a time-based package rollover, finalize it only after the successor package is active, and prove the successor's own usage allowance is not inflated by the outgoing package's traffic.
+seed: 4526
+suite: p0
+priority: p0
+tags: [virtual, usage, accounting, policy]
+status: active
+provider:
+  type: virtual
+world:
+  networks: 1
+  sites_per_network: 1
+  nodes_per_site:
+    tower: 1
+    amplifier: 1
+    controller: 1
+  ues_per_site: 1
+packages:
+  - ref: current_plan
+    name: Outlived Session Current
+    data_mb: 10
+    duration_minutes: 1
+    amount: 1.00
+    assign_percent: 100
+  - ref: successor_plan
+    name: Outlived Session Successor
+    data_mb: 2
+    duration_minutes: 10
+    amount: 2.00
+    assign_percent: 0
+setup:
+  create_via_bff: [networks, sites, nodes, node_site_links, packages, subscribers, sims]
+runtime:
+  start: [nodes]
+  wait: [nodes_ready]
+phases:
+  - name: outlive_the_rollover
+    events:
+      - type: toggle_service
+        sites: all
+        state: on
+      - type: start_ues
+        ues: all
+      - type: wait_ues_attached
+        ues: all
+      - type: purchase_package
+        ues: all
+        package: successor_plan
+      - type: traffic
+        ues: all
+        amount_mb: 3
+      - type: wait
+        seconds: 90
+      - type: finalize_ue_sessions
+        ues: all
+        seconds: 60
+      - type: start_ues
+        ues: all
+      - type: wait_ues_attached
+        ues: all
+    checks:
+      - type: package_state
+        ues: all
+        package: successor_plan
+        expected: active
+      - type: traffic_allowed
+        ues: all
+        amount_mb: 1
+      - type: usage_per_sim
+        ues: all
+        expected: from_model


### PR DESCRIPTION
This PR fixes #1663 and closes #1663 by providing the following:

- Fix usage counting on PCRF.
- Enhance errors and status codes.