### PR TITLE
device: fix skipping service cmds for the cached state machine (#1642)

### DIFF
--- a/nodes/ukamaOS/distro/system/deviced/src/control.c
+++ b/nodes/ukamaOS/distro/system/deviced/src/control.c
@@ -263,7 +263,7 @@ bool control_set_pending(ControlCtx *ctx,
      * already applied is idempotent. Reboot is an action and must always be
      * scheduled while idle, even though its bookkeeping state is OFF.
      */
-    if (subsystem != CONTROL_SUBSYS_REBOOT &&
+    if (subsystem == CONTROL_SUBSYS_RADIO &&
         ss->Phase == CONTROL_PHASE_IDLE &&
         ss->Current == desired) {
         status  = HttpStatus_OK;


### PR DESCRIPTION
Fix #1642 

```
ULAB_OVS_ALLOW_UNMETERED_FALLBACK=1 ./bin/ukama-lab validate scenarios/p0/console-kpi/network/tc-008-network-uptime.yaml \          
  --sim-type ukama_data \                            
  --warehouse-url http://warehouse-ukama.udev.ukama.com \
  --factory-url http://factory-ukama.udev.ukama.com \
  --bff https://bff.udev.ukama.com/gateway/graphql \
  --out runs \                               
  --verbose \
  --repo /home/kashif/work/ukama/repos/ukama/

SCENARIO   p0-console-kpi-network-uptime
PURPOSE    Take one of two sites out of service through GraphQL for a controlled interval and verify NETWORK_UPTIME publishes a Console-visible partial-period percentage within valid bounds.
WORLD      networks=1 sites=2 nodes=6 ues=0
WORLD      subscribers=0 packages=0
NET        ensure lab podman network
SITE       factory/build/start site node bundles
SITE       factory/build/start site-001
SITE       site-001 tnode=uk-sa2637-tnode-v0-5780 cnode=uk-sa2637-cnode-v0-5780 anode=uk-sa2637-anode-v0-5780
SITE       factory/build/start site-002
SITE       site-002 tnode=uk-sa2637-tnode-v0-5b1a cnode=uk-sa2637-cnode-v0-5b1a anode=uk-sa2637-anode-v0-5b1a
NODE       wait nodes ready
NODE       wait ready lab-p0-console-kpi-network-uptime-4713-1788897877-tower-site-001-001
NODE       wait ready lab-p0-console-kpi-network-uptime-4713-1788897877-amplifier-site-001-001
NODE       wait ready lab-p0-console-kpi-network-uptime-4713-1788897877-controller-site-001-001
NODE       wait ready lab-p0-console-kpi-network-uptime-4713-1788897877-tower-site-002-001
NODE       wait ready lab-p0-console-kpi-network-uptime-4713-1788897877-amplifier-site-002-001
NODE       wait ready lab-p0-console-kpi-network-uptime-4713-1788897877-controller-site-002-001
BACKEND    creating backend world resources
NETWORK    add network net-001
BACKEND    site site-001 anchor online uk-sa2637-tnode-v0-5780 lat=33.942810 lng=-118.410000
SITE       add site site-001
BACKEND    waiting site site-002 anchor online/location
BACKEND    waiting site site-002 anchor online/location
BACKEND    waiting site site-002 anchor online/location
BACKEND    site site-002 anchor online uk-sa2637-tnode-v0-5b1a lat=33.942810 lng=-118.410000
SITE       add site site-002
PHASE      create_network_uptime_window
EVENT      toggle_service
SERVICE    off
SERVICE    wait off lab-p0-console-kpi-network-uptime-4713-1788897877-tower-site-001-001
PASS       event create_network_uptime_window/toggle_service: ok
EVENT      wait
WAIT       30 sec
PASS       event create_network_uptime_window/wait: ok
EVENT      toggle_service
SERVICE    on
SERVICE    wait on lab-p0-console-kpi-network-uptime-4713-1788897877-tower-site-001-001
PASS       event create_network_uptime_window/toggle_service: ok
EVENT      wait
WAIT       10 sec
PASS       event create_network_uptime_window/wait: ok
VERIFY     run checks
PASS       kpi_contract: kpi=NETWORK_UPTIME found=true value=100 expected=0 op=AVG scope=network_id:39192133-6221-482a-ac02-7d00cc4fa758 computed_at=2026-09-08T20:09:43Z trend=new
PASS       kpi_value: kpi=NETWORK_UPTIME found=true value=100 expected=100 op=AVG scope=network_id:39192133-6221-482a-ac02-7d00cc4fa758 computed_at=2026-09-08T20:09:43Z trend=new
CLEANUP    detach UE sessions
CLEANUP    cleanup UE containers
CLEANUP    delete backend resources
CLEANUP    stop media/nodes/network
PASS       events=4 checks=2 artifacts=runs/lab-p0-console-kpi-network-uptime-4713-1788897877
```